### PR TITLE
Fixing warnings when running for first time

### DIFF
--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -340,7 +340,7 @@ func (p *Plugin) ReadBytes(identifier string) ([]byte, error) {
 	fullPath := util.FilePath(folderPath, `/`, fileName)
 
 	bytes, err := os.ReadFile(fullPath)
-	if err != nil && err != fs.ErrNotExist {
+	if err != nil && !os.IsNotExist(err) {
 		mudlog.Warn(`plugin.ReadBytes`, `name`, p.name, `path`, fullPath, `error`, err)
 	}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -868,7 +868,6 @@ func SaveRoundCount(fpath string) {
 
 	err := os.WriteFile(fpath, []byte(strconv.FormatUint(roundCount, 10)), 0644)
 	if err != nil {
-
 		mudlog.Error("SaveRoundCount()", "error", err)
 	}
 
@@ -879,16 +878,14 @@ func LoadRoundCount(fpath string) uint64 {
 	roundCountData, err := os.ReadFile(fpath)
 	if err != nil {
 		roundCount = RoundCountMinimum
-		roundCount = RoundCountMinimum
-		mudlog.Warn("LoadRoundCount()", "error", err, "message", "Trying to create...")
+		mudlog.Warn("LoadRoundCount()", "error", err, "message", "Trying to create... (First time running?)")
 		SaveRoundCount(fpath)
+		roundCountData = []byte(strconv.FormatUint(roundCount, 10))
 	}
 
 	roundCountUint64, err := strconv.ParseUint(string(roundCountData), 10, 64)
 	if err != nil {
-
 		mudlog.Warn("LoadRoundCount()", "error", err, "file-contents", string(roundCountData))
-
 	} else {
 		roundCount = roundCountUint64
 	}


### PR DESCRIPTION
# Description

Some warnings are too verbose or uninformative when first running the codebase. This addresses some of it.

## Changes

- Do not log warnings when plugins can't find a data file.
- Add (first time running?) message with missing round data warning.
- Fix a condition that leads to unnecessary logging.
- Removed an unnecessary line of code.

