### PR TITLE
Room instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _datafiles/**/users/*
 _datafiles/**/plugin-data/*
 **/config-overrides.yaml
 **/.roundcount
+**/rooms.instances
 vendor/
 server.crt
 server.key

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ clean:
 	$(DOCKER_COMPOSE) down --volumes --remove-orphans
 	docker system prune -a
 
+.PHONY: clean-instances
+clean-instances: ### Deletes all room instance data. Starts the world fresh.
+	rm -Rf _datafiles/world/default/rooms.instances
+	rm -Rf _datafiles/world/empty/rooms.instances
+
 ## Run Targets
 
 .PHONY: run 

--- a/_datafiles/world/default/rooms/catacombs/89.yaml
+++ b/_datafiles/world/default/rooms/catacombs/89.yaml
@@ -14,9 +14,6 @@ exits:
     roomid: 81
   north:
     roomid: 88
-items:
-- itemid: 10002
-gold: 6
 spawninfo:
 - mobid: 15
   message: The bones in the room stir, and a skeleton rises from the dirt.

--- a/_datafiles/world/default/rooms/dark_forest/878.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/878.yaml
@@ -18,9 +18,6 @@ containers:
   ornate chest:
     lock:
       difficulty: 8
-    items:
-    - itemid: 25
-    gold: 1
 exits:
   out:
     roomid: 877

--- a/_datafiles/world/default/rooms/endless_trashheap/142.yaml
+++ b/_datafiles/world/default/rooms/endless_trashheap/142.yaml
@@ -16,13 +16,6 @@ exits:
     roomid: 143
   west:
     roomid: 141
-items:
-- itemid: 20001
-- itemid: 20001
-- itemid: 20001
-- itemid: 20011
-- itemid: 20011
-- itemid: 20011
 idlemessages:
 - the mountain of trash shifts slightly.
 - the trash heal trembles, threatening to collapse at any moment.

--- a/_datafiles/world/default/rooms/endless_trashheap/152.yaml
+++ b/_datafiles/world/default/rooms/endless_trashheap/152.yaml
@@ -16,8 +16,6 @@ exits:
     roomid: 153
   south:
     roomid: 151
-items:
-- itemid: 5
 idlemessages:
 - the mountain of trash shifts slightly.
 - the trash heal trembles, threatening to collapse at any moment.

--- a/_datafiles/world/default/rooms/frost_lake/828.yaml
+++ b/_datafiles/world/default/rooms/frost_lake/828.yaml
@@ -13,8 +13,6 @@ maplegend: Rocks
 exits:
   southeast:
     roomid: 319
-items:
-- itemid: 10016
 idlemessages:
 - A gust of wind sends a chill throgh the air.
 - A large wave crashes against the shore.

--- a/_datafiles/world/default/rooms/frostfang/21.yaml
+++ b/_datafiles/world/default/rooms/frostfang/21.yaml
@@ -18,8 +18,6 @@ exits:
     roomid: 22
   west:
     roomid: 20
-stash:
-- itemid: 10001
 spawninfo:
 - mobid: 1
   message: A rat scurries out from a dark hole and wiggles its whiskers.

--- a/_datafiles/world/default/rooms/frostfang/269.yaml
+++ b/_datafiles/world/default/rooms/frostfang/269.yaml
@@ -13,8 +13,6 @@ biome: house
 exits:
   south:
     roomid: 259
-items:
-- itemid: 26
 spawninfo:
 - mobid: 26
   levelmod: 10

--- a/_datafiles/world/default/rooms/frostfang/433.yaml
+++ b/_datafiles/world/default/rooms/frostfang/433.yaml
@@ -15,8 +15,6 @@ exits:
     roomid: 111
   west:
     roomid: 166
-items:
-- itemid: 5
 spawninfo:
 - itemid: 5
   respawnrate: 1 real day

--- a/_datafiles/world/default/rooms/frostfang/6.yaml
+++ b/_datafiles/world/default/rooms/frostfang/6.yaml
@@ -13,7 +13,6 @@ exits:
     roomid: 36
   south:
     roomid: 5
-gold: 124
 spawninfo:
 - mobid: 2
   message: A town guard emerges from a nearby building.

--- a/_datafiles/world/default/rooms/frostfang/784.yaml
+++ b/_datafiles/world/default/rooms/frostfang/784.yaml
@@ -14,10 +14,6 @@ containers:
   chest:
     lock:
       difficulty: 3
-    items:
-    - itemid: 30002
-      uses: 1
-    gold: 75
 exits:
   south:
     roomid: 778

--- a/_datafiles/world/default/rooms/frostfang_slums/436.yaml
+++ b/_datafiles/world/default/rooms/frostfang_slums/436.yaml
@@ -15,8 +15,6 @@ exits:
     roomid: 435
   west:
     roomid: 437
-items:
-- itemid: 20011
 spawninfo:
 - mobid: 12
   message: A massive rat saunters out from the shadows.

--- a/_datafiles/world/default/rooms/frostfang_slums/462.yaml
+++ b/_datafiles/world/default/rooms/frostfang_slums/462.yaml
@@ -19,8 +19,6 @@ exits:
     roomid: 464
   west:
     roomid: 447
-items:
-- itemid: 20011
 spawninfo:
 - mobid: 12
   message: A massive rat saunters out from the shadows.

--- a/_datafiles/world/default/rooms/frostfang_slums/474.yaml
+++ b/_datafiles/world/default/rooms/frostfang_slums/474.yaml
@@ -15,8 +15,6 @@ exits:
     roomid: 473
   west:
     roomid: 475
