### PR TITLE
Mob pathing additions

### DIFF
--- a/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
+++ b/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
@@ -81,6 +81,9 @@ ActorObjects are the basic object that represents Users and NPCs
   - [ActorObject.SetTameMastery(mobId int, newSkillLevel int)](#actorobjectsettamemasterymobid-int-newskilllevel-int)
   - [ActorObject.GetChanceToTame(target ScriptActor) int](#actorobjectgetchancetotametarget-scriptactor-int)
   - [ActorObject.GetStatMod(statModName string) int](#actorobjectgetstatmodstatmodname-string-int)
+  - [ActorObject.IsHome() bool](#actorobjectishome-bool)
+  - [ActorObject.Pathing() bool](#actorobjectpathing-bool)
+  - [ActorObject.PathingAtWaypoint() bool](#actorobjectpathingatwaypoint-bool)
 
 
 
@@ -553,3 +556,12 @@ returns the total specific statmod from worn items and buffs
 |  Argument | Explanation |
 | --- | --- |
 | statModName | The name of the special stat mod, such as "strength" or "tame" |
+
+## [ActorObject.IsHome() bool](/internal/scripting/actor_func.go)
+(mobs only) Returns true if the actor is at their home roomId
+
+## [ActorObject.Pathing() bool](/internal/scripting/actor_func.go)
+(mobs only) Returns true if actor is currently pathing
+
+## [ActorObject.PathingAtWaypoint() bool](/internal/scripting/actor_func.go)
+(mobs only) Returns true if actor is pathing and at a waypoint.

--- a/_datafiles/guides/building/scripting/SCRIPTING_MOBS.md
+++ b/_datafiles/guides/building/scripting/SCRIPTING_MOBS.md
@@ -190,3 +190,16 @@ function onDie(mob ActorObject, room RoomObject, eventDetails object) {
 
 ---
 
+```
+function onAsk(mob ActorObject, room RoomObject, eventDetails object) {
+}
+```
+
+`onPath()` is called when mob is asked something. Returning `true` will end the pathing and skip any additional path processing. 
+NOTE: You can safely start a new path with `mob.Command('pathto 123')` before returning true, since the command will be executed slightly later in the event chain.
+
+|  Argument | Explanation |
+| --- | --- |
+| mob | [ActorObject](FUNCTIONS_ACTORS.md) |
+| room | [RoomObject](FUNCTIONS_ROOMS.md) |
+| eventDetails.status | `start`, `waypoint`, or `end` |

--- a/_datafiles/world/default/conversations/frostfang/40.yaml
+++ b/_datafiles/world/default/conversations/frostfang/40.yaml
@@ -1,0 +1,9 @@
+- 
+  Supported: # A map of lowercase names of "Initiator" (#1) to array of "Participant" (#2) names allowed to use this conversation. 
+    "rodric": ["wench"]
+  Conversation:
+    - ["#1 sayto #2 I'll 'ave a mug 'o ale, wench!"]
+    - ["#2 say Very well, Rodric, but be off with you. We don't need you lingering around the guests smelling like death."]
+    - ["#2 emote hands Rodric a mug."]
+    - ["#1 say Aye, i'll be off, then."]
+    - ["#2 emote mumbles something under their breath."]

--- a/_datafiles/world/default/mobs/frostfang/40-rodric.yaml
+++ b/_datafiles/world/default/mobs/frostfang/40-rodric.yaml
@@ -1,5 +1,5 @@
 mobid:  40
-zone: Frostfang Slums
+zone: Frostfang
 itemdropchance: 2
 hostile: false
 maxwander: 5

--- a/_datafiles/world/default/mobs/frostfang/scripts/40-rodric.js
+++ b/_datafiles/world/default/mobs/frostfang/scripts/40-rodric.js
@@ -1,6 +1,7 @@
 
 const startNouns = ["rat", "rats", "too many", "problem"];
 const thievesNouns = ["thief", "thieves", "guild", "hideout", "entrance", "dogs", "slums"];
+const INN_ROOM_ID = 61;
 
 function onAsk(mob, room, eventDetails) {
 
@@ -111,24 +112,38 @@ function onGive(mob, room, eventDetails) {
 }
 
 
-RANDOM_IDLE = [
+function onPath(mob, room, eventDetails) {
+
+    if ( eventDetails.status == "waypoint" && room.RoomId() == INN_ROOM_ID ) {
+        mob.Command("converse 1");
+    }
+
+}
+
+const RANDOM_IDLE = [
     "emote shakes his head in disbelief.",
     "emote attempts to fix a rat trap.",
     "say There's just too many rats. We'll never get rid of them all.",
     "say I'm so tired. I need a break.",
     "say I'm running out of traps. I need to find more.",
     "say I'm worried about the rats in the slums. They're everywhere!",
-    "say I'm running out of traps and don't seem to be making a dent in the rat numbers."
+    "say I'm running out of traps and don't seem to be making a dent in the rat numbers.",
+    "pathto "+String(INN_ROOM_ID),
 ];
 
 // Invoked once every round if mob is idle
 function onIdle(mob, room) {
 
+    if ( room.RoomId() == INN_ROOM_ID ) {
+        mob.Command("pathto home");
+        return true;
+    }
+
     if ( UtilGetRoundNumber()%3 != 0 ) {
         return true;
     }
 
-    randNum = UtilDiceRoll(1, 10)-1;
+    randNum = UtilDiceRoll(1, 12)-1;
     if ( randNum < RANDOM_IDLE.length ) {
         mob.Command(RANDOM_IDLE[randNum]);
         return true;

--- a/internal/hooks/MobIdle_HandleIdleMobs.go
+++ b/internal/hooks/MobIdle_HandleIdleMobs.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/conversations"
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/mobcommands"
 	"github.com/GoMudEngine/GoMud/internal/mobs"
@@ -34,7 +35,7 @@ func HandleIdleMobs(e events.Event) events.ListenerReturn {
 		}
 	}
 
-	if mob.CanConverse() && util.Rand(100) < int(configs.GetGamePlayConfig().MobConverseChance) {
+	if conversations.HasConverseFile(int(mob.MobId), mob.Character.Zone) && util.Rand(100) < int(configs.GetGamePlayConfig().MobConverseChance) {
 		if mobRoom := rooms.LoadRoom(mob.Character.RoomId); mobRoom != nil {
 			mobcommands.Converse(``, mob, mobRoom) // Execute this directly so that target mob doesn't leave the room before this command executes
 		}

--- a/internal/hooks/MobIdle_HandleIdleMobs.go
+++ b/internal/hooks/MobIdle_HandleIdleMobs.go
@@ -23,11 +23,15 @@ func HandleIdleMobs(e events.Event) events.ListenerReturn {
 		return events.Cancel
 	}
 
+	isCharmed := mob.Character.IsCharmed()
+
 	// if a mob shouldn't be allowed to leave their area (via wandering)
 	// but has somehow been displaced, such as pulling through combat, spells, or otherwise
 	// tell them to path back home
 	if mob.MaxWander == 0 && mob.Character.RoomId != mob.HomeRoomId {
-		mob.Command("pathto home")
+		if !isCharmed {
+			mob.Command("pathto home")
+		}
 	}
 
 	if mob.CanConverse() && util.Rand(100) < int(configs.GetGamePlayConfig().MobConverseChance) {
@@ -40,32 +44,35 @@ func HandleIdleMobs(e events.Event) events.ListenerReturn {
 	handled, _ := scripting.TryMobScriptEvent("onIdle", mob.InstanceId, 0, ``, nil)
 	if !handled {
 
-		if !mob.Character.IsCharmed() { // Won't do this stuff if befriended
-
-			if mob.MaxWander > -1 && mob.WanderCount > mob.MaxWander {
-				mob.Command(`pathto home`)
-			}
-
-		}
-
-		//
-		// Look for trouble
-		//
-		if mob.Character.IsCharmed() {
+		if isCharmed {
 			// Only some mobs can apply first aid
+			// If a charmed mob can aid someone, try.
 			if mob.Character.KnowsFirstAid() {
 				mob.Command(`lookforaid`)
 			}
 		} else {
 
-			idleCmd := `lookfortrouble`
-			if util.Rand(100) < mob.ActivityLevel {
-				idleCmd = mob.GetIdleCommand()
-				if idleCmd == `` {
-					idleCmd = `lookfortrouble`
+			if mob.MaxWander > -1 && mob.WanderCount > mob.MaxWander {
+
+				// Not charmed and far from home, and should never leave home.
+				// So go home.
+				mob.Command(`pathto home`)
+
+			} else {
+
+				//
+				// Look for trouble
+				//
+
+				idleCmd := `lookfortrouble`
+				if util.Rand(100) < mob.ActivityLevel {
+					idleCmd = mob.GetIdleCommand()
+					if idleCmd == `` {
+						idleCmd = `lookfortrouble`
+					}
 				}
+				mob.Command(idleCmd)
 			}
-			mob.Command(idleCmd)
 		}
 	}
 

--- a/internal/hooks/NewRound_IdleMobs.go
+++ b/internal/hooks/NewRound_IdleMobs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/mobs"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/scripting"
 	"github.com/GoMudEngine/GoMud/internal/users"
 	"github.com/GoMudEngine/GoMud/internal/util"
 )
@@ -85,6 +86,12 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 		if currentStep := mob.Path.Current(); currentStep != nil || mob.Path.Len() > 0 {
 
 			if currentStep == nil {
+
+				if endPathingAndSkip, _ := scripting.TryMobScriptEvent("onPath", mob.InstanceId, 0, ``, map[string]any{`status`: `start`}); endPathingAndSkip {
+					mob.Path.Clear()
+					continue
+				}
+
 				if mobPathAnnounce {
 					mob.Command(`say I'm beginning a new path.`)
 				}
@@ -133,10 +140,16 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 
 			}
 
+			mob.Path.Clear()
+
+			if endPathingAndSkip, _ := scripting.TryMobScriptEvent("onPath", mob.InstanceId, 0, ``, map[string]any{`status`: `end`}); endPathingAndSkip {
+				continue
+			}
+
 			if mobPathAnnounce {
 				mob.Command(`say I'm.... done.`)
 			}
-			mob.Path.Clear()
+
 		}
 
 		events.AddToQueue(events.MobIdle{MobInstanceId: mobId})

--- a/internal/hooks/NewRound_IdleMobs.go
+++ b/internal/hooks/NewRound_IdleMobs.go
@@ -97,7 +97,7 @@ func IdleMobs(e events.Event) events.ListenerReturn {
 				}
 			} else {
 
-				// If their currentStep isnt' actually the room they are in
+				// If their currentStep isn't actually the room they are in
 				// They've somehow been moved. Reclaculate a new path.
 				if currentStep.RoomId() != mob.Character.RoomId {
 					if mobPathAnnounce {

--- a/internal/mobcommands/converse.go
+++ b/internal/mobcommands/converse.go
@@ -12,15 +12,11 @@ import (
 func Converse(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Don't bother if no players are present
-	if room.PlayerCt() < 1 {
-		// return true, nil
-	}
-
 	if mob.InConversation() {
 		return true, nil
 	}
 
-	if !mob.CanConverse() {
+	if !conversations.HasConverseFile(int(mob.MobId), mob.Character.Zone) {
 		return true, nil
 	}
 
@@ -46,9 +42,13 @@ func Converse(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 			conversationId := 0
 			if rest != `` {
 				forceIndex, _ := strconv.Atoi(rest)
-				conversationId = conversations.AttemptConversation(int(mob.MobId), mob.InstanceId, mob.Character.Name, m.InstanceId, m.Character.Name, m.Character.Zone, forceIndex)
+				conversationId = conversations.AttemptConversation(int(mob.MobId), mob.InstanceId, mob.Character.Name,
+					m.InstanceId, m.Character.Name,
+					mob.Character.Zone, forceIndex)
 			} else {
-				conversationId = conversations.AttemptConversation(int(mob.MobId), mob.InstanceId, mob.Character.Name, m.InstanceId, m.Character.Name, m.Character.Zone)
+				conversationId = conversations.AttemptConversation(int(mob.MobId), mob.InstanceId, mob.Character.Name,
+					m.InstanceId, m.Character.Name,
+					mob.Character.Zone)
 			}
 
 			if conversationId > 0 {

--- a/internal/mobcommands/portal.go
+++ b/internal/mobcommands/portal.go
@@ -48,7 +48,7 @@ func Portal(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 			mob.Command(`portal home;drop all`)
 
-			return true, fmt.Errorf("failed to find temporary exit to room")
+			return true, fmt.Errorf("failed to find worthy room with loot")
 		}
 		portalTargetRoomId = mostItemRoomId
 	}

--- a/internal/mobcommands/shout.go
+++ b/internal/mobcommands/shout.go
@@ -11,19 +11,14 @@ import (
 
 func Shout(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	// Don't bother if no players are present
-	if room.PlayerCt() < 1 {
-		return true, nil
-	}
-
 	isSneaking := mob.Character.HasBuffFlag(buffs.Hidden)
 
 	rest = strings.ToUpper(rest)
 
 	if isSneaking {
-		room.SendText(fmt.Sprintf(`someone shouts, "<ansi fg="saytext-mob">%s</ansi>"`, rest), mob.InstanceId)
+		room.SendText(fmt.Sprintf(`someone shouts, "<ansi fg="saytext-mob">%s</ansi>"`, rest))
 	} else {
-		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> shouts, "<ansi fg="saytext-mob">%s</ansi>"`, mob.Character.Name, rest), mob.InstanceId)
+		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> shouts, "<ansi fg="saytext-mob">%s</ansi>"`, mob.Character.Name, rest))
 	}
 
 	for _, roomInfo := range room.Exits {

--- a/internal/mobs/mobs.go
+++ b/internal/mobs/mobs.go
@@ -76,7 +76,6 @@ type Mob struct {
 	BuffIds         []int    `yaml:"buffids,omitempty"`         // Buff Id's this mob always has upon spawn
 	tempDataStore   map[string]any
 	conversationId  int       // Identifier of conversation currently involved in.
-	hasConverseFile bool      // whether they have a converse file to look for conversations in
 	Path            PathQueue `yaml:"-"` // a pre-calculated path the mob is following.
 }
 
@@ -256,10 +255,6 @@ func (m *Mob) AddBuff(buffId int, source string) {
 		Source:        source,
 	})
 
-}
-
-func (m *Mob) CanConverse() bool {
-	return m.hasConverseFile
 }
 
 func (m *Mob) InConversation() bool {
@@ -587,8 +582,6 @@ func (r *Mob) Validate() error {
 	} else if r.ActivityLevel > 100 {
 		r.ActivityLevel = 100
 	}
-
-	r.hasConverseFile = conversations.HasConverseFile(int(r.MobId), r.Zone)
 
 	r.Character.Validate()
 	return nil


### PR DESCRIPTION
# Description

Adds additional scriptability around pathing, and fixes some small bugs and quirks.

## Changes

- Add scripting documentation for actors and mobs
- Rewrote parts of lakeworker script to use pathfinding.
- Improved lakeworker script to do a little more while pathing.
- Added script event functions for various stages of a path.
- Fixed misbehavior of mob `shout` command.
- Updated command processing so that mobs subject to similar waiting rules as players when commands are queued with delays.
- Added caching for mobs that cannot find a path home.
- Mobs that can't go home receive an adjective `lost`
- Fixed some conversation bugginess, added some caching
- Moved `Rodric` to frostfang folder, where he should be.
- Improved Rodric scripting slightly to have some more interesting behavior.


