### PR TITLE
Add cmd reload translations

### DIFF
--- a/_datafiles/world/default/templates/admincommands/help/command.reload.template
+++ b/_datafiles/world/default/templates/admincommands/help/command.reload.template
@@ -1,3 +1,4 @@
 The <ansi fg="command">reload</ansi> command can be used in the following ways:
 
 <ansi fg="command">reload items</ansi> - Reloads items data files, including any new ones.
+<ansi fg="command">reload translations</ansi> - Reloads all translation localize files.

--- a/_datafiles/world/empty/templates/admincommands/help/command.reload.template
+++ b/_datafiles/world/empty/templates/admincommands/help/command.reload.template
@@ -1,3 +1,4 @@
 The <ansi fg="command">reload</ansi> command can be used in the following ways:
 
 <ansi fg="command">reload items</ansi> - Reloads items data files, including any new ones.
+<ansi fg="command">reload translations</ansi> - Reloads all translation localize files.

--- a/internal/language/testdata/reload-test/.gitignore
+++ b/internal/language/testdata/reload-test/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/internal/usercommands/admin.reload.go
+++ b/internal/usercommands/admin.reload.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/language"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
 	"github.com/GoMudEngine/GoMud/internal/templates"
 	"github.com/GoMudEngine/GoMud/internal/users"
@@ -26,6 +27,13 @@ func Reload(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 	case `items`:
 		items.LoadDataFiles()
 		user.SendText(`Items reloaded.`)
+	case `translations`:
+		ok := language.ReloadTranslation()
+		if !ok {
+			user.SendText(`Translations reload failed.`)
+		} else {
+			user.SendText(`Translations reloaded.`)
+		}
 	default:
 		user.SendText(`Unknown reload command.`)
 	}


### PR DESCRIPTION
Admin can reload runtime translation localize files using the command `reload translations`

![Screenshot](https://github.com/user-attachments/assets/edd39ce2-fa4f-4ca8-b14c-5d31fa09129b)