-items:
-- itemid: 20010
 gold: 10
 spawninfo:
 - mobid: 28

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -348,6 +348,18 @@ type Party struct {
 
 func (p Party) Type() string { return `Party` }
 
+// Rebuilds mapper for a given RoomId
+// NOTE: RoomId should USUALLY be the Room's Zone.RootRoomId
+type RebuildMap struct {
+	MapRootRoomId int
+	SkipIfExists  bool
+}
+
+func (r RebuildMap) Type() string { return `RebuildMap` }
+func (r RebuildMap) UniqueID() string {
+	return `RebuildMap-` + strconv.Itoa(r.MapRootRoomId) + `-` + strconv.FormatBool(r.SkipIfExists)
+}
+
 type RedrawPrompt struct {
 	UserId        int
 	OnlyIfChanged bool

--- a/internal/hooks/RebuildMap_HandleMapRebuild.go
+++ b/internal/hooks/RebuildMap_HandleMapRebuild.go
@@ -1,0 +1,16 @@
+package hooks
+
+import (
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/mapper"
+)
+
+// Handles force rebuilding maps via event
+func HandleMapRebuild(e events.Event) events.ListenerReturn {
+
+	evt := e.(events.RebuildMap)
+
+	mapper.GetMapper(evt.MapRootRoomId, !evt.SkipIfExists)
+
+	return events.Continue
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -75,6 +75,8 @@ func RegisterListeners() {
 
 	events.RegisterListener(events.Broadcast{}, Broadcast_SendToAll)
 
+	events.RegisterListener(events.RebuildMap{}, HandleMapRebuild)
+
 	// Log tee to users
 	events.RegisterListener(events.Log{}, FollowLogs)
 

--- a/internal/mutators/mutators.go
+++ b/internal/mutators/mutators.go
@@ -38,9 +38,37 @@ func (tb TextBehavior) IsValid() bool {
 type MutatorList []Mutator
 
 type Mutator struct {
-	MutatorId      string // Short text that will uniquely identify this modifier ("dusty")
-	SpawnedRound   uint64 `yaml:"-"` // Tracks when this mutator was created (useful for decay)
-	DespawnedRound uint64 `yaml:"-"` // Track when it decayed to nothing.
+	MutatorId      string `yaml:"mutatorid,omitempty"`      // Short text that will uniquely identify this modifier ("dusty")
+	SpawnedRound   uint64 `yaml:"spawnedround,omitempty"`   // Tracks when this mutator was created (useful for decay)
+	DespawnedRound uint64 `yaml:"despawnedround,omitempty"` // Track when it decayed to nothing.
+}
+
+// This is a special function used for when room instance data is saved
+// It handles checking for special equality cases that the normal reflect.DeepEqual() doesn't handle the way we want.
+func (m MutatorList) SkipInstanceSave(other any) bool {
+	return false
+	m2, ok := other.(MutatorList)
+	if !ok {
+		return false
+	}
+
+	if len(m) != len(m2) { // length different?
+		return false
+	}
+
+	for i, _ := range m {
+
+		if m[i].MutatorId != m2[i].MutatorId {
+			return false
+		}
+
+		if m[i].Removable() != m2[i].Removable() {
+			return false
+		}
+
+	}
+
+	return true
 }
 
 type TextModifier struct {

--- a/internal/rooms/roommanager.go
+++ b/internal/rooms/roommanager.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -15,32 +14,28 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/configs"
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/exit"
-	"github.com/GoMudEngine/GoMud/internal/fileloader"
 	"github.com/GoMudEngine/GoMud/internal/mobs"
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/GoMud/internal/users"
 	"github.com/GoMudEngine/GoMud/internal/util"
-	"gopkg.in/yaml.v2"
 )
 
 var (
 	roomManager = &RoomManager{
-		rooms:                make(map[int]*Room),
-		zones:                make(map[string]ZoneInfo),
-		roomsWithUsers:       make(map[int]int),
-		roomsWithMobs:        make(map[int]int),
-		roomDescriptionCache: make(map[string]string),
-		roomIdToFileCache:    make(map[int]string),
+		rooms:             make(map[int]*Room),
+		zones:             make(map[string]ZoneInfo),
+		roomsWithUsers:    make(map[int]int),
+		roomsWithMobs:     make(map[int]int),
+		roomIdToFileCache: make(map[int]string),
 	}
 )
 
 type RoomManager struct {
-	rooms                map[int]*Room
-	zones                map[string]ZoneInfo // a map of zone name to room id
-	roomsWithUsers       map[int]int         // key is roomId to # players
-	roomsWithMobs        map[int]int         // key is roomId to # mobs
-	roomDescriptionCache map[string]string   // key is a hash, value is the description
-	roomIdToFileCache    map[int]string      // key is room id, value is the file path
+	rooms             map[int]*Room
+	zones             map[string]ZoneInfo // a map of zone name to room id
+	roomsWithUsers    map[int]int         // key is roomId to # players
+	roomsWithMobs     map[int]int         // key is roomId to # mobs
+	roomIdToFileCache map[int]string      // key is room id, value is the file path
 }
 
 const (
@@ -426,119 +421,6 @@ func GetRoomsWithMobs() []int {
 	return roomsWithMobs
 }
 
-func SaveAllRooms() error {
-
-	// Unhash the descriptions before saving
-	for _, loadedRoom := range roomManager.rooms {
-
-		if strings.HasPrefix(loadedRoom.Description, `h:`) {
-			hash := strings.TrimPrefix(loadedRoom.Description, `h:`)
-			if description, ok := roomManager.roomDescriptionCache[hash]; ok {
-				loadedRoom.Description = description
-			}
-		}
-	}
-
-	start := time.Now()
-
-	saveModes := []fileloader.SaveOption{}
-
-	if configs.GetFilePathsConfig().CarefulSaveFiles {
-		saveModes = append(saveModes, fileloader.SaveCareful)
-	}
-
-	saveCt, err := fileloader.SaveAllFlatFiles[int, *Room](configs.GetFilePathsConfig().DataFiles.String()+`/rooms`, roomManager.rooms, saveModes...)
-
-	mudlog.Info("SaveAllRooms()", "savedCount", saveCt, "expectedCt", len(roomManager.rooms), "Time Taken", time.Since(start))
-
-	return err
-}
-
-// Goes through all of the rooms and caches key information
-func loadAllRoomZones() error {
-	start := time.Now()
-
-	nextRoomId := GetNextRoomId()
-	defer func() {
-		if nextRoomId != GetNextRoomId() {
-			SetNextRoomId(nextRoomId)
-		}
-	}()
-
-	loadedRooms, err := fileloader.LoadAllFlatFiles[int, *Room](configs.GetFilePathsConfig().DataFiles.String() + `/rooms`)
-	if err != nil {
-		return err
-	}
-
-	roomsWithoutEntrances := map[int]string{}
-
-	for _, loadedRoom := range loadedRooms {
-
-		// configs.GetConfig().DeathRecoveryRoom is the death/shadow realm and gets a pass
-		if loadedRoom.RoomId == int(configs.GetSpecialRoomsConfig().DeathRecoveryRoom) {
-			continue
-		}
-
-		// If it has never been set, set it to the filepath
-		if _, ok := roomsWithoutEntrances[loadedRoom.RoomId]; !ok {
-			roomsWithoutEntrances[loadedRoom.RoomId] = loadedRoom.Filepath()
-		}
-
-		for _, exit := range loadedRoom.Exits {
-			roomsWithoutEntrances[exit.RoomId] = ``
-		}
-
-	}
-
-	for roomId, filePath := range roomsWithoutEntrances {
-
-		if filePath == `` {
-			delete(roomsWithoutEntrances, roomId)
-			continue
-		}
-
-		mudlog.Warn("No Entrance", "roomId", roomId, "filePath", filePath)
-	}
-
-	for _, loadedRoom := range loadedRooms {
-		// Keep track of the highest roomId
-
-		if loadedRoom.RoomId >= nextRoomId {
-			nextRoomId = loadedRoom.RoomId + 1
-		}
-
-		// Cache the file path for every roomId
-		roomManager.roomIdToFileCache[loadedRoom.RoomId] = loadedRoom.Filepath()
-
-		// Update the zone info cache
-		if _, ok := roomManager.zones[loadedRoom.Zone]; !ok {
-			roomManager.zones[loadedRoom.Zone] = ZoneInfo{
-				RootRoomId: 0,
-				RoomIds:    make(map[int]struct{}),
-			}
-		}
-
-		// Update the zone info
-		zoneInfo := roomManager.zones[loadedRoom.Zone]
-		zoneInfo.RoomIds[loadedRoom.RoomId] = struct{}{}
-
-		if loadedRoom.ZoneConfig.RoomId == loadedRoom.RoomId {
-			zoneInfo.RootRoomId = loadedRoom.RoomId
-			zoneInfo.DefaultBiome = loadedRoom.Biome
-
-			if len(loadedRoom.ZoneConfig.Mutators) > 0 {
-				zoneInfo.HasZoneMutators = true
-			}
-		}
-
-		roomManager.zones[loadedRoom.Zone] = zoneInfo
-	}
-
-	mudlog.Info("rooms.loadAllRoomZones()", "loadedCount", len(loadedRooms), "Time Taken", time.Since(start))
-
-	return nil
-}
-
 // Saves a room to disk and unloads it from memory
 func removeRoomFromMemory(r *Room) {
 
@@ -568,14 +450,8 @@ func removeRoomFromMemory(r *Room) {
 		}
 	}
 
-	//beforeCt := len(roomManager.rooms)
-
 	SaveRoom(*room)
 	delete(roomManager.rooms, r.RoomId)
-
-	//afterCt := len(roomManager.rooms)
-
-	//mudlog.Info("Removing from memory", "RoomId", r.RoomId, "Title", r.Title, "beforeCt", beforeCt, "afterCt", afterCt)
 }
 
 // Loads a room from disk and stores in memory
@@ -590,14 +466,6 @@ func addRoomToMemory(r *Room) {
 	if _, ok := roomManager.roomIdToFileCache[r.RoomId]; !ok {
 		roomManager.roomIdToFileCache[r.RoomId] = r.Filepath()
 	}
-
-	// Hash the descriptions and store centrally.
-	// This saves a lot of memory because many descriptions are duplicates
-	hash := util.Hash(r.Description)
-	if _, ok := roomManager.roomDescriptionCache[hash]; !ok {
-		roomManager.roomDescriptionCache[hash] = r.Description
-	}
-	r.Description = fmt.Sprintf(`h:%s`, hash)
 
 	// Track whatever the last room id created is so we know what to number the next one.
 	if r.RoomId >= GetNextRoomId() {
@@ -621,46 +489,6 @@ func addRoomToMemory(r *Room) {
 
 	roomManager.zones[r.Zone] = zoneInfo
 
-}
-
-func findRoomFile(roomId int) string {
-
-	foundFilePath := ``
-	searchFileName := filepath.FromSlash(fmt.Sprintf(`/%d.yaml`, roomId))
-
-	walkPath := filepath.FromSlash(configs.GetFilePathsConfig().DataFiles.String() + `/rooms`)
-
-	filepath.Walk(walkPath, func(path string, info os.FileInfo, err error) error {
-
-		if err != nil {
-			return err
-		}
-
-		if strings.HasSuffix(path, searchFileName) {
-			foundFilePath = path
-			return errors.New(`found`)
-		}
-
-		return nil
-	})
-
-	return strings.TrimPrefix(foundFilePath, walkPath)
-}
-
-func loadRoomFromFile(roomFilePath string) (*Room, error) {
-
-	roomFilePath = util.FilePath(roomFilePath)
-
-	roomPtr, err := fileloader.LoadFlatFile[*Room](roomFilePath)
-	if err != nil {
-		mudlog.Error("loadRoomFromFile()", "error", err.Error())
-		return roomPtr, err
-	}
-
-	// Automatically set the last visitor to now (reset the timer)
-	roomPtr.lastVisited = util.GetRoundCount()
-
-	return roomPtr, err
 }
 
 func GetZoneRoot(zone string) (int, error) {
@@ -688,62 +516,6 @@ func IsRoomLoaded(roomId int) bool {
 
 	_, ok := roomManager.rooms[roomId]
 	return ok
-}
-
-// Load room grabs the room from memory and returns a pointer to it.
-// If the room hasn't been loaded yet, it loads it into memory
-func LoadRoom(roomId int) *Room {
-
-	// Room 0 aliases to start room
-	if roomId == StartRoomIdAlias {
-		if roomId = int(configs.GetSpecialRoomsConfig().StartRoom); roomId == 0 {
-			roomId = 1
-		}
-	}
-
-	room, ok := roomManager.rooms[roomId]
-
-	if ok {
-		return room
-	}
-
-	filename := findRoomFile(roomId)
-	if len(filename) == 0 {
-		return nil
-	}
-
-	retRoom, _ := loadRoomFromFile(util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms`, `/`, filename))
-
-	addRoomToMemory(retRoom)
-
-	return retRoom
-}
-
-func SaveRoom(r Room) error {
-
-	if strings.HasPrefix(r.Description, `h:`) {
-		hash := strings.TrimPrefix(r.Description, `h:`)
-		if description, ok := roomManager.roomDescriptionCache[hash]; ok {
-			r.Description = description
-		}
-	}
-
-	data, err := yaml.Marshal(&r)
-	if err != nil {
-		return err
-	}
-
-	zone := ZoneToFolder(r.Zone)
-
-	roomFilePath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms`, `/`, fmt.Sprintf("%s%d.yaml", zone, r.RoomId))
-
-	if err = os.WriteFile(roomFilePath, data, 0777); err != nil {
-		return err
-	}
-
-	//mudlog.Info("Saved room", "room", r.RoomId)
-
-	return nil
 }
 
 func ZoneStats(zone string) (rootRoomId int, totalRooms int, err error) {
@@ -809,18 +581,19 @@ func GetZoneBiome(zone string) string {
 
 func MoveToZone(roomId int, newZoneName string) error {
 
-	room, ok := roomManager.rooms[roomId]
+	tplRoom := LoadRoomTemplate(roomId)
 
-	if !ok {
+	if tplRoom == nil {
 		return errors.New("room doesn't exist")
 	}
 
-	oldZoneName := room.Zone
+	oldZoneName := tplRoom.Zone
 	oldZoneInfo, ok := roomManager.zones[oldZoneName]
 	if !ok {
 		return errors.New("old zone doesn't exist")
 	}
-	oldFilePath := fmt.Sprintf("%s/rooms/%s", configs.GetFilePathsConfig().DataFiles.String(), room.Filepath())
+	oldFilePath := fmt.Sprintf("%s/rooms/%s", configs.GetFilePathsConfig().DataFiles.String(), tplRoom.Filepath())
+	oldInstanceFilePath := fmt.Sprintf("%s/rooms.instances/%s", configs.GetFilePathsConfig().DataFiles.String(), tplRoom.Filepath())
 
 	newZoneInfo, ok := roomManager.zones[newZoneName]
 	if !ok {
@@ -831,12 +604,15 @@ func MoveToZone(roomId int, newZoneName string) error {
 		return errors.New("can't move the root room of a zone")
 	}
 
-	room.Zone = newZoneName
-	newFilePath := fmt.Sprintf("%s/rooms/%s", configs.GetFilePathsConfig().DataFiles.String(), room.Filepath())
+	tplRoom.Zone = newZoneName
+	newFilePath := fmt.Sprintf("%s/rooms/%s", configs.GetFilePathsConfig().DataFiles.String(), tplRoom.Filepath())
+	newInstanceFilePath := fmt.Sprintf("%s/rooms.instances/%s", configs.GetFilePathsConfig().DataFiles.String(), tplRoom.Filepath())
 
 	if err := os.Rename(oldFilePath, newFilePath); err != nil {
 		return err
 	}
+
+	os.Rename(oldInstanceFilePath, newInstanceFilePath)
 
 	delete(oldZoneInfo.RoomIds, roomId)
 	roomManager.zones[oldZoneName] = oldZoneInfo
@@ -844,7 +620,7 @@ func MoveToZone(roomId int, newZoneName string) error {
 	newZoneInfo.RoomIds[roomId] = struct{}{}
 	roomManager.zones[newZoneName] = newZoneInfo
 
-	SaveRoom(*room)
+	SaveRoomTemplate(*tplRoom)
 
 	return nil
 }
@@ -869,6 +645,11 @@ func CreateZone(zoneName string) (roomId int, err error) {
 		return 0, err
 	}
 
+	instanceZoneFolder := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), "/", "rooms.instances", "/", ZoneToFolder(zoneName))
+	if err := os.Mkdir(instanceZoneFolder, 0755); err != nil {
+		return 0, err
+	}
+
 	newRoom := NewRoom(zoneName)
 
 	newRoom.ZoneConfig = ZoneConfig{RoomId: newRoom.RoomId}
@@ -877,10 +658,10 @@ func CreateZone(zoneName string) (roomId int, err error) {
 		return 0, err
 	}
 
-	addRoomToMemory(newRoom)
-
 	// save to the flat file
-	SaveRoom(*newRoom)
+	SaveRoomTemplate(*newRoom)
+
+	addRoomToMemory(newRoom)
 
 	// write room to the folder under the new ID
 	return newRoom.RoomId, nil
@@ -909,16 +690,7 @@ func BuildRoom(fromRoomId int, exitName string, mapDirection ...string) (room *R
 	}
 
 	newRoom.Title = fromRoom.Title
-
-	if strings.HasPrefix(fromRoom.Description, `h:`) {
-		hash := strings.TrimPrefix(fromRoom.Description, `h:`)
-		if description, ok := roomManager.roomDescriptionCache[hash]; ok {
-			newRoom.Description = description
-		}
-	} else {
-		newRoom.Description = fromRoom.Description
-	}
-
+	newRoom.Description = fromRoom.Description
 	newRoom.MapSymbol = fromRoom.MapSymbol
 	newRoom.MapLegend = fromRoom.MapLegend
 	newRoom.Biome = fromRoom.Biome
@@ -936,13 +708,10 @@ func BuildRoom(fromRoomId int, exitName string, mapDirection ...string) (room *R
 	}
 	fromRoom.Exits[exitName] = newExit
 
-	//if _, ok := roomManager.rooms[newRoom.RoomId]; !ok {
-	//	roomManager.rooms[newRoom.RoomId] = newRoom
-	//}
 	addRoomToMemory(newRoom)
 
 	SaveRoom(*fromRoom)
-	SaveRoom(*newRoom)
+	SaveRoomTemplate(*newRoom)
 
 	return newRoom, nil
 }

--- a/internal/rooms/roommanager.go
+++ b/internal/rooms/roommanager.go
@@ -769,9 +769,13 @@ func BuildRoom(fromRoomId int, exitName string, mapDirection ...string) (room *R
 		return nil, fmt.Errorf(`room %d not found`, fromRoomId)
 	}
 
+	if _, ok := fromRoom.Exits[exitName]; ok {
+		return nil, fmt.Errorf(`this room already has a %s exit`, exitName)
+	}
+
 	newRoom := NewRoom(fromRoom.Zone)
-	if newRoom != nil {
-		newRoom.Validate()
+	if err := newRoom.Validate(); err != nil {
+		return nil, fmt.Errorf("BuildRoom(%d, %s, %s): %w", fromRoomId, exitName, exitMapDirection, err)
 	}
 
 	newRoom.Title = fromRoom.Title
@@ -793,8 +797,11 @@ func BuildRoom(fromRoomId int, exitName string, mapDirection ...string) (room *R
 	}
 	fromRoom.Exits[exitName] = newExit
 
+	// Add the new room to memory.
 	addRoomToMemory(newRoom)
-	roomManager.rooms[fromRoom.RoomId] = fromRoom
+
+	// Update the memory for the source room
+	addRoomToMemory(fromRoom, true)
 
 	SaveRoomTemplate(*fromRoom)
 	SaveRoomTemplate(*newRoom)

--- a/internal/rooms/roommanager.go
+++ b/internal/rooms/roommanager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -30,6 +31,10 @@ var (
 	}
 )
 
+const (
+	StartRoomIdAlias = 0
+)
+
 type RoomManager struct {
 	rooms             map[int]*Room
 	zones             map[string]ZoneInfo // a map of zone name to room id
@@ -38,9 +43,74 @@ type RoomManager struct {
 	roomIdToFileCache map[int]string      // key is room id, value is the file path
 }
 
-const (
-	StartRoomIdAlias = 0
-)
+// Deletes any knowledge of a room in memory.
+// Loading this room after the fact will trigger full re-loading and caching of room data.
+func ClearRoomCache(roomId int) error {
+
+	room := roomManager.rooms[roomId]
+	if room == nil {
+		return fmt.Errorf(`room %d not found in cache`, roomId)
+	}
+
+	if zoneData, ok := roomManager.zones[room.Zone]; ok {
+
+		if zoneData.RootRoomId == roomId {
+			return fmt.Errorf(`room %d is the zone root`, roomId)
+		}
+
+		delete(zoneData.RoomIds, roomId)
+		roomManager.zones[room.Zone] = zoneData
+	}
+
+	delete(roomManager.rooms, roomId)
+	delete(roomManager.roomsWithUsers, roomId)
+	delete(roomManager.roomsWithMobs, roomId)
+	delete(roomManager.roomIdToFileCache, roomId)
+
+	return nil
+}
+
+func (r *RoomManager) GetFilePath(roomId int) string {
+
+	if cachedPath, ok := roomManager.roomIdToFileCache[roomId]; ok {
+		return cachedPath
+	}
+
+	filename := searchForRoomFile(roomId)
+
+	if filename == `` {
+		return filename
+	}
+
+	roomManager.roomIdToFileCache[roomId] = filename
+
+	return filename
+}
+
+// Find a file for a roomId and cache the file location.
+func searchForRoomFile(roomId int) string {
+
+	searchFileName := filepath.FromSlash(fmt.Sprintf(`/%d.yaml`, roomId))
+
+	walkPath := filepath.FromSlash(configs.GetFilePathsConfig().DataFiles.String() + `/rooms`)
+
+	foundFilePath := ``
+	filepath.Walk(walkPath, func(path string, info os.FileInfo, err error) error {
+
+		if err != nil {
+			return err
+		}
+
+		if strings.HasSuffix(path, searchFileName) {
+			foundFilePath = path
+			return errors.New(`found`)
+		}
+
+		return nil
+	})
+
+	return strings.TrimPrefix(foundFilePath, walkPath)
+}
 
 type ZoneInfo struct {
 	RootRoomId      int
@@ -450,45 +520,60 @@ func removeRoomFromMemory(r *Room) {
 		}
 	}
 
-	SaveRoom(*room)
+	SaveRoomInstance(*room)
 	delete(roomManager.rooms, r.RoomId)
 }
 
-// Loads a room from disk and stores in memory
-func addRoomToMemory(r *Room) {
+func getRoomFromMemory(roomId int) *Room {
+	return roomManager.rooms[roomId]
+}
 
-	if _, ok := roomManager.rooms[r.RoomId]; ok {
-		return
+// Loads a room from disk and stores in memory
+func addRoomToMemory(room *Room, forceOverWrite ...bool) error {
+
+	if len(forceOverWrite) > 0 && forceOverWrite[0] {
+		ClearRoomCache(room.RoomId)
 	}
 
-	roomManager.rooms[r.RoomId] = r
+	if _, ok := roomManager.rooms[room.RoomId]; ok {
+		return fmt.Errorf(`room %d is already stored in memory`, room.RoomId)
+	}
 
-	if _, ok := roomManager.roomIdToFileCache[r.RoomId]; !ok {
-		roomManager.roomIdToFileCache[r.RoomId] = r.Filepath()
+	// Automatically set the last visitor to now (reset the unload timer)
+	room.lastVisited = util.GetRoundCount()
+
+	// Save to room cache lookup
+	roomManager.rooms[room.RoomId] = room
+
+	// Save filepath to cache
+	if _, ok := roomManager.roomIdToFileCache[room.RoomId]; !ok {
+		roomManager.roomIdToFileCache[room.RoomId] = room.Filepath()
 	}
 
 	// Track whatever the last room id created is so we know what to number the next one.
-	if r.RoomId >= GetNextRoomId() {
-		SetNextRoomId(r.RoomId + 1)
+	if room.RoomId >= GetNextRoomId() {
+		SetNextRoomId(room.RoomId + 1)
 	}
 
-	if _, ok := roomManager.zones[r.Zone]; !ok {
-		roomManager.zones[r.Zone] = ZoneInfo{
+	//
+	zoneInfo, ok := roomManager.zones[room.Zone]
+	if !ok {
+		zoneInfo = ZoneInfo{
 			RootRoomId: 0,
 			RoomIds:    make(map[int]struct{}),
 		}
 	}
 
-	// Populate the zone info
-	zoneInfo := roomManager.zones[r.Zone]
-	zoneInfo.RoomIds[r.RoomId] = struct{}{}
+	// Populate the room present lookup in the zone info
+	zoneInfo.RoomIds[room.RoomId] = struct{}{}
 
-	if r.ZoneConfig.RoomId == r.RoomId {
-		zoneInfo.RootRoomId = r.RoomId
+	if room.ZoneConfig.RoomId == room.RoomId {
+		zoneInfo.RootRoomId = room.RoomId
 	}
 
-	roomManager.zones[r.Zone] = zoneInfo
+	roomManager.zones[room.Zone] = zoneInfo
 
+	return nil
 }
 
 func GetZoneRoot(zone string) (int, error) {
@@ -679,7 +764,7 @@ func BuildRoom(fromRoomId int, exitName string, mapDirection ...string) (room *R
 		exitMapDirection = mapDirection[0]
 	}
 
-	fromRoom := LoadRoom(fromRoomId)
+	fromRoom := LoadRoomTemplate(fromRoomId)
 	if fromRoom == nil {
 		return nil, fmt.Errorf(`room %d not found`, fromRoomId)
 	}
@@ -699,7 +784,7 @@ func BuildRoom(fromRoomId int, exitName string, mapDirection ...string) (room *R
 		//newRoom.IdleMessages = fromRoom.IdleMessages
 	}
 
-	mudlog.Info("Connection room", "fromRoom", fromRoom.RoomId, "newRoom", newRoom.RoomId, "exitName", exitName)
+	mudlog.Info("Connecting room", "fromRoom", fromRoom.RoomId, "newRoom", newRoom.RoomId, "exitName", exitName)
 
 	// connect the old room to the new room
 	newExit := exit.RoomExit{RoomId: newRoom.RoomId, Secret: false}
@@ -709,8 +794,9 @@ func BuildRoom(fromRoomId int, exitName string, mapDirection ...string) (room *R
 	fromRoom.Exits[exitName] = newExit
 
 	addRoomToMemory(newRoom)
+	roomManager.rooms[fromRoom.RoomId] = fromRoom
 
-	SaveRoom(*fromRoom)
+	SaveRoomTemplate(*fromRoom)
 	SaveRoomTemplate(*newRoom)
 
 	return newRoom, nil
@@ -729,12 +815,12 @@ func ConnectRoom(fromRoomId int, toRoomId int, exitName string, mapDirection ...
 		exitMapDirection = mapDirection[0]
 	}
 
-	fromRoom := LoadRoom(fromRoomId)
+	fromRoom := LoadRoomTemplate(fromRoomId)
 	if fromRoom == nil {
 		return fmt.Errorf(`room %d not found`, fromRoomId)
 	}
 
-	toRoom := LoadRoom(toRoomId)
+	toRoom := LoadRoomTemplate(toRoomId)
 	if toRoom == nil {
 		return fmt.Errorf(`room %d not found`, toRoomId)
 	}
@@ -746,7 +832,8 @@ func ConnectRoom(fromRoomId int, toRoomId int, exitName string, mapDirection ...
 	}
 	fromRoom.Exits[exitName] = newExit
 
-	SaveRoom(*fromRoom)
+	SaveRoomTemplate(*fromRoom)
+	roomManager.rooms[fromRoom.RoomId] = fromRoom
 
 	return nil
 }

--- a/internal/rooms/rooms.go
+++ b/internal/rooms/rooms.go
@@ -63,39 +63,39 @@ const (
 
 type Room struct {
 	//mutex
-	RoomId            int                               `yaml:"roomid"`                      // a unique numeric index of the room. Also the filename.
-	Zone              string                            `yaml:"zone"`                        // zone is a way to partition rooms into groups. Also into folders.
-	ZoneConfig        ZoneConfig                        `yaml:"zoneconfig,omitempty"`        // If non-null is a root room.
-	MusicFile         string                            `yaml:"musicfile,omitempty"`         // background music to play when in this room
-	IsBank            bool                              `yaml:"isbank,omitempty"`            // Is this a bank room? If so, players can deposit/withdraw gold here.
-	IsStorage         bool                              `yaml:"isstorage,omitempty"`         // Is this a storage room? If so, players can add/remove objects here.
-	IsCharacterRoom   bool                              `yaml:"ischaracterroom,omitempty"`   // Is this a room where characters can create new characters to swap between them?
-	Title             string                            `yaml:"title"`                       // Title shown to the user
-	Description       string                            `yaml:"description"`                 // Description shown to the user
-	MapSymbol         string                            `yaml:"mapsymbol,omitempty"`         // The symbol to use when generating a map of the zone
-	MapLegend         string                            `yaml:"maplegend,omitempty"`         // The text to display in the legend for this room. Should be one word.
-	Biome             string                            `yaml:"biome,omitempty"`             // The biome of the room. Used for weather generation.
-	Containers        map[string]Container              `yaml:"containers,omitempty"`        // If this room has a chest, what is in it?
-	Exits             map[string]exit.RoomExit          `yaml:"exits"`                       // Exits to other rooms
-	ExitsTemp         map[string]exit.TemporaryRoomExit `yaml:"-"`                           // Temporary exits that will be removed after a certain time. Don't bother saving on sever shutting down.
-	Nouns             map[string]string                 `yaml:"nouns,omitempty"`             // Interesting nouns to highlight in the room or reveal on succesful searches.
-	Items             []items.Item                      `yaml:"items,omitempty"`             // Items on the floor
-	Stash             []items.Item                      `yaml:"stash,omitempty"`             // list of items in the room that are not visible to players
-	Corpses           []Corpse                          `yaml:"-"`                           // Any corpses laying around from recent deaths
-	Gold              int                               `yaml:"gold,omitempty"`              // How much gold is on the ground?
-	SpawnInfo         []SpawnInfo                       `yaml:"spawninfo,omitempty"`         // key is creature ID, value is spawn chance
-	SkillTraining     map[string]TrainingRange          `yaml:"skilltraining,omitempty"`     // list of skills that can be trained in this room
-	Signs             []Sign                            `yaml:"sign,omitempty"`              // list of scribbles in the room
-	IdleMessages      []string                          `yaml:"idlemessages,omitempty"`      // list of messages that can be displayed to players in the room
-	LastIdleMessage   uint8                             `yaml:"-"`                           // index of the last idle message displayed
-	LongTermDataStore map[string]any                    `yaml:"longtermdatastore,omitempty"` // Long term data store for the room
-	Mutators          mutators.MutatorList              `yaml:"mutators,omitempty"`          // mutators this room spawns with.
-	Pvp               bool                              `yaml:"pvp,omitempty"`               // if config pvp is set to `limited`, uses this value
-	players           []int                             `yaml:"-"`                           // list of user IDs currently in the room
-	mobs              []int                             `yaml:"-"`                           // list of mob instance IDs currently in the room. Does not get saved.
-	visitors          map[VisitorType]map[int]uint64    `yaml:"-"`                           // list of user IDs that have visited this room, and the last round they did
-	lastVisited       uint64                            `yaml:"-"`                           // last round a visitor was in the room
-	tempDataStore     map[string]any                    `yaml:"-"`                           // Temporary data store for the room
+	RoomId            int                               `yaml:"roomid"`                                      // a unique numeric index of the room. Also the filename.
+	Zone              string                            `yaml:"zone"`                                        // zone is a way to partition rooms into groups. Also into folders.
+	ZoneConfig        ZoneConfig                        `yaml:"zoneconfig,omitempty"`                        // If non-null is a root room.
+	MusicFile         string                            `yaml:"musicfile,omitempty"`                         // background music to play when in this room
+	IsBank            bool                              `yaml:"isbank,omitempty"`                            // Is this a bank room? If so, players can deposit/withdraw gold here.
+	IsStorage         bool                              `yaml:"isstorage,omitempty"`                         // Is this a storage room? If so, players can add/remove objects here.
+	IsCharacterRoom   bool                              `yaml:"ischaracterroom,omitempty" instance:"true"`   // Is this a room where characters can create new characters to swap between them?
+	Title             string                            `yaml:"title" instance:"true"`                       // Title shown to the user
+	Description       string                            `yaml:"description" instance:"true"`                 // Description shown to the user
+	MapSymbol         string                            `yaml:"mapsymbol,omitempty"`                         // The symbol to use when generating a map of the zone
+	MapLegend         string                            `yaml:"maplegend,omitempty"`                         // The text to display in the legend for this room. Should be one word.
+	Biome             string                            `yaml:"biome,omitempty"`                             // The biome of the room. Used for weather generation.
+	Containers        map[string]Container              `yaml:"containers,omitempty"`                        // If this room has a chest, what is in it?
+	Exits             map[string]exit.RoomExit          `yaml:"exits"`                                       // Exits to other rooms
+	ExitsTemp         map[string]exit.TemporaryRoomExit `yaml:"-"`                                           // Temporary exits that will be removed after a certain time. Don't bother saving on sever shutting down.
+	Nouns             map[string]string                 `yaml:"nouns,omitempty"`                             // Interesting nouns to highlight in the room or reveal on succesful searches.
+	Items             []items.Item                      `yaml:"items,omitempty" instance:"true"`             // Items on the floor
+	Stash             []items.Item                      `yaml:"stash,omitempty" instance:"true"`             // list of items in the room that are not visible to players
+	Corpses           []Corpse                          `yaml:"-"`                                           // Any corpses laying around from recent deaths
+	Gold              int                               `yaml:"gold,omitempty" instance:"true"`              // How much gold is on the ground?
+	SpawnInfo         []SpawnInfo                       `yaml:"spawninfo,omitempty"`                         // key is creature ID, value is spawn chance
+	SkillTraining     map[string]TrainingRange          `yaml:"skilltraining,omitempty"`                     // list of skills that can be trained in this room
+	Signs             []Sign                            `yaml:"sign,omitempty" instance:"true"`              // list of scribbles in the room
+	IdleMessages      []string                          `yaml:"idlemessages,omitempty" `                     // list of messages that can be displayed to players in the room
+	LastIdleMessage   uint8                             `yaml:"-"`                                           // index of the last idle message displayed
+	LongTermDataStore map[string]any                    `yaml:"longtermdatastore,omitempty" instance:"true"` // Long term data store for the room
+	Mutators          mutators.MutatorList              `yaml:"mutators,omitempty"`                          // mutators this room spawns with.
+	Pvp               bool                              `yaml:"pvp,omitempty"`                               // if config pvp is set to `limited`, uses this value
+	players           []int                             `yaml:"-"`                                           // list of user IDs currently in the room
+	mobs              []int                             `yaml:"-"`                                           // list of mob instance IDs currently in the room. Does not get saved.
+	visitors          map[VisitorType]map[int]uint64    `yaml:"-"`                                           // list of user IDs that have visited this room, and the last round they did
+	lastVisited       uint64                            `yaml:"-"`                                           // last round a visitor was in the room
+	tempDataStore     map[string]any                    `yaml:"-"`                                           // Temporary data store for the room
 }
 
 type TrainingRange struct {

--- a/internal/rooms/rooms.go
+++ b/internal/rooms/rooms.go
@@ -63,39 +63,40 @@ const (
 
 type Room struct {
 	//mutex
-	RoomId            int                               `yaml:"roomid"`                                      // a unique numeric index of the room. Also the filename.
-	Zone              string                            `yaml:"zone"`                                        // zone is a way to partition rooms into groups. Also into folders.
-	ZoneConfig        ZoneConfig                        `yaml:"zoneconfig,omitempty"`                        // If non-null is a root room.
-	MusicFile         string                            `yaml:"musicfile,omitempty"`                         // background music to play when in this room
-	IsBank            bool                              `yaml:"isbank,omitempty"`                            // Is this a bank room? If so, players can deposit/withdraw gold here.
-	IsStorage         bool                              `yaml:"isstorage,omitempty"`                         // Is this a storage room? If so, players can add/remove objects here.
-	IsCharacterRoom   bool                              `yaml:"ischaracterroom,omitempty" instance:"true"`   // Is this a room where characters can create new characters to swap between them?
-	Title             string                            `yaml:"title" instance:"true"`                       // Title shown to the user
-	Description       string                            `yaml:"description" instance:"true"`                 // Description shown to the user
-	MapSymbol         string                            `yaml:"mapsymbol,omitempty"`                         // The symbol to use when generating a map of the zone
-	MapLegend         string                            `yaml:"maplegend,omitempty"`                         // The text to display in the legend for this room. Should be one word.
-	Biome             string                            `yaml:"biome,omitempty"`                             // The biome of the room. Used for weather generation.
-	Containers        map[string]Container              `yaml:"containers,omitempty"`                        // If this room has a chest, what is in it?
-	Exits             map[string]exit.RoomExit          `yaml:"exits"`                                       // Exits to other rooms
-	ExitsTemp         map[string]exit.TemporaryRoomExit `yaml:"-"`                                           // Temporary exits that will be removed after a certain time. Don't bother saving on sever shutting down.
-	Nouns             map[string]string                 `yaml:"nouns,omitempty"`                             // Interesting nouns to highlight in the room or reveal on succesful searches.
-	Items             []items.Item                      `yaml:"items,omitempty" instance:"true"`             // Items on the floor
-	Stash             []items.Item                      `yaml:"stash,omitempty" instance:"true"`             // list of items in the room that are not visible to players
-	Corpses           []Corpse                          `yaml:"-"`                                           // Any corpses laying around from recent deaths
-	Gold              int                               `yaml:"gold,omitempty" instance:"true"`              // How much gold is on the ground?
-	SpawnInfo         []SpawnInfo                       `yaml:"spawninfo,omitempty"`                         // key is creature ID, value is spawn chance
-	SkillTraining     map[string]TrainingRange          `yaml:"skilltraining,omitempty"`                     // list of skills that can be trained in this room
-	Signs             []Sign                            `yaml:"sign,omitempty" instance:"true"`              // list of scribbles in the room
-	IdleMessages      []string                          `yaml:"idlemessages,omitempty" `                     // list of messages that can be displayed to players in the room
-	LastIdleMessage   uint8                             `yaml:"-"`                                           // index of the last idle message displayed
-	LongTermDataStore map[string]any                    `yaml:"longtermdatastore,omitempty" instance:"true"` // Long term data store for the room
-	Mutators          mutators.MutatorList              `yaml:"mutators,omitempty"`                          // mutators this room spawns with.
-	Pvp               bool                              `yaml:"pvp,omitempty"`                               // if config pvp is set to `limited`, uses this value
-	players           []int                             `yaml:"-"`                                           // list of user IDs currently in the room
-	mobs              []int                             `yaml:"-"`                                           // list of mob instance IDs currently in the room. Does not get saved.
-	visitors          map[VisitorType]map[int]uint64    `yaml:"-"`                                           // list of user IDs that have visited this room, and the last round they did
-	lastVisited       uint64                            `yaml:"-"`                                           // last round a visitor was in the room
-	tempDataStore     map[string]any                    `yaml:"-"`                                           // Temporary data store for the room
+	RoomId            int                               `yaml:"roomid"`                               // a unique numeric index of the room. Also the filename.
+	Zone              string                            `yaml:"zone"`                                 // zone is a way to partition rooms into groups. Also into folders.
+	ZoneConfig        ZoneConfig                        `yaml:"zoneconfig,omitempty" instance:"skip"` // If non-null is a root room.
+	MusicFile         string                            `yaml:"musicfile,omitempty"`                  // background music to play when in this room
+	IsBank            bool                              `yaml:"isbank,omitempty"`                     // Is this a bank room? If so, players can deposit/withdraw gold here.
+	IsStorage         bool                              `yaml:"isstorage,omitempty"`                  // Is this a storage room? If so, players can add/remove objects here.
+	IsCharacterRoom   bool                              `yaml:"ischaracterroom,omitempty"`            // Is this a room where characters can create new characters to swap between them?
+	Title             string                            `yaml:"title"`                                // Title shown to the user
+	Description       string                            `yaml:"description"`                          // Description shown to the user
+	MapSymbol         string                            `yaml:"mapsymbol,omitempty"`                  // The symbol to use when generating a map of the zone
+	MapLegend         string                            `yaml:"maplegend,omitempty"`                  // The text to display in the legend for this room. Should be one word.
+	Biome             string                            `yaml:"biome,omitempty"`                      // The biome of the room. Used for weather generation.
+	Containers        map[string]Container              `yaml:"containers,omitempty"`                 // If this room has a chest, what is in it?
+	Exits             map[string]exit.RoomExit          `yaml:"exits"`                                // Exits to other rooms
+	ExitsTemp         map[string]exit.TemporaryRoomExit `yaml:"-"`                                    // Temporary exits that will be removed after a certain time. Don't bother saving on sever shutting down.
+	Nouns             map[string]string                 `yaml:"nouns,omitempty"`                      // Interesting nouns to highlight in the room or reveal on succesful searches.
+	Items             []items.Item                      `yaml:"items,omitempty"`                      // Items on the floor
+	Stash             []items.Item                      `yaml:"stash,omitempty"`                      // list of items in the room that are not visible to players
+	Corpses           []Corpse                          `yaml:"-"`                                    // Any corpses laying around from recent deaths
+	Gold              int                               `yaml:"gold,omitempty"`                       // How much gold is on the ground?
+	SpawnInfo         []SpawnInfo                       `yaml:"spawninfo,omitempty" instance:"skip"`  // key is creature ID, value is spawn chance
+	SkillTraining     map[string]TrainingRange          `yaml:"skilltraining,omitempty"`              // list of skills that can be trained in this room
+	Signs             []Sign                            `yaml:"sign,omitempty"`                       // list of scribbles in the room
+	IdleMessages      []string                          `yaml:"idlemessages,omitempty" `              // list of messages that can be displayed to players in the room
+	LastIdleMessage   uint8                             `yaml:"-"`                                    // index of the last idle message displayed
+	LongTermDataStore map[string]any                    `yaml:"longtermdatastore,omitempty"`          // Long term data store for the room
+	Mutators          mutators.MutatorList              `yaml:"mutators,omitempty"`                   // mutators this room spawns with.
+	Pvp               bool                              `yaml:"pvp,omitempty"`                        // if config pvp is set to `limited`, uses this value
+	// Unexported/private
+	players       []int                          // list of user IDs currently in the room
+	mobs          []int                          // list of mob instance IDs currently in the room. Does not get saved.
+	visitors      map[VisitorType]map[int]uint64 // list of user IDs that have visited this room, and the last round they did
+	lastVisited   uint64                         // last round a visitor was in the room
+	tempDataStore map[string]any                 // Temporary data store for the room
 }
 
 type TrainingRange struct {
@@ -1336,13 +1337,7 @@ func (r *Room) GetDescriptionFormatted(lineSplit int, highlightNouns bool) strin
 }
 
 func (r *Room) GetDescription() string {
-
-	if !strings.HasPrefix(r.Description, `h:`) {
-		return r.Description
-	}
-	hash := strings.TrimPrefix(r.Description, `h:`)
-
-	return roomManager.roomDescriptionCache[hash]
+	return r.Description
 }
 
 func (r *Room) HasRecentVisitors() bool {

--- a/internal/rooms/save_and_load.go
+++ b/internal/rooms/save_and_load.go
@@ -1,15 +1,14 @@
 package rooms
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/fileloader"
 	"github.com/GoMudEngine/GoMud/internal/items"
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
@@ -17,32 +16,64 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func LoadRoomTemplate(roomId int) *Room {
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// RULES FOR SAVING AND LOADING ROOMS
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// The following are rules for reading and writing room files.
+// This set of rules must be followed or behaviors will break.
+// DO NOT CHANGE CODE FOR THE PROCESS unless you understand the implications.
+//
+// NOTE: in-memory cache contains a RoomId => Room struct map. This Room struct is TEMPLATE data updated on load with INSTANCE data.
+// Once loaded into memory, the in-memory cache is the most recent source-of-truth for INSTANCE data.
+//
+// TEMPLATE data is stored in the /rooms/ folder
+// INSTANCE data is stored in the /rooms.instances/ folder (may only be created on running the MUD)
+//
+// INSTANCE data can be cleared out by deleting the /rooms.instances/ folder, or running the `make clean-instances` to do it.
+//
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// A. LOADING ROOMS BLINDLY                                                                                              AKA LoadRoom()
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// NOTE: This is the only way outside code should be loading rooms. The other functions are exported for very specialized purposes.
+//
+// 1. Look for in-memory Room cache record for RoomId. If found, return it.
+// 2. Do [B. LOADING ROOMS FROM FILES]
+// 3. Save result to in-memory Room cache.
+//
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// B. LOADING ROOMS FROM FILES                                                                                  AKA  LoadRoomInstance()
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  1. Load the TEMPLATE data into a Room struct.
+//  2. Load the INSTANCE data into the same struct - the result is only the field present in the INSTANCE data will overwrite the
+//     TEMPLATE data.
+//
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// C. SAVING ROOM TEMPLATES                                                                                      AKA SaveRoomTemplate()
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  1. Anytime a change is made to a TEMPLATE, first load the TEMPLATE ONLY, make any changes, then save the TEMPLATE ONLY.
+//  2. There may be data from the OLD in-memory Room struct that needs to be copied over to the new one. (items, users, mobs, etc).
+//     If so, do it.
+//  3. Update the in-memory Room struct for the RoomId to use the NEW TEMPLATE version.
+//  4. Rebuild maps for the Room's Zone.RoomId and then the room.RoomId, in that order. That ensures it's added to the zone map
+//     IF it should be, and if not, will generate its own map.
+//
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// D. SAVING ROOMS INSTANCES                                                                                     AKA SaveRoomInstance()
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  1. Load the TEMPLATE data into a variable
+//  2. Use reflection to iterate through the structure.
+//  3. If field isn't readable (unexported/lowercase) or has the struct tag `instance:"skip"`, skip writing it.
+//  4. If the field value matches the TEMPLATE version of the field, skip writing it.
+//  5. If the final result of the data to write is empty ( "{}\n" ), delete and do not write the new save file.
+//
+// ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	filename := ``
-
-	if cachedPath, ok := roomManager.roomIdToFileCache[roomId]; ok {
-		filename = cachedPath
-	} else {
-		filename = findRoomFile(roomId)
-	}
-
-	if len(filename) == 0 {
-		return nil
-	}
-
-	filepath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms`, `/`, filename)
-
-	retRoom, _ := loadRoomFromFile(filepath)
-
-	return retRoom
-}
-
-// Load room grabs the room from memory and returns a pointer to it.
-// If the room hasn't been loaded yet, it:
-// 1. loads it from the template file
-// 2. loads any instance data and overlays it
-// 3. adds it to memory
+// See: A. LOADING ROOMS BLINDLY
 func LoadRoom(roomId int) *Room {
 
 	// Room 0 aliases to start room
@@ -52,61 +83,102 @@ func LoadRoom(roomId int) *Room {
 		}
 	}
 
-	room, ok := roomManager.rooms[roomId]
-
-	if ok {
+	if room := getRoomFromMemory(roomId); room != nil {
 		return room
 	}
 
-	roomTpl := LoadRoomTemplate(roomId)
-
-	if roomTpl != nil {
-
-		filename := ``
-		if cachedPath, ok := roomManager.roomIdToFileCache[roomId]; ok {
-			filename = cachedPath
-		} else {
-			filename = findRoomFile(roomId)
-		}
-
-		filepath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`, `/`, filename)
-		if _, err := os.Stat(filepath); err == nil {
-			if bytes, err := os.ReadFile(filepath); err == nil {
-				yaml.Unmarshal(bytes, roomTpl)
-			}
-		}
-
-		addRoomToMemory(roomTpl)
+	if room := LoadRoomInstance(roomId); room != nil {
+		addRoomToMemory(room)
+		return room
 	}
 
-	return roomTpl
+	return nil
 }
 
-// Saves whatever room file is passed to it as the template.
-// Use with caution, accidentally passing an object that has items etc.
-// will mean this room's blank state will always have these items.
-func SaveRoomTemplate(r Room) error {
+// See: B. LOADING ROOMS FROM FILES
+func LoadRoomInstance(roomId int) *Room {
 
-	data, err := yaml.Marshal(&r)
+	room := LoadRoomTemplate(roomId)
+	if room == nil {
+		return nil
+	}
+
+	filename := roomManager.GetFilePath(roomId)
+
+	if len(filename) == 0 {
+		return nil
+	}
+
+	// Look for specially saved instance data
+	filepath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/rooms.instances/`, filename)
+
+	if bytes, err := os.ReadFile(filepath); err == nil {
+		// Unmarshal onto the default template data, overwriting any set fields in the instance save file
+		yaml.Unmarshal(bytes, room)
+	}
+
+	return room
+}
+
+// Only loads the template data, ignores instance data.
+func LoadRoomTemplate(roomId int) *Room {
+
+	filename := roomManager.GetFilePath(roomId)
+
+	if len(filename) == 0 {
+		return nil
+	}
+
+	filepath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/rooms/`, filename)
+
+	retRoom, _ := loadRoomFromFile(filepath)
+
+	return retRoom
+}
+
+// See C. UPDATING EXISTING ROOM TEMPLATES
+func SaveRoomTemplate(roomTpl Room) error {
+
+	// Do not accept a RoomId of zero.
+	if roomTpl.RoomId == 0 {
+		roomTpl.RoomId = GetNextRoomId()
+		SetNextRoomId(roomTpl.RoomId + 1)
+	}
+
+	//
+	// It is assumed that `roomTpl` contains empty room data
+	// That means no players/mobs/items/gold/etc that aren't intended to be included in the default/empty room template
+	//
+	data, err := yaml.Marshal(&roomTpl)
 	if err != nil {
 		return err
 	}
 
-	zone := ZoneToFolder(r.Zone)
+	zoneFolder := ZoneToFolder(roomTpl.Zone)
 
-	roomFilePath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms`, `/`, fmt.Sprintf("%s%d.yaml", zone, r.RoomId))
-
+	// First write the empty version to its template file
+	roomFilePath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/rooms/`, fmt.Sprintf("%s%d.yaml", zoneFolder, roomTpl.RoomId))
 	if err = os.WriteFile(roomFilePath, data, 0777); err != nil {
 		return err
 	}
 
-	copyFromRoom := roomManager.rooms[r.RoomId]
-	room := LoadRoomTemplate(r.RoomId)
+	// Get zone root
+	cfg := GetZoneConfig(roomTpl.Zone)
+
+	// Queue rebuild the zone map
+	events.AddToQueue(events.RebuildMap{MapRootRoomId: cfg.RoomId})
+	// Also queue rebuild the map based on the room, if it's not already present in a map (AKA, SkipIfExists)
+	events.AddToQueue(events.RebuildMap{MapRootRoomId: roomTpl.RoomId, SkipIfExists: true})
+
+	//
+	// Now we can make changes to the roomTpl as though it is the room (copy over stuff etc)
+	//
+	roomBeingReplaced := roomManager.rooms[roomTpl.RoomId]
 
 	// Copy container contents (if new vs. old room container names match)
-	for containerName, container := range copyFromRoom.Containers {
+	for containerName, container := range roomBeingReplaced.Containers {
 
-		if newContainer, ok := room.Containers[containerName]; ok {
+		if newContainer, ok := roomTpl.Containers[containerName]; ok {
 
 			if newContainer.Gold == 0 {
 				newContainer.Gold = container.Gold
@@ -117,47 +189,55 @@ func SaveRoomTemplate(r Room) error {
 				copy(newContainer.Items, container.Items)
 			}
 
-			room.Containers[containerName] = newContainer
+			roomTpl.Containers[containerName] = newContainer
 		}
-
 	}
 
 	// Copy items and stashed items
-	for _, itm := range copyFromRoom.GetAllFloorItems(true) {
+	for _, itm := range roomBeingReplaced.GetAllFloorItems(true) {
 		if itm.StashedBy > 0 {
-			room.AddItem(itm, true)
+			roomTpl.AddItem(itm, true)
 		} else {
-			room.AddItem(itm, false)
+			roomTpl.AddItem(itm, false)
 		}
 	}
 
-	// Copy gol don floor
-	room.Gold = copyFromRoom.Gold
+	// Copy gold on floor
+	roomTpl.Gold = roomBeingReplaced.Gold
 
 	// Copy signs
-	room.Signs = make([]Sign, len(copyFromRoom.Signs))
-	copy(room.Signs, copyFromRoom.Signs)
+	roomTpl.Signs = make([]Sign, len(roomBeingReplaced.Signs))
+	copy(roomTpl.Signs, roomBeingReplaced.Signs)
 
 	// Copy mobs in room
-	room.mobs = make([]int, len(copyFromRoom.mobs))
-	copy(room.mobs, copyFromRoom.mobs)
+	roomTpl.mobs = make([]int, len(roomBeingReplaced.mobs))
+	copy(roomTpl.mobs, roomBeingReplaced.mobs)
 
 	// Copy players in room
-	room.players = make([]int, len(copyFromRoom.players))
-	copy(room.players, copyFromRoom.players)
+	roomTpl.players = make([]int, len(roomBeingReplaced.players))
+	copy(roomTpl.players, roomBeingReplaced.players)
 
-	roomManager.rooms[room.RoomId] = room
+	// Add to memory with the force flag true
+	// This will clear out the old data and force write the new data.
+	addRoomToMemory(&roomTpl, true)
 
-	SaveRoom(*room)
+	// Save whatever is in this room as the instance data
+	SaveRoomInstance(roomTpl)
 
 	return nil
 }
 
-// SaveRoom loads the original template for the room
-// It then compares for changes and saves all elligible data
-func SaveRoom(r Room) error {
+type SaveEqualityChecker interface {
+	SkipInstanceSave(other any) bool // Should we skip due to everything looking the same?
+}
 
-	rTpl := LoadRoomTemplate(r.RoomId)
+// See: D. SAVING ROOMS INSTANCES
+func SaveRoomInstance(r Room) error {
+
+	rTpl := LoadRoomTemplate(r.RoomId) // This is also a Room{}
+	if rTpl == nil {
+		return fmt.Errorf(`could not load template for room %d`, r.RoomId)
+	}
 
 	rVal := reflect.ValueOf(r)
 	tplVal := reflect.ValueOf(*rTpl)
@@ -183,40 +263,38 @@ func SaveRoom(r Room) error {
 		rVal2 := rVal.Field(i)
 		tplVal2 := tplVal.Field(i)
 
-		// Compare using DeepEqual
-		if !reflect.DeepEqual(rVal2.Interface(), tplVal2.Interface()) {
-
-			marshal1, _ := yaml.Marshal(rVal2.Interface())
-			marshal2, _ := yaml.Marshal(tplVal2.Interface())
-
-			if string(marshal1) == string(marshal2) {
+		if iface, ok := rVal2.Interface().(SaveEqualityChecker); ok {
+			if iface.SkipInstanceSave(tplVal2.Interface()) {
 				continue
 			}
-
-			tagParts := strings.Split(yamlTag, ",")
-			fieldName := tagParts[0]
-			if fieldName == `` || fieldName == `omitempty` || fieldName == `flow` {
-				fieldName = field.Name
-			}
-
-			instanceSaveData[fieldName] = rVal2.Interface()
-
 		}
+
+		if reflect.DeepEqual(rVal2.Interface(), tplVal2.Interface()) {
+			continue
+		}
+
+		tagParts := strings.Split(yamlTag, ",")
+		fieldName := tagParts[0]
+		if fieldName == `` || fieldName == `omitempty` || fieldName == `flow` {
+			fieldName = field.Name
+		}
+
+		instanceSaveData[fieldName] = rVal2.Interface()
+
+	}
+
+	zone := ZoneToFolder(r.Zone)
+	folderPath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/rooms.instances/`, zone)
+	instanceFilePath := fmt.Sprintf("%s%d.yaml", folderPath, r.RoomId)
+
+	if len(instanceSaveData) == 0 {
+		os.Remove(instanceFilePath)
+		return nil
 	}
 
 	data, err := yaml.Marshal(instanceSaveData)
 	if err != nil {
 		return err
-	}
-
-	zone := ZoneToFolder(r.Zone)
-
-	folderPath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`, `/`, zone)
-	instanceFilePath := fmt.Sprintf("%s%d.yaml", folderPath, r.RoomId)
-
-	if string(data[0:2]) == `{}` {
-		os.Remove(instanceFilePath)
-		return nil
 	}
 
 	if err = os.WriteFile(instanceFilePath, data, 0777); err != nil {
@@ -226,30 +304,6 @@ func SaveRoom(r Room) error {
 	return nil
 }
 
-func findRoomFile(roomId int) string {
-
-	foundFilePath := ``
-	searchFileName := filepath.FromSlash(fmt.Sprintf(`/%d.yaml`, roomId))
-
-	walkPath := filepath.FromSlash(configs.GetFilePathsConfig().DataFiles.String() + `/rooms`)
-
-	filepath.Walk(walkPath, func(path string, info os.FileInfo, err error) error {
-
-		if err != nil {
-			return err
-		}
-
-		if strings.HasSuffix(path, searchFileName) {
-			foundFilePath = path
-			return errors.New(`found`)
-		}
-
-		return nil
-	})
-
-	return strings.TrimPrefix(foundFilePath, walkPath)
-}
-
 func loadRoomFromFile(roomFilePath string) (*Room, error) {
 
 	roomFilePath = util.FilePath(roomFilePath)
@@ -257,11 +311,7 @@ func loadRoomFromFile(roomFilePath string) (*Room, error) {
 	roomPtr, err := fileloader.LoadFlatFile[*Room](roomFilePath)
 	if err != nil {
 		mudlog.Error("loadRoomFromFile()", "error", err.Error())
-		return roomPtr, err
 	}
-
-	// Automatically set the last visitor to now (reset the timer)
-	roomPtr.lastVisited = util.GetRoundCount()
 
 	return roomPtr, err
 }
@@ -273,7 +323,7 @@ func SaveAllRooms() error {
 	errCt := 0
 	for _, r := range roomManager.rooms {
 
-		if SaveRoom(*r) != nil {
+		if SaveRoomInstance(*r) != nil {
 			errCt++
 			continue
 		}
@@ -349,7 +399,7 @@ func loadAllRoomZones() error {
 				RoomIds:    make(map[int]struct{}),
 			}
 
-			folderPath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`, `/`, ZoneNameSanitize(loadedRoom.Zone))
+			folderPath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/rooms.instances/`, ZoneNameSanitize(loadedRoom.Zone))
 			if _, err := os.Stat(folderPath); os.IsNotExist(err) {
 				os.MkdirAll(folderPath, 0755)
 			}

--- a/internal/rooms/save_and_load.go
+++ b/internal/rooms/save_and_load.go
@@ -1,0 +1,377 @@
+package rooms
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/fileloader"
+	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/util"
+	"gopkg.in/yaml.v2"
+)
+
+func LoadRoomTemplate(roomId int) *Room {
+
+	filename := ``
+
+	if cachedPath, ok := roomManager.roomIdToFileCache[roomId]; ok {
+		filename = cachedPath
+	} else {
+		filename = findRoomFile(roomId)
+	}
+
+	if len(filename) == 0 {
+		return nil
+	}
+
+	filepath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms`, `/`, filename)
+
+	retRoom, _ := loadRoomFromFile(filepath)
+
+	return retRoom
+}
+
+// Load room grabs the room from memory and returns a pointer to it.
+// If the room hasn't been loaded yet, it:
+// 1. loads it from the template file
+// 2. loads any instance data and overlays it
+// 3. adds it to memory
+func LoadRoom(roomId int) *Room {
+
+	// Room 0 aliases to start room
+	if roomId == StartRoomIdAlias {
+		if roomId = int(configs.GetSpecialRoomsConfig().StartRoom); roomId == 0 {
+			roomId = 1
+		}
+	}
+
+	room, ok := roomManager.rooms[roomId]
+
+	if ok {
+		return room
+	}
+
+	roomTpl := LoadRoomTemplate(roomId)
+
+	if roomTpl != nil {
+
+		filename := ``
+		if cachedPath, ok := roomManager.roomIdToFileCache[roomId]; ok {
+			filename = cachedPath
+		} else {
+			filename = findRoomFile(roomId)
+		}
+
+		filepath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`, `/`, filename)
+		if _, err := os.Stat(filepath); err == nil {
+			if bytes, err := os.ReadFile(filepath); err == nil {
+				yaml.Unmarshal(bytes, roomTpl)
+			}
+		}
+
+		addRoomToMemory(roomTpl)
+	}
+
+	return roomTpl
+}
+
+// Saves whatever room file is passed to it as the template.
+// Use with caution, accidentally passing an object that has items etc.
+// will mean this room's blank state will always have these items.
+func SaveRoomTemplate(r Room) error {
+
+	data, err := yaml.Marshal(&r)
+	if err != nil {
+		return err
+	}
+
+	zone := ZoneToFolder(r.Zone)
+
+	roomFilePath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms`, `/`, fmt.Sprintf("%s%d.yaml", zone, r.RoomId))
+
+	if err = os.WriteFile(roomFilePath, data, 0777); err != nil {
+		return err
+	}
+
+	copyFromRoom := roomManager.rooms[r.RoomId]
+	room := LoadRoomTemplate(r.RoomId)
+
+	// Copy container contents (if new vs. old room container names match)
+	for containerName, container := range copyFromRoom.Containers {
+
+		if newContainer, ok := room.Containers[containerName]; ok {
+
+			if newContainer.Gold == 0 {
+				newContainer.Gold = container.Gold
+			}
+
+			if len(newContainer.Items) == 0 && len(container.Items) > 0 {
+				newContainer.Items = make([]items.Item, len(container.Items))
+				copy(newContainer.Items, container.Items)
+			}
+
+			room.Containers[containerName] = newContainer
+		}
+
+	}
+
+	// Copy items and stashed items
+	for _, itm := range copyFromRoom.GetAllFloorItems(true) {
+		if itm.StashedBy > 0 {
+			room.AddItem(itm, true)
+		} else {
+			room.AddItem(itm, false)
+		}
+	}
+
+	// Copy gol don floor
+	room.Gold = copyFromRoom.Gold
+
+	// Copy signs
+	room.Signs = make([]Sign, len(copyFromRoom.Signs))
+	copy(room.Signs, copyFromRoom.Signs)
+
+	// Copy mobs in room
+	room.mobs = make([]int, len(copyFromRoom.mobs))
+	copy(room.mobs, copyFromRoom.mobs)
+
+	// Copy players in room
+	room.players = make([]int, len(copyFromRoom.players))
+	copy(room.players, copyFromRoom.players)
+
+	roomManager.rooms[room.RoomId] = room
+
+	SaveRoom(*room)
+
+	return nil
+}
+
+// SaveRoom loads the original template for the room
+// It then compares for changes and saves all elligible data
+func SaveRoom(r Room) error {
+
+	rTpl := LoadRoomTemplate(r.RoomId)
+
+	rVal := reflect.ValueOf(r)
+	tplVal := reflect.ValueOf(*rTpl)
+	t := reflect.TypeOf(r)
+
+	instanceSaveData := make(map[string]interface{})
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+
+		yamlTag := field.Tag.Get("yaml")
+		if yamlTag == `-` {
+			continue
+		}
+
+		if field.Tag.Get("instance") == "skip" {
+			continue
+		}
+
+		rVal2 := rVal.Field(i)
+		tplVal2 := tplVal.Field(i)
+
+		// Compare using DeepEqual
+		if !reflect.DeepEqual(rVal2.Interface(), tplVal2.Interface()) {
+
+			marshal1, _ := yaml.Marshal(rVal2.Interface())
+			marshal2, _ := yaml.Marshal(tplVal2.Interface())
+
+			if string(marshal1) == string(marshal2) {
+				continue
+			}
+
+			tagParts := strings.Split(yamlTag, ",")
+			fieldName := tagParts[0]
+			if fieldName == `` || fieldName == `omitempty` || fieldName == `flow` {
+				fieldName = field.Name
+			}
+
+			instanceSaveData[fieldName] = rVal2.Interface()
+
+		}
+	}
+
+	data, err := yaml.Marshal(instanceSaveData)
+	if err != nil {
+		return err
+	}
+
+	zone := ZoneToFolder(r.Zone)
+
+	folderPath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`, `/`, zone)
+	instanceFilePath := fmt.Sprintf("%s%d.yaml", folderPath, r.RoomId)
+
+	if string(data[0:2]) == `{}` {
+		os.Remove(instanceFilePath)
+		return nil
+	}
+
+	if err = os.WriteFile(instanceFilePath, data, 0777); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func findRoomFile(roomId int) string {
+
+	foundFilePath := ``
+	searchFileName := filepath.FromSlash(fmt.Sprintf(`/%d.yaml`, roomId))
+
+	walkPath := filepath.FromSlash(configs.GetFilePathsConfig().DataFiles.String() + `/rooms`)
+
+	filepath.Walk(walkPath, func(path string, info os.FileInfo, err error) error {
+
+		if err != nil {
+			return err
+		}
+
+		if strings.HasSuffix(path, searchFileName) {
+			foundFilePath = path
+			return errors.New(`found`)
+		}
+
+		return nil
+	})
+
+	return strings.TrimPrefix(foundFilePath, walkPath)
+}
+
+func loadRoomFromFile(roomFilePath string) (*Room, error) {
+
+	roomFilePath = util.FilePath(roomFilePath)
+
+	roomPtr, err := fileloader.LoadFlatFile[*Room](roomFilePath)
+	if err != nil {
+		mudlog.Error("loadRoomFromFile()", "error", err.Error())
+		return roomPtr, err
+	}
+
+	// Automatically set the last visitor to now (reset the timer)
+	roomPtr.lastVisited = util.GetRoundCount()
+
+	return roomPtr, err
+}
+
+func SaveAllRooms() error {
+
+	start := time.Now()
+	saveCt := 0
+	errCt := 0
+	for _, r := range roomManager.rooms {
+
+		if SaveRoom(*r) != nil {
+			errCt++
+			continue
+		}
+		saveCt++
+
+	}
+
+	mudlog.Info("SaveAllRooms()", "savedCount", saveCt, "expectedCt", len(roomManager.rooms), "errorCount", errCt, "Time Taken", time.Since(start))
+
+	return nil
+}
+
+// Goes through all of the rooms and caches key information
+func loadAllRoomZones() error {
+	start := time.Now()
+
+	nextRoomId := GetNextRoomId()
+	defer func() {
+		if nextRoomId != GetNextRoomId() {
+			SetNextRoomId(nextRoomId)
+		}
+	}()
+
+	loadedRooms, err := fileloader.LoadAllFlatFiles[int, *Room](configs.GetFilePathsConfig().DataFiles.String() + `/rooms`)
+	if err != nil {
+		return err
+	}
+
+	roomsWithoutEntrances := map[int]string{}
+
+	for _, loadedRoom := range loadedRooms {
+
+		// configs.GetConfig().DeathRecoveryRoom is the death/shadow realm and gets a pass
+		if loadedRoom.RoomId == int(configs.GetSpecialRoomsConfig().DeathRecoveryRoom) {
+			continue
+		}
+
+		// If it has never been set, set it to the filepath
+		if _, ok := roomsWithoutEntrances[loadedRoom.RoomId]; !ok {
+			roomsWithoutEntrances[loadedRoom.RoomId] = loadedRoom.Filepath()
+		}
+
+		for _, exit := range loadedRoom.Exits {
+			roomsWithoutEntrances[exit.RoomId] = ``
+		}
+
+	}
+
+	for roomId, filePath := range roomsWithoutEntrances {
+
+		if filePath == `` {
+			delete(roomsWithoutEntrances, roomId)
+			continue
+		}
+
+		mudlog.Warn("No Entrance", "roomId", roomId, "filePath", filePath)
+	}
+
+	for _, loadedRoom := range loadedRooms {
+		// Keep track of the highest roomId
+
+		if loadedRoom.RoomId >= nextRoomId {
+			nextRoomId = loadedRoom.RoomId + 1
+		}
+
+		// Cache the file path for every roomId
+		roomManager.roomIdToFileCache[loadedRoom.RoomId] = loadedRoom.Filepath()
+
+		// Update the zone info cache
+		if _, ok := roomManager.zones[loadedRoom.Zone]; !ok {
+			roomManager.zones[loadedRoom.Zone] = ZoneInfo{
+				RootRoomId: 0,
+				RoomIds:    make(map[int]struct{}),
+			}
+
+			folderPath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`, `/`, ZoneNameSanitize(loadedRoom.Zone))
+			if _, err := os.Stat(folderPath); os.IsNotExist(err) {
+				os.MkdirAll(folderPath, 0755)
+			}
+		}
+
+		// Update the zone info
+		zoneInfo := roomManager.zones[loadedRoom.Zone]
+		zoneInfo.RoomIds[loadedRoom.RoomId] = struct{}{}
+
+		if loadedRoom.ZoneConfig.RoomId == loadedRoom.RoomId {
+			zoneInfo.RootRoomId = loadedRoom.RoomId
+			zoneInfo.DefaultBiome = loadedRoom.Biome
+
+			if len(loadedRoom.ZoneConfig.Mutators) > 0 {
+				zoneInfo.HasZoneMutators = true
+			}
+		}
+
+		roomManager.zones[loadedRoom.Zone] = zoneInfo
+	}
+
+	mudlog.Info("rooms.loadAllRoomZones()", "loadedCount", len(loadedRooms), "Time Taken", time.Since(start))
+
+	return nil
+}

--- a/internal/usercommands/admin.build.go
+++ b/internal/usercommands/admin.build.go
@@ -79,16 +79,16 @@ func Build(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 
 			if gotoRoomId == 0 {
 
-				if newRoom, err := rooms.BuildRoom(user.Character.RoomId, exitName, mapDirection); err != nil {
-					user.SendText(err.Error())
-				} else {
-					destinationRoom = newRoom
-				}
+				newRoom, err := rooms.BuildRoom(user.Character.RoomId, exitName, mapDirection)
 
-				if destinationRoom == nil {
+				// If there was a problem building the room, send the error to the user before returning
+				if err != nil {
+					user.SendText(err.Error())
 					user.SendText(fmt.Sprintf("Error building room %s.", exitName))
 					return false, nil
 				}
+
+				destinationRoom = newRoom
 
 			} else {
 				destinationRoom = rooms.LoadRoom(gotoRoomId)
@@ -110,10 +110,6 @@ func Build(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 
 				rooms.ConnectRoom(destinationRoom.RoomId, user.Character.RoomId, returnName, returnMapDirection)
 			}
-
-			// Force a refresh of map data
-			rootRoomId, _ := rooms.GetZoneRoot(room.Zone)
-			mapper.GetMapper(rootRoomId, true)
 
 			if err := rooms.MoveToRoom(user.UserId, destinationRoom.RoomId); err != nil {
 				user.SendText(err.Error())

--- a/internal/usercommands/admin.build.go
+++ b/internal/usercommands/admin.build.go
@@ -75,7 +75,9 @@ func Build(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 				return true, err
 			}
 
-			if gotoRoomId, _ := rMapper.FindAdjacentRoom(user.Character.RoomId, exitName, 1); gotoRoomId == 0 {
+			gotoRoomId, _ := rMapper.FindAdjacentRoom(user.Character.RoomId, exitName, 1)
+
+			if gotoRoomId == 0 {
 
 				if newRoom, err := rooms.BuildRoom(user.Character.RoomId, exitName, mapDirection); err != nil {
 					user.SendText(err.Error())
@@ -88,10 +90,16 @@ func Build(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 					return false, nil
 				}
 
+			} else {
+				destinationRoom = rooms.LoadRoom(gotoRoomId)
+				if _, ok := destinationRoom.Exits[exitName]; !ok {
+					rooms.ConnectRoom(user.Character.RoomId, destinationRoom.RoomId, exitName, mapDirection)
+				}
 			}
 
 			// Connect the exit back
 			if len(returnName) > 0 {
+
 				returnMapDirection := returnName
 				if strings.Contains(returnName, `-`) {
 					returnMapDirection = returnName
@@ -102,6 +110,10 @@ func Build(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 
 				rooms.ConnectRoom(destinationRoom.RoomId, user.Character.RoomId, returnName, returnMapDirection)
 			}
+
+			// Force a refresh of map data
+			rootRoomId, _ := rooms.GetZoneRoot(room.Zone)
+			mapper.GetMapper(rootRoomId, true)
 
 			if err := rooms.MoveToRoom(user.UserId, destinationRoom.RoomId); err != nil {
 				user.SendText(err.Error())

--- a/main.go
+++ b/main.go
@@ -134,6 +134,9 @@ func main() {
 	//
 	mudlog.Info(`========================`)
 
+	// Older versions of GoMud may not have this folder present.
+	err := os.Mkdir(util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`), os.ModeDir|0755)
+
 	// Register the plugin filesystem with the template system
 	templates.RegisterFS(plugins.GetPluginRegistry())
 	usercommands.AddFunctionExporter(plugins.GetPluginRegistry())

--- a/main.go
+++ b/main.go
@@ -135,7 +135,8 @@ func main() {
 	mudlog.Info(`========================`)
 
 	// Older versions of GoMud may not have this folder present.
-	err := os.Mkdir(util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`), os.ModeDir|0755)
+	// Also deleting the folder is a quick way to reset instance state, so this corrects that if it happens.
+	os.Mkdir(util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/`, `rooms.instances`), os.ModeDir|0755)
 
 	// Register the plugin filesystem with the template system
 	templates.RegisterFS(plugins.GetPluginRegistry())


### PR DESCRIPTION
# Description

The goal of this PR is to split Room data files into two save forms:

1. The "Template", saved in `_datafiles/world/{worldname}/rooms/` which is just the normal, empty state room definition. This is how the room should be loaded into the memory the first time it is ever encountered. Items shouldn't be on the floor (unless it is desired to start with an item on the floor), gold, containers, etc. are all in their initial state.
2. The "Instance", saved in `_datafiles/world/{worldname}/rooms.instances/` which is everything (or most things) that have changed about the room and are worth saving in case the room gets unloaded from memory.

## Changes

- Updated room "Template" data files to remove random objects that were saved and committed into rooms in the past.
- Instance loading/saving and Template loading/saving are distinct operations with different purposes, and code functions etc. have been created to handle them.
  - Developers should generally not have to interface with these, they are for precise modification to specific data when needed, such as in admin commands. The `rooms.LoadRoom()` function remains the primary way to load room data.
- Fixed some inefficiencies with room filenames, should have been caching but wasn't.
- Added a makefile target to delete all instance data for purposes of testing.
- Added an event and handler to rebuild mapper data.
- Fixed a lot of messy/poorly named functions and variables to try and make clearer
- Added lots of code comments for whatever poor soul must revisit this process.
- Moved room save/load functions to own file in package folder.
- Updated admin `build` command to modify template data.
- Updated admin `room` command to modify template data.
