### PR TITLE
Mob pathfinding

### DIFF
--- a/_datafiles/world/default/mobs/frostfang/scripts/2-guard.js
+++ b/_datafiles/world/default/mobs/frostfang/scripts/2-guard.js
@@ -1,7 +1,15 @@
 
+var PathTargets = [
+    [1, 59, 263, 'home'],          // town square => east gate => east residential district => home
+    [781, 35, 1, 'home'],          // west residential district => west gate => town square => home
+    [166, 63, 76, 62, 61, 'home'], // bank => steelwhisper armory => Hacking Hut => Icy Emporium => Inn => home
+    [16, 'home'],                  // south end of beggars lane => home
+    [44, 42, 'home'],              // east castle wing => west castle wing => home
+];
+
 function onIdle(mob, room) {
     
-    var random = Math.floor(Math.random() * 8);
+    var random = Math.floor(Math.random() * 10);
     switch (random) {
         case 0:
             mob.Command("emote flexes his muscles");
@@ -9,7 +17,13 @@ function onIdle(mob, room) {
         case 1:
             return true; // does nothing.
         case 2:
+            // Start a patrol path
+            var randomPath = Math.floor(Math.random() * PathTargets.length);
+            var selectedPath = PathTargets[randomPath]
+            mob.Command("pathto "+selectedPath.join(' '));
+            return true;
         case 3:
+            // wander randomly.
             mob.Command("wander");
             return true;
         default:

--- a/_datafiles/world/default/mobs/frostfang/scripts/26-frostfang_citizen-locketsadness.js
+++ b/_datafiles/world/default/mobs/frostfang/scripts/26-frostfang_citizen-locketsadness.js
@@ -48,13 +48,6 @@ function onAsk(mob, room, eventDetails) {
 
     }
 
-    match = UtilFindMatchIn(eventDetails.askText, lichSubjects);
-    if ( match.found ) {
-        mob.Command("say An ancient lich king eh? Do you have any proof that what you say is true?");
-
-        return true;
-    }
-
     return true;
 }
 

--- a/internal/hooks/Message_SendMessages.go
+++ b/internal/hooks/Message_SendMessages.go
@@ -54,7 +54,7 @@ func Message_SendMessage(e events.Event) events.ListenerReturn {
 			skip := false
 
 			if message.UserId == userId {
-				return events.Continue
+				continue
 			}
 
 			exLen := len(message.ExcludeUserIds)
@@ -68,20 +68,20 @@ func Message_SendMessage(e events.Event) events.ListenerReturn {
 			}
 
 			if skip {
-				return events.Continue
+				continue
 			}
 
 			if user := users.GetByUserId(userId); user != nil {
 
 				// If they are deafened, they cannot hear user communications
 				if message.IsCommunication && user.Deafened {
-					return events.Continue
+					continue
 				}
 
 				// If this is a quiet message, make sure the player can hear it
 				if message.IsQuiet {
 					if !user.Character.HasBuffFlag(buffs.SuperHearing) {
-						return events.Continue
+						continue
 					}
 				}
 

--- a/internal/hooks/NewRound_IdleMobs.go
+++ b/internal/hooks/NewRound_IdleMobs.go
@@ -24,6 +24,8 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 
 	// evt := e.(events.NewRound)
 
+	mobPathAnnounce := false // useful for debugging purposes.
+
 	mc := configs.GetMemoryConfig()
 	gp := configs.GetGamePlayConfig()
 
@@ -79,17 +81,27 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 			continue
 		}
 
+		if mob.InConversation() {
+			mob.Converse()
+			continue
+		}
+
 		// Check whether they are currently in the middle of a path, or have one waiting to start.
+		// This comes after checks for whether they are currently in a conersation, or in combat, etc.
 		if currentStep := mob.Path.Current(); currentStep != nil || mob.Path.Len() > 0 {
 
 			if currentStep == nil {
-				//mob.Command(`say I'm beginning a new path.`)
+				if mobPathAnnounce {
+					mob.Command(`say I'm beginning a new path.`)
+				}
 			} else {
 
 				// If their currentStep isnt' actually the room they are in
 				// They've somehow been moved. Reclaculate a new path.
 				if currentStep.RoomId() != mob.Character.RoomId {
-					//mob.Command(`say I seem to have wandered off my path.`)
+					if mobPathAnnounce {
+						mob.Command(`say I seem to have wandered off my path.`)
+					}
 
 					reDoWaypoints := mob.Path.Waypoints()
 					if len(reDoWaypoints) > 0 {
@@ -101,12 +113,16 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 						continue
 					}
 
+					// if we were unable to come up with a new path, send them home.
 					mob.Command(`pathto home`)
+
 					continue
 				}
 
 				if currentStep.Waypoint() {
-					//mob.Command(`say I've reached a waypoint.`)
+					if mobPathAnnounce {
+						mob.Command(`say I've reached a waypoint.`)
+					}
 				}
 			}
 
@@ -123,13 +139,10 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 
 			}
 
-			//mob.Command(`say I'm.... done.`)
+			if mobPathAnnounce {
+				mob.Command(`say I'm.... done.`)
+			}
 			mob.Path.Clear()
-		}
-
-		if mob.InConversation() {
-			mob.Converse()
-			continue
 		}
 
 		if mob.CanConverse() && util.Rand(100) < globalConverseChance {

--- a/internal/hooks/NewRound_IdleMobs.go
+++ b/internal/hooks/NewRound_IdleMobs.go
@@ -145,6 +145,14 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 			mob.Path.Clear()
 		}
 
+		// if a mob shouldn't be allowed to leave their area (via wandering)
+		// but has somehow been displaced, such as pulling through combat, spells, or otherwise
+		// tell them to path back home
+		if mob.MaxWander == 0 && mob.Character.RoomId != mob.HomeRoomId {
+			mob.Command("pathto home")
+			continue
+		}
+
 		if mob.CanConverse() && util.Rand(100) < globalConverseChance {
 			if mobRoom := rooms.LoadRoom(mob.Character.RoomId); mobRoom != nil {
 				mobcommands.Converse(``, mob, mobRoom) // Execute this directly so that target mob doesn't leave the room before this command executes
@@ -159,12 +167,8 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 
 			if !mob.Character.IsCharmed() { // Won't do this stuff if befriended
 
-				if mob.MaxWander > -1 && len(mob.RoomStack) > mob.MaxWander {
-					mob.GoingHome = true
-				}
-
-				if mob.GoingHome {
-					mob.Command(`go home`)
+				if mob.MaxWander > -1 && mob.WanderCount > mob.MaxWander {
+					mob.Command(`pathto home`)
 					continue
 				}
 

--- a/internal/hooks/NewRound_IdleMobs.go
+++ b/internal/hooks/NewRound_IdleMobs.go
@@ -3,6 +3,7 @@ package hooks
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
@@ -76,6 +77,54 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 				}
 			}
 			continue
+		}
+
+		// Check whether they are currently in the middle of a path, or have one waiting to start.
+		if currentStep := mob.Path.Current(); currentStep != nil || mob.Path.Len() > 0 {
+
+			if currentStep == nil {
+				//mob.Command(`say I'm beginning a new path.`)
+			} else {
+
+				// If their currentStep isnt' actually the room they are in
+				// They've somehow been moved. Reclaculate a new path.
+				if currentStep.RoomId() != mob.Character.RoomId {
+					//mob.Command(`say I seem to have wandered off my path.`)
+
+					reDoWaypoints := mob.Path.Waypoints()
+					if len(reDoWaypoints) > 0 {
+						newCommand := `pathto`
+						for _, wpInt := range reDoWaypoints {
+							newCommand += ` ` + strconv.Itoa(wpInt)
+						}
+						mob.Command(newCommand)
+						continue
+					}
+
+					mob.Command(`pathto home`)
+					continue
+				}
+
+				if currentStep.Waypoint() {
+					//mob.Command(`say I've reached a waypoint.`)
+				}
+			}
+
+			if nextStep := mob.Path.Next(); nextStep != nil {
+
+				if room := rooms.LoadRoom(mob.Character.RoomId); room != nil {
+					if exitInfo, ok := room.Exits[nextStep.ExitName()]; ok {
+						if exitInfo.RoomId == nextStep.RoomId() {
+							mob.Command(nextStep.ExitName())
+							continue
+						}
+					}
+				}
+
+			}
+
+			//mob.Command(`say I'm.... done.`)
+			mob.Path.Clear()
 		}
 
 		if mob.InConversation() {

--- a/internal/hooks/NewRound_IdleMobs.go
+++ b/internal/hooks/NewRound_IdleMobs.go
@@ -22,8 +22,6 @@ import (
 
 func IdleMobs(e events.Event) events.ListenerReturn {
 
-	// evt := e.(events.NewRound)
-
 	mobPathAnnounce := false // useful for debugging purposes.
 
 	mc := configs.GetMemoryConfig()

--- a/internal/mapper/mapper.path.go
+++ b/internal/mapper/mapper.path.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"container/heap"
 	"errors"
+	"fmt"
 	"math"
 	"time"
 
@@ -188,17 +189,17 @@ func GetPath(startRoomId int, endRoomId ...int) ([]pathStep, error) {
 	}()
 
 	if len(endRoomId) == 0 {
-		return []pathStep{}, ErrPathNotFound
+		return []pathStep{}, fmt.Errorf("%d => %d (endRoom not found): %w", startRoomId, endRoomId, ErrPathNotFound)
 	}
 
 	startRoom := rooms.LoadRoom(startRoomId)
 	if startRoom == nil {
-		return []pathStep{}, ErrPathNotFound
+		return []pathStep{}, fmt.Errorf("%d => %d (startRoom  not found): %w", startRoomId, endRoomId, ErrPathNotFound)
 	}
 
 	m := GetZoneMapper(startRoom.Zone)
 	if m == nil {
-		return []pathStep{}, ErrPathNotFound
+		return []pathStep{}, fmt.Errorf("%d => %d (mapper not fond): %w", startRoomId, endRoomId, ErrPathNotFound)
 	}
 
 	rNow := startRoomId
@@ -210,12 +211,12 @@ func GetPath(startRoomId int, endRoomId ...int) ([]pathStep, error) {
 		}
 
 		if !m.HasRoom(roomId) {
-			return []pathStep{}, ErrPathNotFound
+			return []pathStep{}, fmt.Errorf("%d => %d (room not in mapper): %w", rNow, roomId, ErrPathNotFound)
 		}
 
 		p, err := m.findPath(rNow, roomId)
 		if err != nil {
-			return []pathStep{}, ErrPathNotFound
+			return []pathStep{}, fmt.Errorf("%d => %d: %w", rNow, roomId, ErrPathNotFound)
 		}
 
 		finalPath = append(finalPath, p...)

--- a/internal/mapper/mapper.path.go
+++ b/internal/mapper/mapper.path.go
@@ -204,6 +204,11 @@ func GetPath(startRoomId int, endRoomId ...int) ([]pathStep, error) {
 	rNow := startRoomId
 	finalPath := []pathStep{}
 	for _, roomId := range endRoomId {
+
+		if rNow == roomId { // Avoid repeating id's
+			continue
+		}
+
 		if !m.HasRoom(roomId) {
 			return []pathStep{}, ErrPathNotFound
 		}

--- a/internal/mapper/mapper.path_test.go
+++ b/internal/mapper/mapper.path_test.go
@@ -1,17 +1,19 @@
 package mapper
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // buildTestMapper creates a simple 3-room chain: 1 -east-> 2 -south-> 3
 func buildTestMapper() *mapper {
 	m := NewMapper(1)
 	m.crawledRooms = map[int]*mapNode{
-		1: &mapNode{RoomId: 1, Pos: positionDelta{x: 0, y: 0, z: 0}, Exits: map[string]nodeExit{"east": {RoomId: 2}}},
-		2: &mapNode{RoomId: 2, Pos: positionDelta{x: 1, y: 0, z: 0}, Exits: map[string]nodeExit{"south": {RoomId: 3}}},
-		3: &mapNode{RoomId: 3, Pos: positionDelta{x: 1, y: 1, z: 0}, Exits: map[string]nodeExit{}},
+		1: {RoomId: 1, Pos: positionDelta{x: 0, y: 0, z: 0}, Exits: map[string]nodeExit{"east": {RoomId: 2}}},
+		2: {RoomId: 2, Pos: positionDelta{x: 1, y: 0, z: 0}, Exits: map[string]nodeExit{"south": {RoomId: 3}}},
+		3: {RoomId: 3, Pos: positionDelta{x: 1, y: 1, z: 0}, Exits: map[string]nodeExit{}},
 	}
 	return m
 }
@@ -20,9 +22,9 @@ func buildTestMapper() *mapper {
 func buildCycleMapper() *mapper {
 	m := NewMapper(1)
 	m.crawledRooms = map[int]*mapNode{
-		1: &mapNode{RoomId: 1, Pos: positionDelta{x: 0, y: 0, z: 0}, Exits: map[string]nodeExit{"to2": {RoomId: 2}}},
-		2: &mapNode{RoomId: 2, Pos: positionDelta{x: 1, y: 0, z: 0}, Exits: map[string]nodeExit{"to1": {RoomId: 1}, "to3": {RoomId: 3}}},
-		3: &mapNode{RoomId: 3, Pos: positionDelta{x: 2, y: 0, z: 0}, Exits: map[string]nodeExit{}},
+		1: {RoomId: 1, Pos: positionDelta{x: 0, y: 0, z: 0}, Exits: map[string]nodeExit{"to2": {RoomId: 2}}},
+		2: {RoomId: 2, Pos: positionDelta{x: 1, y: 0, z: 0}, Exits: map[string]nodeExit{"to1": {RoomId: 1}, "to3": {RoomId: 3}}},
+		3: {RoomId: 3, Pos: positionDelta{x: 2, y: 0, z: 0}, Exits: map[string]nodeExit{}},
 	}
 	return m
 }
@@ -30,81 +32,62 @@ func buildCycleMapper() *mapper {
 func Test_findPath_DestMatch(t *testing.T) {
 	m := buildTestMapper()
 	_, err := m.findPath(1, 1)
-	if err != ErrPathDestMatch {
-		t.Fatalf("expected ErrPathDestMatch, got %v", err)
-	}
+	assert.ErrorIs(t, err, ErrPathDestMatch)
 }
 
 func Test_findPath_RoomNotFound(t *testing.T) {
 	m := NewMapper(1)
 	m.crawledRooms = map[int]*mapNode{
-		1: &mapNode{RoomId: 1, Pos: positionDelta{}, Exits: map[string]nodeExit{}},
+		1: {RoomId: 1, Pos: positionDelta{}, Exits: map[string]nodeExit{}},
 	}
 
 	_, err := m.findPath(1, 2)
-	if err != ErrRoomNotFound {
-		t.Fatalf("expected ErrRoomNotFound for missing dest, got %v", err)
-	}
+	assert.ErrorIs(t, err, ErrRoomNotFound, "expected ErrRoomNotFound for missing dest")
 
 	_, err = m.findPath(2, 1)
-	if err != ErrRoomNotFound {
-		t.Fatalf("expected ErrRoomNotFound for missing source, got %v", err)
-	}
+	assert.ErrorIs(t, err, ErrRoomNotFound, "expected ErrRoomNotFound for missing source")
 }
 
 func Test_findPath_Simple(t *testing.T) {
 	m := buildTestMapper()
 	path, err := m.findPath(1, 3)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if len(path) != 2 {
-		t.Fatalf("expected path length 2, got %d", len(path))
-	}
+	require.NoError(t, err)
+	require.Len(t, path, 2)
 
-	if got := path[0]; got.exitName != "east" || got.roomId != 2 || got.waypoint {
-		t.Errorf("step0 = %+v; want {ExitName:east RoomId:2 Waypoint:false}", got)
-	}
-	if got := path[1]; got.exitName != "south" || got.roomId != 3 || !got.waypoint {
-		t.Errorf("step1 = %+v; want {ExitName:south RoomId:3 Waypoint:true}", got)
-	}
+	assert.Equal(t, "east", path[0].exitName)
+	assert.Equal(t, 2, path[0].roomId)
+	assert.False(t, path[0].waypoint)
+
+	assert.Equal(t, "south", path[1].exitName)
+	assert.Equal(t, 3, path[1].roomId)
+	assert.True(t, path[1].waypoint)
 }
 
 func Test_findPath_Unreachable(t *testing.T) {
 	m := NewMapper(1)
 	m.crawledRooms = map[int]*mapNode{
-		1: &mapNode{RoomId: 1, Pos: positionDelta{}, Exits: map[string]nodeExit{}},
-		2: &mapNode{RoomId: 2, Pos: positionDelta{x: 1}, Exits: map[string]nodeExit{}},
+		1: {RoomId: 1, Pos: positionDelta{}, Exits: map[string]nodeExit{}},
+		2: {RoomId: 2, Pos: positionDelta{x: 1}, Exits: map[string]nodeExit{}},
 	}
 
 	_, err := m.findPath(1, 2)
-	if err != ErrPathNotFound {
-		t.Fatalf("expected ErrPathNotFound, got %v", err)
-	}
+	assert.ErrorIs(t, err, ErrPathNotFound)
 }
 
 func Test_findPath_Cycle(t *testing.T) {
 	m := buildCycleMapper()
 	path, err := m.findPath(1, 3)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if len(path) != 2 {
-		t.Fatalf("expected path length 2, got %d", len(path))
-	}
+	require.NoError(t, err)
+	require.Len(t, path, 2)
 
-	if got := path[0]; got.exitName != "to2" || got.roomId != 2 {
-		t.Errorf("step0 = %+v; want {ExitName:to2 RoomId:2}", got)
-	}
-	if got := path[1]; got.exitName != "to3" || got.roomId != 3 {
-		t.Errorf("step1 = %+v; want {ExitName:to3 RoomId:3}", got)
-	}
+	assert.Equal(t, "to2", path[0].exitName)
+	assert.Equal(t, 2, path[0].roomId)
+
+	assert.Equal(t, "to3", path[1].exitName)
+	assert.Equal(t, 3, path[1].roomId)
 }
 
 func Test_GetPath_StartNotFound(t *testing.T) {
 	_, err := GetPath(999999)
-
-	if !errors.Is(err, ErrPathNotFound) {
-		t.Fatalf("expected ErrPathNotFound for missing start, got %v", err)
-	}
+	assert.ErrorIs(t, err, ErrPathNotFound, "expected ErrPathNotFound for missing start")
 }

--- a/internal/mapper/mapper.path_test.go
+++ b/internal/mapper/mapper.path_test.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -102,7 +103,8 @@ func Test_findPath_Cycle(t *testing.T) {
 
 func Test_GetPath_StartNotFound(t *testing.T) {
 	_, err := GetPath(999999)
-	if err != ErrPathNotFound {
+
+	if !errors.Is(err, ErrPathNotFound) {
 		t.Fatalf("expected ErrPathNotFound for missing start, got %v", err)
 	}
 }

--- a/internal/mobcommands/mobcommands.go
+++ b/internal/mobcommands/mobcommands.go
@@ -48,6 +48,7 @@ var (
 		"lookforaid":     {LookForAid, false},
 		"lookfortrouble": {LookForTrouble, false},
 		"noop":           {Noop, true},
+		"pathto":         {Pathto, false},
 		"portal":         {Portal, false},
 		"put":            {Put, false},
 		"remove":         {Remove, false},

--- a/internal/mobcommands/pathto.go
+++ b/internal/mobcommands/pathto.go
@@ -1,0 +1,48 @@
+package mobcommands
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/mapper"
+	"github.com/GoMudEngine/GoMud/internal/mobs"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+func Pathto(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
+
+	toRoomIds := []int{}
+
+	for _, roomIdStr := range util.SplitButRespectQuotes(strings.ToLower(rest)) {
+
+		if roomIdStr == `home` {
+			toRoomIds = append(toRoomIds, mob.HomeRoomId)
+			continue
+		}
+
+		if roomIdInt, err := strconv.Atoi(roomIdStr); err == nil {
+			toRoomIds = append(toRoomIds, roomIdInt)
+		}
+	}
+
+	if len(toRoomIds) == 0 {
+		return false, nil
+	}
+
+	path, err := mapper.GetPath(mob.Character.RoomId, toRoomIds...)
+	if err != nil {
+		return false, err
+	}
+
+	newPath := []mobs.PathRoom{}
+
+	// Copy everything over
+	for _, p := range path {
+		newPath = append(newPath, p)
+	}
+
+	mob.Path.SetPath(newPath)
+
+	return true, nil
+}

--- a/internal/mobcommands/pathto.go
+++ b/internal/mobcommands/pathto.go
@@ -26,8 +26,8 @@ func Pathto(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		}
 	}
 
-	if len(toRoomIds) == 0 {
-		return false, nil
+	if len(toRoomIds) < 1 || toRoomIds[0] == mob.Character.RoomId {
+		return true, nil
 	}
 
 	path, err := mapper.GetPath(mob.Character.RoomId, toRoomIds...)

--- a/internal/mobcommands/wander.go
+++ b/internal/mobcommands/wander.go
@@ -17,9 +17,9 @@ func Wander(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 	// If they aren't home and need to go home, do it.
 	if mob.Character.RoomId != mob.HomeRoomId {
 		if mob.MaxWander > -1 { // -1 means they can wander forever and never go home. 0 means they never wander.
-			if len(mob.RoomStack) > mob.MaxWander {
+			if mob.WanderCount > mob.MaxWander {
 
-				mob.Command(`go home`)
+				mob.Command(`pathto home`)
 
 				return true, nil
 			}
@@ -58,6 +58,7 @@ func Wander(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		if r := rooms.LoadRoom(roomId); r != nil {
 			if !restrictZone || r.Zone == mob.Character.Zone {
 
+				mob.WanderCount++
 				mob.Command(fmt.Sprintf("go %s", exitName))
 
 			}

--- a/internal/mobs/mobs.go
+++ b/internal/mobs/mobs.go
@@ -69,8 +69,7 @@ type Mob struct {
 	CombatCommands  []string `yaml:"combatcommands,omitempty"` // Commands they may do while in combat
 	Character       characters.Character
 	MaxWander       int      `yaml:"maxwander,omitempty"`       // Max rooms to wander from home
-	GoingHome       bool     `yaml:"-"`                         // WHether they are trying to get home
-	RoomStack       []int    `yaml:"-"`                         // Stack of rooms to get back home
+	WanderCount     int      `yaml:"-"`                         // How many times this mob has wandered
 	PreventIdle     bool     `yaml:"-"`                         // Whether they can't possibly be idle
 	ScriptTag       string   `yaml:"scripttag"`                 // Script for this mob: mobs/frostfang/scripts/{mobId}-{mobname}-{ScriptTag}.js
 	QuestFlags      []string `yaml:"questflags,omitempty,flow"` // What quest flags are set on this mob?

--- a/internal/mobs/mobs.go
+++ b/internal/mobs/mobs.go
@@ -76,8 +76,9 @@ type Mob struct {
 	QuestFlags      []string `yaml:"questflags,omitempty,flow"` // What quest flags are set on this mob?
 	BuffIds         []int    `yaml:"buffids,omitempty"`         // Buff Id's this mob always has upon spawn
 	tempDataStore   map[string]any
-	conversationId  int  // Identifier of conversation currently involved in.
-	hasConverseFile bool // whether they have a converse file to look for conversations in
+	conversationId  int       // Identifier of conversation currently involved in.
+	hasConverseFile bool      // whether they have a converse file to look for conversations in
+	Path            PathQueue `yaml:"-"` // a pre-calculated path the mob is following.
 }
 
 func MobInstanceExists(instanceId int) bool {

--- a/internal/mobs/mobs_path.go
+++ b/internal/mobs/mobs_path.go
@@ -1,0 +1,55 @@
+package mobs
+
+type PathRoom interface {
+	ExitName() string
+	RoomId() int
+	Waypoint() bool
+}
+
+type PathQueue struct {
+	roomQueue   []PathRoom
+	currentRoom PathRoom
+}
+
+func (p PathQueue) Len() int {
+	return len(p.roomQueue)
+}
+
+func (p *PathQueue) Clear() {
+	p.roomQueue = []PathRoom{}
+	p.currentRoom = nil
+}
+
+func (p PathQueue) Current() PathRoom {
+	return p.currentRoom
+}
+
+func (p *PathQueue) Next() PathRoom {
+	if len(p.roomQueue) == 0 {
+		return nil
+	}
+	p.currentRoom = p.roomQueue[0]
+	p.roomQueue = p.roomQueue[1:]
+	return p.currentRoom
+}
+
+// returns a list of remaining waypoint roomIds
+func (p *PathQueue) Waypoints() []int {
+	wpList := []int{}
+	if p.currentRoom != nil && p.currentRoom.Waypoint() {
+		wpList = append(wpList, p.currentRoom.RoomId())
+	}
+
+	for _, r := range p.roomQueue {
+		if r.Waypoint() {
+			wpList = append(wpList, r.RoomId())
+		}
+	}
+
+	return wpList
+}
+
+func (p *PathQueue) SetPath(path []PathRoom) {
+	p.roomQueue = path
+	p.currentRoom = nil
+}

--- a/internal/scripting/actor_func.go
+++ b/internal/scripting/actor_func.go
@@ -749,6 +749,21 @@ func (a ScriptActor) GetLastInputRound() uint64 {
 	return 0
 }
 
+func (a ScriptActor) Pathing() bool {
+	if a.mobRecord == nil {
+		return false
+	}
+	return a.mobRecord.Path.Current() != nil || a.mobRecord.Path.Len() > 0
+}
+
+func (a ScriptActor) PathingAtWaypoint() bool {
+	if a.mobRecord == nil {
+		return false
+	}
+	pathStep := a.mobRecord.Path.Current()
+	return pathStep != nil && pathStep.Waypoint()
+}
+
 // ////////////////////////////////////////////////////////
 //
 // # These functions get exported to the scripting engine

--- a/internal/usercommands/admin.locate.go
+++ b/internal/usercommands/admin.locate.go
@@ -139,7 +139,7 @@ func Locate(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 					fmt.Sprintf(`%-4d`, mob.Character.RoomId),
 					fmt.Sprintf(`%-24s`, roomTitle),
 					fmt.Sprintf(`%-14s`, mob.Character.Zone),
-					fmt.Sprintf(`%-5s`, fmt.Sprintf(`%d/%d`, len(mob.RoomStack), mob.MaxWander)),
+					fmt.Sprintf(`%-5s`, fmt.Sprintf(`%d/%d`, mob.WanderCount, mob.MaxWander)),
 				})
 
 				if ct >= matchesPerPage {

--- a/main.go
+++ b/main.go
@@ -292,10 +292,8 @@ func main() {
 		}
 	}()
 
-	// Send the worker shutdown signal for each worker thread to read
-	workerShutdownChan <- true
-	workerShutdownChan <- true
-	workerShutdownChan <- true
+	// Close the channel, signalling to the worker threads to shutdown.
+	close(workerShutdownChan)
 
 	// Wait for all workers to finish their tasks.
 	// Otherwise we end up getting flushed file saves incomplete.


### PR DESCRIPTION
# Description

This adds initial implementation of pathfinding for mobs. 
A `pathto` command is added, which accepts multiple room id's, or the keyword `home` (to go back to their spawned-from room) to initiate a path for a mob. This allows testing via the admin `command` command, and also initiating via scripting.

## Changes

Provide a bullet point list of noteworthy changes in this Pull Request:

- Paths are followed when mobs are idle
- `pathto` command added.
  - Example: `pathto 300 1 home` to create/follow a path to roomId 300, then 1, then back to home room.
  - If rooms cannot be fully connected, `pathto` fails without a path.
- Removed old "room stack" tracking used to return home when mobs wander too far. It was buggy anyways. Replaced with `pathto home`
- Added some randomly selected paths for frostfang guards to patrol.
- Scripting functions to check path status
