### PR TITLE
Adding ephemeral detail string to Room GMCP, focing mapper to use low…

### DIFF
--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -223,11 +223,16 @@ func (r *mapper) Start() {
 
 	r.crawlQueue = make([]crawlRoom, 0, 100) // pre-allocate 100 capacity
 
+	lowestRoomId := 0
 	//var lastNode *mapNode = nil
 	r.crawlQueue = append(r.crawlQueue, crawlRoom{RoomId: r.rootRoomId, Pos: positionDelta{}})
 	for len(r.crawlQueue) > 0 {
 
 		roomNow := r.crawlQueue[0]
+
+		if lowestRoomId == 0 || roomNow.RoomId < lowestRoomId {
+			lowestRoomId = roomNow.RoomId
+		}
 
 		r.crawlQueue = r.crawlQueue[1:]
 
@@ -280,11 +285,21 @@ func (r *mapper) Start() {
 
 	r.crawlQueue = nil
 
+	var xOffset, yOffset, zOffset = 0, 0, 0
+	lowestRoom := r.crawledRooms[lowestRoomId]
+	if lowestRoom != nil {
+		xOffset, yOffset, zOffset = lowestRoom.Pos.x, lowestRoom.Pos.y, lowestRoom.Pos.z
+	}
+
 	// calculate the final array length.
+
+	minX, minY, minZ = minX-xOffset, minY-yOffset, minZ-zOffset
+	maxX, maxY, maxZ = maxX-xOffset, maxY-yOffset, maxZ-zOffset
 
 	r.roomGrid.initialize(minX, maxX, minY, maxY, minZ, maxZ)
 
 	for _, node := range r.crawledRooms {
+		node.Pos.x, node.Pos.y, node.Pos.z = node.Pos.x-xOffset, node.Pos.y-yOffset, node.Pos.z-zOffset
 		r.roomGrid.addNode(node)
 	}
 }

--- a/modules/gmcp/gmcp.Room.go
+++ b/modules/gmcp/gmcp.Room.go
@@ -439,6 +439,11 @@ func (g *GMCPRoomModule) GetRoomNode(user *users.UserRecord, gmcpModule string) 
 		if room.IsCharacterRoom {
 			payload.Details = append(payload.Details, `character`)
 		}
+
+		// Indicate if this is an ephemeral room
+		if rooms.IsEphemeralRoomId(room.RoomId) {
+			payload.Details = append(payload.Details, `ephemeral`)
+		}
 		// end room details
 
 	}


### PR DESCRIPTION
# Description

This forces the mapper to use the lowest RoomId in the set as the 0,0,0 origin. This solves the issue of drifting coordinates depending on what gets mapped first.

## Changes

- Added `x`, `y`, `z` offsets based on lowest room in mapper.
- Added `ephemeral` to Room GMCP payload (Details) when a room is ephemeral.

## Examples

without changes (Force to generate dark forest first):
```
Room.Info {
        "num": 1,
        "name": "Town Square",
        "area": "Frostfang",
        "environment": "City",
        "coords": "Frostfang, -18, 1, 0",
        "exits": {
                "east": 54,
                "north": 2,
                "south": 12,
                "west": 7
        },
```
With changes (Still forced to generate dark forest first):
```
Room.Info {
        "num": 1,
        "name": "Town Square",
        "area": "Frostfang",
        "environment": "City",
        "coords": "Frostfang, 0, 0, 0",
        "exits": {
                "east": 54,
                "north": 2,
                "south": 12,
                "west": 7
        },
```