### PR TITLE
Adding a prompt for kicking user when double-logging in

### DIFF
--- a/internal/connections/connections.go
+++ b/internal/connections/connections.go
@@ -100,7 +100,7 @@ func Cleanup() {
 	}
 }
 
-func Kick(id ConnectionId) (err error) {
+func Kick(id ConnectionId, reason string) (err error) {
 
 	lock.Lock()
 	defer lock.Unlock()
@@ -113,7 +113,7 @@ func Kick(id ConnectionId) (err error) {
 		// keep track of the number of disconnects
 		disconnectCounter++
 		// remove the connection from the map
-		mudlog.Info("connection kicked", "connectionId", id, "remoteAddr", cd.RemoteAddr().String())
+		mudlog.Info("connection kicked", "connectionId", id, "remoteAddr", cd.RemoteAddr().String(), `reason`, reason)
 
 		return nil
 

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -108,8 +108,9 @@ func (w WebClientCommand) Type() string { return `WebClientCommand` }
 
 // Messages that are intended to reach all users on the system
 type System struct {
-	Command string
-	Data    any
+	Command     string
+	Data        any
+	Description string
 }
 
 func (s System) Type() string { return `System` }

--- a/internal/hooks/NewRound_InactivePlayers.go
+++ b/internal/hooks/NewRound_InactivePlayers.go
@@ -49,8 +49,9 @@ func InactivePlayers(e events.Event) events.ListenerReturn {
 
 		if li < cutoffRound {
 			events.AddToQueue(events.System{
-				Command: `kick`,
-				Data:    user.UserId,
+				Command:     `kick`,
+				Data:        user.UserId,
+				Description: `Inactivity`,
 			})
 		}
 

--- a/internal/hooks/NewTurn_CleanupZombies.go
+++ b/internal/hooks/NewTurn_CleanupZombies.go
@@ -35,7 +35,11 @@ func CleanupZombies(e events.Event) events.ListenerReturn {
 			mudlog.Info("Expired Zombies", "count", len(expZombies))
 
 			for _, userId := range expZombies {
-				events.AddToQueue(events.System{Command: `leaveworld`, Data: userId})
+				events.AddToQueue(events.System{
+					Command:     `leaveworld`,
+					Data:        userId,
+					Description: `Zombie Expired`,
+				})
 			}
 
 		}

--- a/internal/inputhandlers/login.go
+++ b/internal/inputhandlers/login.go
@@ -3,6 +3,8 @@ package inputhandlers
 import (
 	// ... other imports
 
+	"fmt"
+
 	"github.com/GoMudEngine/GoMud/internal/configs"
 	"github.com/GoMudEngine/GoMud/internal/connections"
 	"github.com/GoMudEngine/GoMud/internal/language"
@@ -24,6 +26,9 @@ func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any
 		if userExists {
 
 			if results["kickuser"] == "y" {
+
+				connDetails := connections.Get(clientInput.ConnectionId)
+
 				// Disconnect/kick the user currently connected
 				userid := users.FindUserId(results["username"])
 				user := users.GetByUserId(userid)
@@ -34,7 +39,8 @@ func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any
 				tplTxt, _ := templates.Process("goodbye", nil)
 				connections.SendTo([]byte(templates.AnsiParse(tplTxt)), existingConnectionId)
 
-				connections.Kick(existingConnectionId)
+				users.SetZombieUser(userid)
+				connections.Kick(existingConnectionId, fmt.Sprintf(`Duplicate login (ip: %s)`, connDetails.RemoteAddr()))
 
 			}
 

--- a/internal/inputhandlers/login.go
+++ b/internal/inputhandlers/login.go
@@ -7,27 +7,10 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/connections"
 	"github.com/GoMudEngine/GoMud/internal/language"
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/templates"
 	"github.com/GoMudEngine/GoMud/internal/term"
 	"github.com/GoMudEngine/GoMud/internal/users"
 )
-
-// Condition Helpers
-
-func ConditionIsNewSignup(results map[string]string) bool {
-	return results["new-signup"] == `new`
-}
-
-// ConditionUserDoesNotExist checks if the username entered does *not* exist.
-func ConditionUserDoesNotExist(results map[string]string) bool {
-	username := results["username"] // Assumes previous step had ID "username"
-	return !users.Exists(username)
-}
-
-// ConditionUserExists checks if the username entered *does* exist.
-func ConditionUserExists(results map[string]string) bool {
-	username := results["username"] // Assumes previous step had ID "username"
-	return users.Exists(username)
-}
 
 // FinalizeLoginOrCreate is called after all prompts are successfully answered.
 func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any, clientInput *connections.ClientInput) bool {
@@ -39,6 +22,22 @@ func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any
 		userExists := users.Exists(username)
 
 		if userExists {
+
+			if results["kickuser"] == "y" {
+				// Disconnect/kick the user currently connected
+				userid := users.FindUserId(results["username"])
+				user := users.GetByUserId(userid)
+
+				existingConnectionId := user.ConnectionId()
+
+				// Send a goodbye message to the currently connected user
+				tplTxt, _ := templates.Process("goodbye", nil)
+				connections.SendTo([]byte(templates.AnsiParse(tplTxt)), existingConnectionId)
+
+				connections.Kick(existingConnectionId)
+
+			}
+
 			// Existing User Login Logic (No changes needed)
 			tmpUser, err := users.LoadUser(username)
 			if err != nil {
@@ -164,6 +163,31 @@ func GetLoginPromptHandler() connections.InputHandler {
 			MaskTemplate:   "login/password.mask", // Optional: specify if different from "*"
 			Validator:      ValidatePassword,
 			Condition:      func(results map[string]string) bool { return results["username"] != `new` }, // Only run if username was not "new"
+		},
+		{
+			ID:             "kickuser",
+			PromptTemplate: "generic/prompt.yn",
+			GetDataFunc: func(results map[string]string) map[string]any {
+				// Dynamically generate the data for the generic y/n prompt
+				return map[string]any{
+					"prompt":  "User is already connected. Kick them?",
+					"options": []string{"y", "n"},
+					"default": "n", // Default shown in the prompt, actual default on empty input handled by validator
+				}
+			},
+			MaskInput: false,
+			Validator: ValidateYesNo,
+			Condition: func(results map[string]string) bool {
+				if results["username"] == `new` {
+					return false
+				}
+
+				userid := users.FindUserId(results["username"])
+
+				user := users.GetByUserId(userid)
+
+				return user != nil && user.PasswordMatches(results["password"])
+			}, // Only run if username was not "new", password matches, and user is currently online.
 		},
 		//////////////////////////////////////////////////
 		// End If NOT a new user signup (Just a login)

--- a/internal/inputhandlers/systemcommands.go
+++ b/internal/inputhandlers/systemcommands.go
@@ -118,7 +118,7 @@ func trySystemCommand(cmd string, connectionId connections.ConnectionId) bool {
 
 		connections.SendTo([]byte(templates.AnsiParse(tplTxt)), connectionId)
 
-		connections.Kick(connectionId)
+		connections.Kick(connectionId, `/quit`)
 		return true
 	}
 

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -581,3 +581,9 @@ func Exists(name string) bool {
 
 	return found
 }
+
+func FindUserId(username string) int {
+	idx := NewUserIndex()
+	userid, _ := idx.FindByUsername(username)
+	return int(userid)
+}

--- a/world.go
+++ b/world.go
@@ -183,7 +183,7 @@ func (w *World) HandleSystemEvents(e events.Event) events.ListenerReturn {
 		})
 
 	} else if sys.Command == `kick` {
-		w.Kick(sys.Data.(int))
+		w.Kick(sys.Data.(int), sys.Description)
 	} else if sys.Command == `leaveworld` {
 
 		if userInfo := users.GetByUserId(sys.Data.(int)); userInfo != nil {
@@ -1025,19 +1025,17 @@ func (w *World) UpdateStats() {
 }
 
 // Force disconnect a user (Makes them a zombie)
-func (w *World) Kick(userId int) {
-
-	mudlog.Info(`Kick`, `userId`, userId)
+func (w *World) Kick(userId int, reason string) {
 
 	user := users.GetByUserId(userId)
 	if user == nil {
 		return
 	}
+
 	users.SetZombieUser(userId)
+	user.EventLog.Add(`conn`, fmt.Sprintf(`Kicked (%s)`, reason))
 
-	user.EventLog.Add(`conn`, `Kicked`)
-
-	connections.Kick(user.ConnectionId())
+	connections.Kick(user.ConnectionId(), reason)
 }
 
 func (w *World) logOff(userId int) {


### PR DESCRIPTION
# Description

When a user is already logged in, and tries to log in again, it denies them and disconnects.

However, there may be situations where they are not really logged in, and something is maintaining the connection, preventing them from logging in until an inactivity timeout kicks the "almost zombie" user.

This adds a prompt to the login process allowing a second login to optionally kick the first login, and replace them.

## Changes

- Added a new prompt: "User is already connected. Kick them?"
- When `no` is selected, they are denied login as it is currently.
- When `yes` is selected, the currently connected user is kicked, and the new login replaces them.
- Removed some unused code/functions

