### PR TITLE
Mapper fixes

### DIFF
--- a/internal/mapper/mapper.path.go
+++ b/internal/mapper/mapper.path.go
@@ -209,7 +209,7 @@ func GetPath(startRoomId int, endRoomId ...int) ([]pathStep, error) {
 		return []pathStep{}, fmt.Errorf("%d => %d (startRoom  not found): %w", startRoomId, endRoomId, ErrPathNotFound)
 	}
 
-	m := GetZoneMapper(startRoom.Zone)
+	m := GetMapper(startRoom.RoomId)
 	if m == nil {
 		return []pathStep{}, fmt.Errorf("%d => %d (mapper not fond): %w", startRoomId, endRoomId, ErrPathNotFound)
 	}

--- a/internal/rooms/roommanager.go
+++ b/internal/rooms/roommanager.go
@@ -181,6 +181,21 @@ func GetAllZoneNames() []string {
 	return zoneNames
 }
 
+func GetAllZoneRoomsIds(zoneName string) []int {
+
+	if zoneInfo, ok := roomManager.zones[zoneName]; ok {
+		result := make([]int, len(zoneInfo.RoomIds))
+		idx := 0
+		for roomId, _ := range zoneInfo.RoomIds {
+			result[idx] = roomId
+			idx++
+		}
+		return result
+	}
+
+	return []int{}
+}
+
 func MoveToRoom(userId int, toRoomId int, isSpawn ...bool) error {
 
 	user := users.GetByUserId(userId)

--- a/internal/scripting/room_func.go
+++ b/internal/scripting/room_func.go
@@ -340,10 +340,10 @@ func GetMap(mapRoomId int, zoomLevel int, mapHeight int, mapWidth int, mapName s
 		return ""
 	}
 
-	zMapper := mapper.GetZoneMapper(room.Zone)
-	if zMapper == nil {
-		mudlog.Error("Map", "error", "Could not find mapper for zone:"+room.Zone)
-		return "Could not find mapper for zone:" + room.Zone
+	rMapper := mapper.GetMapper(room.RoomId)
+	if rMapper == nil {
+		mudlog.Error("Map", "error", "Could not find mapper for roomId:"+strconv.Itoa(room.RoomId))
+		return "Could not find mapper for roomId:" + strconv.Itoa(room.RoomId)
 	}
 
 	c := mapper.Config{
@@ -371,7 +371,7 @@ func GetMap(mapRoomId int, zoomLevel int, mapHeight int, mapWidth int, mapName s
 		}
 	}
 
-	mapOutput := zMapper.GetLimitedMap(mapRoomId, c)
+	mapOutput := rMapper.GetLimitedMap(mapRoomId, c)
 
 	legend := mapOutput.GetLegend(keywords.GetAllLegendAliases(room.Zone))
 

--- a/internal/usercommands/admin.build.go
+++ b/internal/usercommands/admin.build.go
@@ -67,15 +67,15 @@ func Build(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 			var destinationRoom *rooms.Room = nil
 			// If it's a compass direction, reject it if a room already exists in that direction
 
-			zMapper := mapper.GetZoneMapper(room.Zone)
-			if zMapper == nil {
-				err := fmt.Errorf("Could not find mapper for zone: %s", room.Zone)
+			rMapper := mapper.GetMapper(room.RoomId)
+			if rMapper == nil {
+				err := fmt.Errorf("Could not find mapper for roomId: %d", room.RoomId)
 				mudlog.Error("Map", "error", err)
 				user.SendText(`No map found (or an error occured)"`)
 				return true, err
 			}
 
-			if gotoRoomId, _ := zMapper.FindAdjacentRoom(user.Character.RoomId, exitName, 1); gotoRoomId == 0 {
+			if gotoRoomId, _ := rMapper.FindAdjacentRoom(user.Character.RoomId, exitName, 1); gotoRoomId == 0 {
 
 				if newRoom, err := rooms.BuildRoom(user.Character.RoomId, exitName, mapDirection); err != nil {
 					user.SendText(err.Error())

--- a/internal/usercommands/admin.teleport.go
+++ b/internal/usercommands/admin.teleport.go
@@ -43,7 +43,7 @@ func Teleport(rest string, user *users.UserRecord, room *rooms.Room, flags event
 				return true, nil
 			}
 
-			zMapper := mapper.GetZoneMapper(room.Zone)
+			zMapper := mapper.GetMapper(room.RoomId)
 			if zMapper == nil {
 				err := fmt.Errorf("Could not find mapper for zone: %s", room.Zone)
 				mudlog.Error("Map", "error", err)

--- a/internal/usercommands/look.go
+++ b/internal/usercommands/look.go
@@ -465,7 +465,7 @@ func lookRoom(user *users.UserRecord, roomId int, secretLook bool) {
 
 	if tinyMapOn.(bool) && roomId > 0 {
 
-		zMapper := mapper.GetZoneMapper(room.Zone)
+		zMapper := mapper.GetMapper(room.RoomId)
 		if zMapper == nil {
 
 			mudlog.Error("Map", "error", "Could not find mapper for zone:"+room.Zone)

--- a/internal/usercommands/skill.map.go
+++ b/internal/usercommands/skill.map.go
@@ -110,7 +110,7 @@ func Map(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 
 	}
 
-	zMapper := mapper.GetZoneMapper(zone)
+	zMapper := mapper.GetMapper(roomId)
 	if zMapper == nil {
 		mudlog.Error("Map", "error", "Could not find mapper for zone:"+zone)
 		user.SendText(`No map found (or an error occured)"`)

--- a/modules/gmcp/gmcp.Room.go
+++ b/modules/gmcp/gmcp.Room.go
@@ -357,7 +357,7 @@ func (g *GMCPRoomModule) GetRoomNode(user *users.UserRecord, gmcpModule string) 
 
 		// Coordinates
 		payload.Coordinates = room.Zone
-		m := mapper.GetZoneMapper(room.Zone)
+		m := mapper.GetMapper(room.RoomId)
 		x, y, z, err := m.GetCoordinates(room.RoomId)
 		if err != nil {
 			payload.Coordinates += `, 999999999999999999, 999999999999999999, 999999999999999999`


### PR DESCRIPTION
# Description

The mapper generates a map of rooms in a zone, starting from the Root Room ID.

However, if the zone contains other rooms that are disconnect from the main group of rooms, or are reached via an unconventional exit (doesn't have a coordinate direction it exits to), they are being left out.

While still disconnected, this change allows those areas to have their own sub-maps that are accessed based on roomId now instead of a blanket zone name.


## Changes

- mapper now has a separate cache that maps roomId's to their "zone cache"
- Simplified the pre-cache logic
- Renamed `GetZoneMapper()` => `GetMapper()`