### PR TITLE
Script error fix (sophie's locked - frostfang)

### DIFF
--- a/_datafiles/world/default/mobs/frostfang/scripts/26-frostfang_citizen-locketsadness.js
+++ b/_datafiles/world/default/mobs/frostfang/scripts/26-frostfang_citizen-locketsadness.js
@@ -48,13 +48,6 @@ function onAsk(mob, room, eventDetails) {
 
     }
 
-    match = UtilFindMatchIn(eventDetails.askText, lichSubjects);
-    if ( match.found ) {
-        mob.Command("say An ancient lich king eh? Do you have any proof that what you say is true?");
-
-        return true;
-    }
-
     return true;
 }
 


### PR DESCRIPTION
# Description

The Sophie script in frostfang has some code that errors out when run. This was mistakenly copied from another script.

This change removes that code.

## Changes

- Removed offending "lich subject" related code.
