### PR TITLE
Adding Mudlet Discord Rich Presence and Mudlet Mapper and UI commands and GMCP support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ vendor/
 server.crt
 server.key
 __debug*
+mud.sh
+WillowdaleMUD
+WillowdaleMUD.pid
+_datafiles/willowdale-config.yaml
+logs/*
+*.DS_Store

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -59,6 +59,10 @@ Server:
   - print
   - inbox check
   - print
+  - print
+  - checkgui
+  - print
+  - print
   # - Motd -
   #   Message of the day. This is displayed when the motd command is run.
   Motd: '{{ t "Motd" }}'

--- a/modules/gmcp.go
+++ b/modules/gmcp.go
@@ -186,22 +186,13 @@ func (g *GMCPModule) handlePlayerJoin(e events.Event) events.ListenerReturn {
 		g.sendGMCPEnableRequest(evt.ConnectionId)
 	}
 
-	// Only try to send Discord info when a player joins with a Mudlet client
 	// We'll check inside sendExternalDiscordInfo if it's actually a Mudlet client
 	// and only log if it is
 	if user := users.GetByUserId(evt.UserId); user != nil {
 		g.sendExternalDiscordInfo(user)
 		
-		// Check if this is a Mudlet client and send UI notification if appropriate
-		connectionId := uint64(user.ConnectionId())
-		gmcpData, ok := g.cache.Get(connectionId)
-		if ok && gmcpData.Client.IsMudlet {
-			// Check if the user has disabled the UI notice
-			if suppress, ok := user.GetConfigOption("ui_suppress_mudlet_notice").(bool); !ok || !suppress {
-				// Send the notification about the UI
-				user.SendText("\n<ansi fg=\"highlight\">Mudlet client detected.</ansi> If you want to use our Mudlet UI, you can use the '<ansi fg=\"command\">ui install</ansi>' command to install it into Mudlet automatically.")
-			}
-		}
+		// The Mudlet UI notification is now handled by the checkgui command
+		// during login, so we don't need to show it here anymore
 	}
 
 	return events.Continue
@@ -320,11 +311,8 @@ func (g *GMCPModule) HandleIAC(connectionId uint64, iacCmd []byte) bool {
 						if user != nil {
 							g.sendExternalDiscordInfo(user)
 							
-							// Send UI notification if appropriate
-							if suppress, ok := user.GetConfigOption("ui_suppress_mudlet_notice").(bool); !ok || !suppress {
-								// Send the notification about the UI
-								user.SendText("\n<ansi fg=\"highlight\">Mudlet client detected.</ansi> If you want to use our Mudlet UI, you can use the '<ansi fg=\"command\">ui install</ansi>' command to install it into Mudlet automatically.")
-							}
+							// The Mudlet UI notification is now handled by the checkgui command
+							// during login, so we don't need to show it here anymore
 						}
 					}
 				} else {

--- a/modules/mudletclient.go
+++ b/modules/mudletclient.go
@@ -86,22 +86,37 @@ func (g *MudletClientModule) RefreshConfig() {
 	// Load config values from the plugin's config file
 	if uiUrl, ok := g.plug.Config.Get(`Mudlet.UIUrl`).(string); ok && uiUrl != "" {
 		g.uiUrl = uiUrl
+		mudlog.Info("MudletClientModule", "config", "Loaded UIUrl from config", "value", g.uiUrl)
+	} else {
+		mudlog.Info("MudletClientModule", "config", "Using default UIUrl", "value", g.uiUrl)
 	}
 
 	if uiVersion, ok := g.plug.Config.Get(`Mudlet.UIVersion`).(string); ok && uiVersion != "" {
 		g.uiVersion = uiVersion
+		mudlog.Info("MudletClientModule", "config", "Loaded UIVersion from config", "value", g.uiVersion)
+	} else {
+		mudlog.Info("MudletClientModule", "config", "Using default UIVersion", "value", g.uiVersion)
 	}
 
 	if mapUrl, ok := g.plug.Config.Get(`Mudlet.MapUrl`).(string); ok && mapUrl != "" {
 		g.mapUrl = mapUrl
+		mudlog.Info("MudletClientModule", "config", "Loaded MapUrl from config", "value", g.mapUrl)
+	} else {
+		mudlog.Info("MudletClientModule", "config", "Using default MapUrl", "value", g.mapUrl)
 	}
 
 	if mapperUrl, ok := g.plug.Config.Get(`Mudlet.MapperUrl`).(string); ok && mapperUrl != "" {
 		g.mapperUrl = mapperUrl
+		mudlog.Info("MudletClientModule", "config", "Loaded MapperUrl from config", "value", g.mapperUrl)
+	} else {
+		mudlog.Info("MudletClientModule", "config", "Using default MapperUrl", "value", g.mapperUrl)
 	}
 
 	if mapperVersion, ok := g.plug.Config.Get(`Mudlet.MapperVersion`).(string); ok && mapperVersion != "" {
 		g.mapperVersion = mapperVersion
+		mudlog.Info("MudletClientModule", "config", "Loaded MapperVersion from config", "value", g.mapperVersion)
+	} else {
+		mudlog.Info("MudletClientModule", "config", "Using default MapperVersion", "value", g.mapperVersion)
 	}
 }
 

--- a/modules/mudletclient.go
+++ b/modules/mudletclient.go
@@ -1,0 +1,166 @@
+package modules
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+var (
+	//go:embed mudletclient/*
+	mudletclient_Files embed.FS
+	
+	// Instance accessible from elsewhere in this package
+	mudletClientModule MudletClientModule
+)
+
+func init() {
+	// Create the module instance first
+	mudletClientModule = MudletClientModule{
+		plug: plugins.New(`mudletclient`, `1.0`),
+	}
+
+	// Attach the file system to the plugin
+	if err := mudletClientModule.plug.AttachFileSystem(mudletclient_Files); err != nil {
+		panic(err)
+	}
+
+	// Set default values directly during initialization
+	mudletClientModule.setDefaultValues()
+
+	// Register the onLoad callback to load config values after plugin system is ready
+	mudletClientModule.plug.Callbacks.SetOnLoad(func() {
+		mudletClientModule.RefreshConfig()
+	})
+
+	// Export a function to register client info for Mudlet clients
+	mudletClientModule.plug.ExportFunction("SendClientInfo", mudletClientModule.SendClientInfoExported)
+}
+
+type MudletClientModule struct {
+	plug          *plugins.Plugin
+	uiUrl         string
+	uiVersion     string
+	mapUrl        string
+	mapperUrl     string
+	mapperVersion string
+	// Track which users already have data sent
+	registeredUsers map[int]bool
+}
+
+// Set hardcoded default values for initialization
+func (g *MudletClientModule) setDefaultValues() {
+	g.uiUrl = ""
+	g.uiVersion = "1.0.0"
+	g.mapUrl = "https://github.com/MorquinDevlar/GoMudUI/releases/latest/download/gomud.dat"
+	g.mapperUrl = "https://github.com/MorquinDevlar/GoMudUI/releases/latest/download/mudlet-mapper.mpackage"
+	g.mapperVersion = "1.0.0"
+	g.registeredUsers = make(map[int]bool)
+}
+
+// Public function that can be called from the GMCP module
+func (g *MudletClientModule) SendClientInfoExported(userId int) bool {
+	user := users.GetByUserId(userId)
+	if user == nil {
+		return false
+	}
+	
+	// Check if we've already sent info to this user
+	if _, ok := g.registeredUsers[userId]; ok {
+		return true // Already sent
+	}
+	
+	// Mark as registered
+	g.registeredUsers[userId] = true
+	
+	// Send initial client info
+	return g.sendClientInfo(user)
+}
+
+// RefreshConfig loads values from the module's config.yaml file
+func (g *MudletClientModule) RefreshConfig() {
+	// Load config values from the plugin's config file
+	if uiUrl, ok := g.plug.Config.Get(`Mudlet.UIUrl`).(string); ok && uiUrl != "" {
+		g.uiUrl = uiUrl
+	}
+
+	if uiVersion, ok := g.plug.Config.Get(`Mudlet.UIVersion`).(string); ok && uiVersion != "" {
+		g.uiVersion = uiVersion
+	}
+
+	if mapUrl, ok := g.plug.Config.Get(`Mudlet.MapUrl`).(string); ok && mapUrl != "" {
+		g.mapUrl = mapUrl
+	}
+
+	if mapperUrl, ok := g.plug.Config.Get(`Mudlet.MapperUrl`).(string); ok && mapperUrl != "" {
+		g.mapperUrl = mapperUrl
+	}
+
+	if mapperVersion, ok := g.plug.Config.Get(`Mudlet.MapperVersion`).(string); ok && mapperVersion != "" {
+		g.mapperVersion = mapperVersion
+	}
+}
+
+// Helper method to send client info to a user
+func (g *MudletClientModule) sendClientInfo(user *users.UserRecord) bool {
+	anyInfoSent := false
+	
+	// Send GUI URL if configured
+	if g.uiUrl != "" {
+		guiPayload := fmt.Sprintf(`{ 
+			"version": "%s",
+			"url": "%s"
+		}`, g.uiVersion, g.uiUrl)
+
+		// Log specific module being sent
+		mudlog.Info("GMCP", "action", "Sending Client.GUI to Mudlet user", "userId", user.UserId)
+		
+		events.AddToQueue(GMCPOut{
+			UserId:  user.UserId,
+			Module:  `Client.GUI`,
+			Payload: guiPayload,
+		})
+		anyInfoSent = true
+	}
+
+	// Send Map URL if configured
+	if g.mapUrl != "" {
+		mapPayload := fmt.Sprintf(`{ 
+			"url": "%s"
+		}`, g.mapUrl)
+
+		// Log specific module being sent
+		mudlog.Info("GMCP", "action", "Sending Client.Map to Mudlet user", "userId", user.UserId)
+		
+		events.AddToQueue(GMCPOut{
+			UserId:  user.UserId,
+			Module:  `Client.Map`,
+			Payload: mapPayload,
+		})
+		anyInfoSent = true
+	}
+
+	// Send Mapper URL if configured
+	if g.mapperUrl != "" {
+		mapperPayload := fmt.Sprintf(`{ 
+			"version": "%s",
+			"url": "%s"
+		}`, g.mapperVersion, g.mapperUrl)
+
+		// Log specific module being sent
+		mudlog.Info("GMCP", "action", "Sending Client.GUI mapper info to Mudlet user", "userId", user.UserId)
+		
+		events.AddToQueue(GMCPOut{
+			UserId:  user.UserId,
+			Module:  `Client.GUI`,
+			Payload: mapperPayload,
+		})
+		anyInfoSent = true
+	}
+	
+	return anyInfoSent
+}

--- a/modules/mudletclient/data-overlays/config.yaml
+++ b/modules/mudletclient/data-overlays/config.yaml
@@ -1,0 +1,31 @@
+################################################################################
+# If modified, these settings will be copied into your config overrides 
+# folder under `Modules.mudletclient`:
+#
+# Modules:
+#   mudletclient:
+#     Mudlet:
+#       UIUrl: ""
+#       UIVersion: "1.0.0"
+#       MapUrl: ""
+#       MapperUrl: ""
+#       MapperVersion: "1.0.0"
+################################################################################
+# - Mudlet -
+#   Mudlet client integration settings
+Mudlet:
+  # - UIUrl -
+  #   URL for the Mudlet UI package
+  UIUrl: ""
+  # - UIVersion -
+  #   Version of the Mudlet UI package
+  UIVersion: "1.0.0"
+  # - MapUrl -
+  #   URL for the Mudlet map package
+  MapUrl: ""
+  # - MapperUrl -
+  #   URL for the Mudlet mapper package
+  MapperUrl: ""
+  # - MapperVersion -
+  #   Version of the Mudlet mapper package
+  MapperVersion: "1.0.0" 

--- a/modules/mudletdiscord.go
+++ b/modules/mudletdiscord.go
@@ -8,6 +8,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/plugins"
 	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
 )
 
 var (
@@ -90,28 +91,46 @@ func (g *MudletDiscordModule) RefreshConfig() {
 	// Using direct config properties like auctions.go does
 	if inviteUrl, ok := g.plug.Config.Get(`InviteUrl`).(string); ok && inviteUrl != "" {
 		g.inviteUrl = inviteUrl
+		mudlog.Info("MudletDiscordModule", "config", "Loaded InviteUrl from config", "value", g.inviteUrl)
+	} else {
+		mudlog.Info("MudletDiscordModule", "config", "Using default InviteUrl", "value", g.inviteUrl)
 	}
 
 	if applicationId, ok := g.plug.Config.Get(`ApplicationId`).(string); ok && applicationId != "" {
 		g.applicationId = applicationId
+		mudlog.Info("MudletDiscordModule", "config", "Loaded ApplicationId from config", "value", g.applicationId)
+	} else {
+		mudlog.Info("MudletDiscordModule", "config", "Using default ApplicationId", "value", g.applicationId)
 	}
 
 	if largeImageKey, ok := g.plug.Config.Get(`LargeImageKey`).(string); ok && largeImageKey != "" {
 		g.largeImageKey = largeImageKey
+		mudlog.Info("MudletDiscordModule", "config", "Loaded LargeImageKey from config", "value", g.largeImageKey)
+	} else {
+		mudlog.Info("MudletDiscordModule", "config", "Using default LargeImageKey", "value", g.largeImageKey)
 	}
 
 	if state, ok := g.plug.Config.Get(`State`).(string); ok && state != "" {
 		g.state = state
+		mudlog.Info("MudletDiscordModule", "config", "Loaded State from config", "value", g.state)
+	} else {
+		mudlog.Info("MudletDiscordModule", "config", "Using default State", "value", g.state)
 	}
 
 	if details, ok := g.plug.Config.Get(`Details`).(string); ok && details != "" {
 		g.details = details
+		mudlog.Info("MudletDiscordModule", "config", "Loaded Details from config", "value", g.details)
+	} else {
+		mudlog.Info("MudletDiscordModule", "config", "Using default Details", "value", g.details)
 	}
 
 	// Always get MudName from main config
 	c := configs.GetConfig()
 	if c.Server.MudName != "" {
 		g.mudName = string(c.Server.MudName)
+		mudlog.Info("MudletDiscordModule", "config", "Loaded MudName from main config", "value", g.mudName)
+	} else {
+		mudlog.Info("MudletDiscordModule", "config", "Using default MudName", "value", g.mudName)
 	}
 }
 

--- a/modules/mudletdiscord.go
+++ b/modules/mudletdiscord.go
@@ -1,0 +1,147 @@
+package modules
+
+import (
+	"embed"
+	"strconv"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+var (
+	//go:embed mudletdiscord/*
+	mudletdiscord_Files embed.FS
+)
+
+func init() {
+	// Create the module instance first
+	g := MudletDiscordModule{
+		plug: plugins.New(`mudletdiscord`, `1.0`),
+	}
+
+	// Attach the file system to the plugin
+	if err := g.plug.AttachFileSystem(mudletdiscord_Files); err != nil {
+		panic(err)
+	}
+
+	// Set default values directly during initialization
+	g.setDefaultValues()
+
+	// Register the onLoad callback to load config values after plugin system is ready
+	g.plug.Callbacks.SetOnLoad(func() {
+		g.RefreshConfig()
+	})
+
+	// Export a function to register event listeners for any user with GMCP support
+	// The function name remains "RegisterMudletUser" for backward compatibility
+	g.plug.ExportFunction("RegisterMudletUser", g.registerEventListeners)
+}
+
+type MudletDiscordModule struct {
+	plug          *plugins.Plugin
+	inviteUrl     string
+	applicationId string
+	largeImageKey string
+	state         string
+	details       string
+	mudName       string
+	// Track which users already have event listeners registered
+	registeredUsers map[int]bool
+}
+
+// Set hardcoded default values for initialization
+func (g *MudletDiscordModule) setDefaultValues() {
+	g.mudName = "GoMud"
+	g.inviteUrl = "https://discord.gg/FaauSYej3n"
+	g.applicationId = "1234"
+	g.largeImageKey = "server-icon"
+	g.state = "Playing GoMud"
+	g.details = "using GoMud Engine"
+	g.registeredUsers = make(map[int]bool)
+}
+
+// This function gets called when a client with GMCP support is detected
+// Function name kept as is for backward compatibility
+func (g *MudletDiscordModule) registerEventListeners(userId int) bool {
+	// Check if we've already registered this user
+	if _, ok := g.registeredUsers[userId]; ok {
+		return true // Already registered
+	}
+	
+	// Register the user and send initial GMCP data
+	g.registeredUsers[userId] = true
+	
+	// Get the user record
+	user := users.GetByUserId(userId)
+	if user == nil {
+		return false
+	}
+	
+	// Send initial Discord info
+	g.sendDiscordInfo(user)
+	
+	return true
+}
+
+// RefreshConfig loads values from the module's config.yaml file
+func (g *MudletDiscordModule) RefreshConfig() {
+	// Using direct config properties like auctions.go does
+	if inviteUrl, ok := g.plug.Config.Get(`InviteUrl`).(string); ok && inviteUrl != "" {
+		g.inviteUrl = inviteUrl
+	}
+
+	if applicationId, ok := g.plug.Config.Get(`ApplicationId`).(string); ok && applicationId != "" {
+		g.applicationId = applicationId
+	}
+
+	if largeImageKey, ok := g.plug.Config.Get(`LargeImageKey`).(string); ok && largeImageKey != "" {
+		g.largeImageKey = largeImageKey
+	}
+
+	if state, ok := g.plug.Config.Get(`State`).(string); ok && state != "" {
+		g.state = state
+	}
+
+	if details, ok := g.plug.Config.Get(`Details`).(string); ok && details != "" {
+		g.details = details
+	}
+
+	// Always get MudName from main config
+	c := configs.GetConfig()
+	if c.Server.MudName != "" {
+		g.mudName = string(c.Server.MudName)
+	}
+}
+
+// Helper method to send Discord info to a user
+func (g *MudletDiscordModule) sendDiscordInfo(user *users.UserRecord) {
+	if g.inviteUrl != "" {
+		infoPayload := `{ 
+			"inviteurl": "` + g.inviteUrl + `",	
+			"applicationid": "` + g.applicationId + `",
+			"largeImageKey": "` + g.largeImageKey + `"
+		}`
+
+		events.AddToQueue(GMCPOut{
+			UserId:  user.UserId,
+			Module:  `External.Discord.Info`,
+			Payload: infoPayload,
+		})
+
+		// Send Discord Status
+		statusPayload := `{ 
+			"game": "` + g.mudName + `",
+			"startTimestamp": ` + strconv.FormatInt(user.GetConnectTime().Unix(), 10) + `,
+			"state": "` + g.state + `",
+			"details": "` + g.details + `"
+		}`
+
+		events.AddToQueue(GMCPOut{
+			UserId:  user.UserId,
+			Module:  `External.Discord.Status`,
+			Payload: statusPayload,
+		})
+	}
+}

--- a/modules/mudletdiscord/data-overlays/config.yaml
+++ b/modules/mudletdiscord/data-overlays/config.yaml
@@ -1,0 +1,32 @@
+################################################################################
+# If modified, these settings will be copied into your config overrides 
+# folder under `Modules.mudletdiscord`:
+#
+# Modules:
+#   mudletdiscord:
+#     InviteUrl: "https://discord.gg/wT2pdJa5Qu"
+#     ApplicationId: "1282230193876111380"
+#     LargeImageKey: "server-icon"
+#     State: "Playing Willowdale"
+#     Details: "using GoMud Engine"
+################################################################################
+# - InviteUrl -
+#   Discord invite URL for the server
+# InviteUrl: "https://discord.gg/wT2pdJa5Qu"
+InviteUrl: ""
+# - ApplicationId -
+#   Discord application ID for rich presence
+#ApplicationId: "1282230193876111380"
+ApplicationId: ""
+# - LargeImageKey -
+#   Key for the large image in rich presence
+#LargeImageKey: "server-icon"
+LargeImageKey: ""
+# - Details -
+#   Details text for rich presence
+# Details: "using GoMud Engine"
+Details: ""
+# - State -
+#   State text for rich presence
+# State: "https://www.willowdalemud.com"
+State: ""

--- a/modules/ui.go
+++ b/modules/ui.go
@@ -1,0 +1,174 @@
+package modules
+
+import (
+	"embed"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+)
+
+var (
+	//go:embed ui/*
+	ui_Files embed.FS
+	
+	// Instance accessible from elsewhere in this package
+	uiModule UIModule
+)
+
+func init() {
+	// Create the module instance
+	uiModule = UIModule{
+		plug: plugins.New(`ui`, `1.0`),
+	}
+
+	// Attach the file system to the plugin
+	if err := uiModule.plug.AttachFileSystem(ui_Files); err != nil {
+		panic(err)
+	}
+	
+	// Set default values
+	uiModule.setDefaultValues()
+	
+	// Register the onLoad callback to load config values after plugin system is ready
+	uiModule.plug.Callbacks.SetOnLoad(func() {
+		uiModule.RefreshConfig()
+	})
+
+	// Register the user command
+	uiModule.plug.AddUserCommand(`gui`, GUICommand, true, false)
+}
+
+// UIModule stores configuration and state for the UI module
+type UIModule struct {
+	plug        *plugins.Plugin
+	uiUrl       string
+	uiVersion   string
+	removeField string // Field name for removal flag
+}
+
+// Set hardcoded default values for initialization
+func (g *UIModule) setDefaultValues() {
+	g.uiUrl = "https://github.com/MorquinDevlar/GoMudUI/releases/latest/download/gomud-ui.mpackage"
+	g.uiVersion = "1.0.0"
+	g.removeField = "remove"
+}
+
+// RefreshConfig loads values from the module's config.yaml file
+func (g *UIModule) RefreshConfig() {
+	// Using direct config properties like other modules do
+	if uiUrl, ok := g.plug.Config.Get(`UIUrl`).(string); ok && uiUrl != "" {
+		g.uiUrl = uiUrl
+		mudlog.Info("UIModule", "config", "Loaded UIUrl from config", "value", g.uiUrl)
+	} else {
+		mudlog.Info("UIModule", "config", "Using default UIUrl", "value", g.uiUrl)
+	}
+
+	if uiVersion, ok := g.plug.Config.Get(`UIVersion`).(string); ok && uiVersion != "" {
+		g.uiVersion = uiVersion
+		mudlog.Info("UIModule", "config", "Loaded UIVersion from config", "value", g.uiVersion)
+	} else {
+		mudlog.Info("UIModule", "config", "Using default UIVersion", "value", g.uiVersion)
+	}
+	
+	if removeField, ok := g.plug.Config.Get(`RemoveField`).(string); ok && removeField != "" {
+		g.removeField = removeField
+		mudlog.Info("UIModule", "config", "Loaded RemoveField from config", "value", g.removeField)
+	} else {
+		mudlog.Info("UIModule", "config", "Using default RemoveField", "value", g.removeField)
+	}
+}
+
+// GUICommand handles the 'gui' command for users
+func GUICommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	// Check if this is a Mudlet client
+	isMudlet := checkIfMudletClient(user.ConnectionId())
+	if !isMudlet {
+		user.SendText(`This command is only available for Mudlet clients.`)
+		return true, nil
+	}
+
+	// Parse command arguments
+	args := strings.Fields(rest)
+	if len(args) == 0 {
+		showGUIHelp(user)
+		return true, nil
+	}
+
+	switch strings.ToLower(args[0]) {
+	case "install":
+		// Send GUI installation GMCP message using config values
+		guiPayload := `{
+			"version": "` + uiModule.uiVersion + `",
+			"url": "` + uiModule.uiUrl + `"
+		}`
+
+		events.AddToQueue(GMCPOut{
+			UserId:  user.UserId,
+			Module:  `Client.GUI`,
+			Payload: guiPayload,
+		})
+
+		user.SendText(`<ansi fg="command">GUI installation</ansi> package has been sent to your Mudlet client. Please follow any prompts in Mudlet to complete the installation.`)
+		return true, nil
+
+	case "remove":
+		// Send GUI removal GMCP message
+		removePayload := `{
+			"` + uiModule.removeField + `": true
+		}`
+
+		events.AddToQueue(GMCPOut{
+			UserId:  user.UserId,
+			Module:  `Client.GUI`,
+			Payload: removePayload,
+		})
+
+		user.SendText(`<ansi fg="command">GUI removal</ansi> request has been sent to your Mudlet client.`)
+		return true, nil
+
+	case "stop":
+		// Add the flag to the user's config options
+		user.SetConfigOption("ui_suppress_mudlet_notice", true)
+		user.SendText(`The Mudlet GUI detection message has been <ansi fg="command">disabled</ansi>. You won't see it again when you log in.`)
+		return true, nil
+
+	default:
+		showGUIHelp(user)
+		return true, nil
+	}
+}
+
+// Show help for the GUI command
+func showGUIHelp(user *users.UserRecord) {
+	helpText := `
+<ansi fg="h1">GUI Command</ansi>
+
+This command helps you manage the Mudlet GUI package:
+
+<ansi fg="command">gui install</ansi> - Sends a GUI package to your Mudlet client for installation
+<ansi fg="command">gui remove</ansi>  - Removes the GUI package from your Mudlet client
+<ansi fg="command">gui stop</ansi>    - Stops showing the Mudlet GUI notification when you log in
+
+The Mudlet GUI provides an enhanced interface for this MUD, with clickable widgets,
+maps, and other tools to improve your gameplay experience.
+`
+	user.SendText(helpText)
+}
+
+// Check if the client is a Mudlet client
+func checkIfMudletClient(connectionId uint64) bool {
+	// Get the exported IsMudlet function from the gmcp module
+	pluginReg := plugins.GetPluginRegistry()
+	
+	if isMudletFunc, ok := pluginReg.GetExportedFunction("IsMudlet"); ok {
+		if checker, ok := isMudletFunc.(func(uint64) bool); ok {
+			return checker(connectionId)
+		}
+	}
+	
+	return false
+} 

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -1,0 +1,17 @@
+# UI Module
+
+This module provides the 'ui' command for Mudlet users to manage their UI installation.
+
+## Features
+
+- Install the Mudlet UI package
+- Remove the Mudlet UI package
+- Stop showing the Mudlet UI notification on login
+
+## Usage
+
+```
+ui install - Install the Mudlet UI package
+ui remove - Remove the Mudlet UI package
+ui stop - Stop showing the Mudlet UI notification
+``` 

--- a/modules/ui/data-overlays/config.yaml
+++ b/modules/ui/data-overlays/config.yaml
@@ -1,0 +1,10 @@
+# UI Module Configuration
+
+# URL for the UI package
+UIUrl: "https://github.com/MorquinDevlar/GoMudUI/releases/latest/download/GoMudUI.mpackage"
+
+# Version of the UI package
+UIVersion: "1.0.0"
+
+# Field name for the removal flag
+RemoveField: "remove" 


### PR DESCRIPTION
# Description

This adds support for sending GMCP messages for Mudlet Discord Rich Presence and also auto-download of the updated Mudlet mapper.

I've also added in a check for Mudlet as a client, with a login message letting players know they can use a special game command to have the UI auto-install.

## Changes

Provide a bullet point list of noteworthy changes in this Pull Request:

All of these additions only come into effect if Mudlet is detected as a client.

- Added Mudlet Discord Rich Presence GMCP message
- Added Mudlet auto-install of the GMCP mapper script adapted to GoMud
- Added a check when logging in for Mudlet, which will show a message about a command to install the UI