### PR TITLE
Removing makefile `ungenerate` reference, adding start up timer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,7 @@ clean:
 
 .PHONY: run 
 run: generate  ### Build and run server.
-	go build -o tmp-gomud.exe
-	make ungenerate
-	./tmp-gomud.exe
+	@go run .
 
 .PHONY: run-docker
 run-docker: ### Build and run server in docker.

--- a/main.go
+++ b/main.go
@@ -75,6 +75,8 @@ var (
 
 func main() {
 
+	serverStartTime := time.Now()
+
 	// Capture panic and write msg/stack to logs
 	defer func() {
 		if r := recover(); r != nil {
@@ -243,8 +245,8 @@ func main() {
 
 	go worldManager.InputWorker(workerShutdownChan, &wg)
 	go worldManager.MainWorker(workerShutdownChan, &wg)
-	//go worldManager.MaintenanceWorker(workerShutdownChan, &wg)
-	//go worldManager.GameTickWorker(workerShutdownChan, &wg)
+
+	mudlog.Info("Server Ready", "Time Taken", time.Since(serverStartTime))
 
 	// block until a signal comes in
 	<-sigChan


### PR DESCRIPTION
# Description

A couple small changes around start up and running the mud.

## Changes

Provide a bullet point list of noteworthy changes in this Pull Request:

- Removing a missed reference to `ungenerate` left in accidentally.
- No longer building binary with `make run`
- Adding a time when starting mud that logs how long start up took.
