### PR TITLE
Mudlet GMCP Discord Rich Presence functionality

### DIFF
--- a/modules/gmcp/files/data-overlays/config.yaml
+++ b/modules/gmcp/files/data-overlays/config.yaml
@@ -13,10 +13,10 @@ map_version: "1"
 map_url: "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/gomud.dat"
 
 # Discord Rich Presence configuration
-discord_application_id: "1298377884154724412"
-discord_invite_url: "https://discord.gg/FaauSYej3n"
-discord_large_image_key: "server-icon"
-discord_details: "Playing on GoMud"
+discord_application_id: "1298377884154724412" # Default GoMud Discord Server
+# Should the invite possible be in the normal config.yaml?
+discord_invite_url: "https://discord.gg/FaauSYej3n" # Default GoMud Discord Server
+discord_details: "Using GoMudEngine"
 discord_state: "Exploring the world"
-discord_game: "GoMud"
+discord_large_image_key: "server-icon"
 discord_small_image_key: "character-icon"

--- a/modules/gmcp/files/data-overlays/config.yaml
+++ b/modules/gmcp/files/data-overlays/config.yaml
@@ -14,7 +14,6 @@ map_url: "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/g
 
 # Discord Rich Presence configuration
 discord_application_id: "1298377884154724412" # Default GoMud Discord Server
-# Should the invite possible be in the normal config.yaml?
 discord_invite_url: "https://discord.gg/FaauSYej3n" # Default GoMud Discord Server
 discord_details: "Using GoMudEngine"
 discord_state: "Exploring the world"

--- a/modules/gmcp/files/data-overlays/config.yaml
+++ b/modules/gmcp/files/data-overlays/config.yaml
@@ -1,3 +1,23 @@
+################################################################################
+# If modified, these settings will be copied into your config overrides 
+# folder under `Modules.gmcp`:
+#
+# Modules:
+#   gmcp:
+#     mapper_version: "1"
+#     mapper_url: "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/GoMudMapper.mpackage"
+#     ui_version: "1"
+#     ui_url: "https://github.com/GoMudEngine/MudletUI/releases/latest/download/GoMudUI.mpackage"
+#     map_version: "1"
+#     map_url: "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/gomud.dat"
+#     discord_application_id: "1298377884154724412"
+#     discord_invite_url: "https://discord.gg/FaauSYej3n"
+#     discord_details: "Using GoMudEngine"
+#     discord_state: "Exploring the world"
+#     discord_large_image_key: "server-icon"
+#     discord_small_image_key: "character-icon"
+################################################################################
+
 # Mudlet client configuration
 
 # Mapper configuration

--- a/modules/gmcp/files/data-overlays/keywords.yaml
+++ b/modules/gmcp/files/data-overlays/keywords.yaml
@@ -8,6 +8,8 @@ help:
       - checkclient
       - mudletmap
       - mudletui
+    integration:
+      - discord
 
 # Aliases for keywords when typing: help <keyword>
 help-aliases:

--- a/modules/gmcp/files/data-overlays/mudlet-config.yaml
+++ b/modules/gmcp/files/data-overlays/mudlet-config.yaml
@@ -11,3 +11,12 @@ ui_url: "https://github.com/GoMudEngine/MudletUI/releases/latest/download/GoMudU
 # Map data configuration
 map_version: "1"
 map_url: "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/gomud.dat"
+
+# Discord Rich Presence configuration
+discord_application_id: "1298377884154724412"
+discord_invite_url: "https://discord.gg/FaauSYej3n"
+discord_large_image_key: "server-icon"
+discord_details: "Playing on GoMud"
+discord_state: "Exploring the world"
+discord_game: "GoMud"
+discord_small_image_key: "character-icon"

--- a/modules/gmcp/files/datafiles/templates/help/checkclient.template
+++ b/modules/gmcp/files/datafiles/templates/help/checkclient.template
@@ -6,7 +6,7 @@ The <ansi fg="command">checkclient</ansi> command displays information about cli
 
   <ansi fg="command">checkclient</ansi> - Shows details about detected client features and available enhancements
 
-<ansi fg="yellow-bold">NOTES:</ansi>
+<ansi fg="yellow-bold">Notes:</ansi>
 - This command is particularly useful for Mudlet users to see what special features are available
 - It will detect if you're using Mudlet and show relevant package information
 - The command runs automatically when you log in to provide helpful information

--- a/modules/gmcp/files/datafiles/templates/help/client.template
+++ b/modules/gmcp/files/datafiles/templates/help/client.template
@@ -10,7 +10,7 @@ This game supports various MUD clients with special features to enhance your gam
   <ansi fg="white-bold">Other Clients</ansi> - Basic support with standard MUD protocol features
     For the best experience, we recommend using a client that supports GMCP.
 
-<ansi fg="subtitle">GMCP FEATURES:</ansi>
+<ansi fg="yellow-bold">GMCP Features:</ansi>
 - Character information and status updates
 - Room and environment data
 - Communication channels

--- a/modules/gmcp/files/datafiles/templates/help/discord.template
+++ b/modules/gmcp/files/datafiles/templates/help/discord.template
@@ -4,17 +4,25 @@ The <ansi fg="command">discord</ansi> command allows Mudlet client users to cust
 
 <ansi fg="yellow">Usage: </ansi>
 
-  <ansi fg="command">discord</ansi>              - Shows current settings and available commands
-  <ansi fg="command">discord area on|off</ansi>  - Show/hide current area in status
-  <ansi fg="command">discord party on|off</ansi> - Show/hide party information
-  <ansi fg="command">discord name on|off</ansi>  - Show/hide character name
-  <ansi fg="command">discord level on|off</ansi> - Show/hide character level
+  <ansi fg="command">discord</ansi>               - Shows current settings and available commands
+  
+  <ansi fg="command">discord info on|off</ansi>   - Enable/disable Discord application info
+  <ansi fg="command">discord status on|off</ansi> - Enable/disable Discord status updates
 
-<ansi fg="subtitle">NOTES:</ansi>
+  <ansi fg="command">discord area on|off</ansi>   - Show/hide current area in status
+  <ansi fg="command">discord party on|off</ansi>  - Show/hide party information
+  <ansi fg="command">discord name on|off</ansi>   - Show/hide character name
+  <ansi fg="command">discord level on|off</ansi>  - Show/hide character level
+  
+
+<ansi fg="yellow-bold">Notes:</ansi>
 - These commands only work if you are using a Mudlet client
 - All settings default to enabled when not set
 - Character name and level are shown in the format: "Name (lvl. X)"
 - Party information includes party size and current area (if enabled)
+- The info setting controls sending the Discord application ID
+- The status setting controls sending presence updates to Discord
+- Disabling either info or status will clear any cached data
 - Settings persist between sessions
 - Running <ansi fg="command">discord</ansi> without arguments shows current settings
 

--- a/modules/gmcp/files/datafiles/templates/help/discord.template
+++ b/modules/gmcp/files/datafiles/templates/help/discord.template
@@ -1,0 +1,21 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">discord</ansi>
+
+The <ansi fg="command">discord</ansi> command allows Mudlet client users to customize what information is shown in their Discord status.
+
+<ansi fg="yellow">Usage: </ansi>
+
+  <ansi fg="command">discord</ansi>              - Shows current settings and available commands
+  <ansi fg="command">discord area on|off</ansi>  - Show/hide current area in status
+  <ansi fg="command">discord party on|off</ansi> - Show/hide party information
+  <ansi fg="command">discord name on|off</ansi>  - Show/hide character name
+  <ansi fg="command">discord level on|off</ansi> - Show/hide character level
+
+<ansi fg="subtitle">NOTES:</ansi>
+- These commands only work if you are using a Mudlet client
+- All settings default to enabled when not set
+- Character name and level are shown in the format: "Name (lvl. X)"
+- Party information includes party size and current area (if enabled)
+- Settings persist between sessions
+- Running <ansi fg="command">discord</ansi> without arguments shows current settings
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help client</ansi>, <ansi fg="command">checkclient</ansi> 

--- a/modules/gmcp/files/datafiles/templates/help/mudletmap.template
+++ b/modules/gmcp/files/datafiles/templates/help/mudletmap.template
@@ -6,7 +6,7 @@ The <ansi fg="command">mudletmap</ansi> command sends map data to Mudlet clients
 
   <ansi fg="command">mudletmap</ansi> - Sends or refreshes map data to your Mudlet client
 
-<ansi fg="subtitle">NOTES:</ansi>
+<ansi fg="yellow-bold">Notes:</ansi>
 - This command only works if you are using a Mudlet client
 - The map data helps with navigation and visualization of the game world
 - This command runs automatically when you log in with Mudlet

--- a/modules/gmcp/files/datafiles/templates/help/mudletui.template
+++ b/modules/gmcp/files/datafiles/templates/help/mudletui.template
@@ -11,7 +11,7 @@ The <ansi fg="command">mudletui</ansi> command allows Mudlet client users to man
   <ansi fg="command">mudletui hide</ansi>    - Hides automatic Mudlet UI prompts when logging in
   <ansi fg="command">mudletui show</ansi>    - Re-enables automatic Mudlet UI prompts when logging in
 
-<ansi fg="subtitle">NOTES:</ansi>
+<ansi fg="yellow-bold">Notes:</ansi>
 - These commands only work if you are using a Mudlet client
 - The UI package enhances your gameplay experience with custom windows and controls
 - If the installation doesn't work automatically, check for prompts in your Mudlet client

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -2,11 +2,13 @@ package gmcp
 
 import (
 	"embed"
+	"fmt"
 	"strings"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/parties"
 	"github.com/GoMudEngine/GoMud/internal/plugins"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
 	"github.com/GoMudEngine/GoMud/internal/usercommands"
@@ -31,12 +33,22 @@ type MudletConfig struct {
 	// Map data configuration
 	MapVersion string `json:"map_version" yaml:"map_version"`
 	MapURL     string `json:"map_url" yaml:"map_url"`
+
+	// Discord Rich Presence configuration
+	DiscordApplicationID string `json:"discord_application_id" yaml:"discord_application_id"`
+	DiscordInviteURL     string `json:"discord_invite_url" yaml:"discord_invite_url"`
+	DiscordLargeImageKey string `json:"discord_large_image_key" yaml:"discord_large_image_key"`
+	DiscordDetails       string `json:"discord_details" yaml:"discord_details"`
+	DiscordState         string `json:"discord_state" yaml:"discord_state"`
+	DiscordGame          string `json:"discord_game" yaml:"discord_game"`
+	DiscordSmallImageKey string `json:"discord_small_image_key" yaml:"discord_small_image_key"`
 }
 
 // GMCPMudletModule handles Mudlet-specific GMCP functionality
 type GMCPMudletModule struct {
-	plug   *plugins.Plugin
-	config MudletConfig
+	plug        *plugins.Plugin
+	config      MudletConfig
+	mudletUsers map[int]bool // Track which users are using Mudlet clients
 }
 
 // GMCPMudletDetected is an event fired when a Mudlet client is detected
@@ -46,6 +58,22 @@ type GMCPMudletDetected struct {
 }
 
 func (g GMCPMudletDetected) Type() string { return `GMCPMudletDetected` }
+
+// GMCPDiscordStatusRequest is an event fired when a client requests Discord status information
+type GMCPDiscordStatusRequest struct {
+	UserId int
+}
+
+func (g GMCPDiscordStatusRequest) Type() string { return `GMCPDiscordStatusRequest` }
+
+// GMCPDiscordMessage is an event fired when a client sends a Discord-related GMCP message
+type GMCPDiscordMessage struct {
+	ConnectionId uint64
+	Command      string
+	Payload      []byte
+}
+
+func (g GMCPDiscordMessage) Type() string { return `GMCPDiscordMessage` }
 
 func init() {
 	// Set up a default configuration first
@@ -58,7 +86,16 @@ func init() {
 			UIURL:         "https://github.com/GoMudEngine/MudletUI/releases/latest/download/GoMudUI.mpackage",         // Default value
 			MapVersion:    "1",                                                                                         // Default value
 			MapURL:        "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/gomud.dat",            // Default value
+			// Discord defaults
+			DiscordApplicationID: "1298377884154724412",           // Default value
+			DiscordInviteURL:     "https://discord.gg/FaauSYej3n", // Default value
+			DiscordLargeImageKey: "server-icon",                   // Default value
+			DiscordDetails:       "Playing on GoMud",              // Default value
+			DiscordState:         "Exploring the world",           // Default value
+			DiscordGame:          "GoMud",                         // Default value
+			DiscordSmallImageKey: "character-icon",                // Default value
 		},
+		mudletUsers: make(map[int]bool), // Initialize the mudletUsers map
 	}
 
 	// Attach embedded filesystem without logging errors
@@ -83,10 +120,34 @@ func init() {
 	if mapURL, ok := g.plug.Config.Get(`MapURL`).(string); ok {
 		g.config.MapURL = mapURL
 	}
+	if discordAppID, ok := g.plug.Config.Get(`DiscordApplicationID`).(string); ok {
+		g.config.DiscordApplicationID = discordAppID
+	}
+	if discordInviteURL, ok := g.plug.Config.Get(`DiscordInviteURL`).(string); ok {
+		g.config.DiscordInviteURL = discordInviteURL
+	}
+	if discordLargeImageKey, ok := g.plug.Config.Get(`DiscordLargeImageKey`).(string); ok {
+		g.config.DiscordLargeImageKey = discordLargeImageKey
+	}
+	if discordDetails, ok := g.plug.Config.Get(`DiscordDetails`).(string); ok {
+		g.config.DiscordDetails = discordDetails
+	}
+	if discordState, ok := g.plug.Config.Get(`DiscordState`).(string); ok {
+		g.config.DiscordState = discordState
+	}
+	if discordGame, ok := g.plug.Config.Get(`DiscordGame`).(string); ok {
+		g.config.DiscordGame = discordGame
+	}
+	if discordSmallImageKey, ok := g.plug.Config.Get(`DiscordSmallImageKey`).(string); ok {
+		g.config.DiscordSmallImageKey = discordSmallImageKey
+	}
 
 	// Register event listeners
 	events.RegisterListener(events.PlayerSpawn{}, g.playerSpawnHandler)
 	events.RegisterListener(GMCPMudletDetected{}, g.mudletDetectedHandler)
+	events.RegisterListener(GMCPDiscordStatusRequest{}, g.discordStatusRequestHandler)
+	events.RegisterListener(GMCPDiscordMessage{}, g.discordMessageHandler)
+	events.RegisterListener(events.RoomChange{}, g.roomChangeHandler)
 
 	// Register the Mudlet-specific user commands - set as hidden (true for first bool)
 	g.plug.AddUserCommand("mudletmap", g.sendMapCommand, true, false)
@@ -330,7 +391,33 @@ func (g *GMCPMudletModule) sendMudletConfig(userId int) {
 		Payload: guiPayload,
 	})
 
-	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet package config", "userId", userId)
+	// Get the user record to access character details
+	user := users.GetByUserId(userId)
+	if user == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord info", "userId", userId)
+		return
+	}
+
+	// Create a payload for Discord.Info - only applicationid and inviteurl
+	discordInfoPayload := struct {
+		ApplicationID string `json:"applicationid"`
+		InviteURL     string `json:"inviteurl"`
+	}{
+		ApplicationID: g.config.DiscordApplicationID,
+		InviteURL:     g.config.DiscordInviteURL,
+	}
+
+	// Send the External.Discord.Info message
+	events.AddToQueue(GMCPOut{
+		UserId:  userId,
+		Module:  "External.Discord.Info",
+		Payload: discordInfoPayload,
+	})
+
+	// Send the Discord Status information
+	g.sendDiscordStatus(userId)
+
+	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Mudlet package config and Discord info", "userId", userId)
 }
 
 // checkClientCommand checks if the player is using Mudlet and shows information if they are
@@ -358,4 +445,231 @@ func (g *GMCPMudletModule) checkClientCommand(rest string, user *users.UserRecor
 	// Client is not Mudlet - return true but don't show any message
 	// (Return true anyway to avoid command showing up in help)
 	return true, nil
+}
+
+// discordStatusRequestHandler handles the GMCPDiscordStatusRequest event
+func (g *GMCPMudletModule) discordStatusRequestHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(GMCPDiscordStatusRequest)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "GMCPDiscordStatusRequest", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	// Get the user record to access character details
+	userId := evt.UserId
+	user := users.GetByUserId(userId)
+	if user == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord info/status", "userId", userId)
+		return events.Cancel
+	}
+
+	// Create a payload for Discord.Info - only applicationid and inviteurl
+	discordInfoPayload := struct {
+		ApplicationID string `json:"applicationid"`
+		InviteURL     string `json:"inviteurl"`
+	}{
+		ApplicationID: g.config.DiscordApplicationID,
+		InviteURL:     g.config.DiscordInviteURL,
+	}
+
+	// Send the External.Discord.Info message
+	events.AddToQueue(GMCPOut{
+		UserId:  userId,
+		Module:  "External.Discord.Info",
+		Payload: discordInfoPayload,
+	})
+
+	// Also send Discord Status information
+	g.sendDiscordStatus(userId)
+
+	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Info and Status in response to request", "userId", userId)
+	return events.Continue
+}
+
+// discordMessageHandler handles Discord-related GMCP messages from clients
+func (g *GMCPMudletModule) discordMessageHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(GMCPDiscordMessage)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "GMCPDiscordMessage", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	// Try to find the user ID associated with this connection
+	userId := 0
+	for _, user := range users.GetAllActiveUsers() {
+		if user.ConnectionId() == evt.ConnectionId {
+			userId = user.UserId
+			break
+		}
+	}
+
+	if userId == 0 {
+		// No user associated with this connection
+		return events.Cancel
+	}
+
+	// Log the message for debugging
+	mudlog.Info("Mudlet GMCP Discord", "type", evt.Command, "userId", userId, "payload", string(evt.Payload))
+
+	switch evt.Command {
+	case "Hello":
+		// Only send Discord.Info on Hello, as we don't have character info yet
+		discordInfoPayload := struct {
+			ApplicationID string `json:"applicationid"`
+			InviteURL     string `json:"inviteurl"`
+		}{
+			ApplicationID: g.config.DiscordApplicationID,
+			InviteURL:     g.config.DiscordInviteURL,
+		}
+
+		// Send the External.Discord.Info message
+		events.AddToQueue(GMCPOut{
+			UserId:  userId,
+			Module:  "External.Discord.Info",
+			Payload: discordInfoPayload,
+		})
+
+		mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Info in response to Hello", "userId", userId)
+	case "Get":
+		// Get the user record to check if we have character info
+		user := users.GetByUserId(userId)
+		if user == nil || user.Character == nil {
+			// If we don't have character info yet, don't send anything
+			mudlog.Debug("GMCP", "type", "Mudlet", "action", "Ignoring Discord.Get request (no character info yet)", "userId", userId)
+			return events.Continue
+		}
+
+		// We have character info, so send Discord.Status
+		g.sendDiscordStatus(userId)
+		mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Status in response to Get", "userId", userId)
+	case "Status":
+		// Client sent a status update - just log it for now
+		// No specific handling needed
+	}
+
+	return events.Continue
+}
+
+// roomChangeHandler handles the RoomChange event to update Discord status when players change areas/zones
+func (g *GMCPMudletModule) roomChangeHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(events.RoomChange)
+	if !typeOk {
+		return events.Cancel
+	}
+
+	// Only handle player movements (not mobs)
+	if evt.UserId == 0 || evt.MobInstanceId > 0 {
+		return events.Continue
+	}
+
+	// Check if this is a Mudlet client
+	isMudletUser := false
+	if known, exists := g.mudletUsers[evt.UserId]; exists && known {
+		isMudletUser = true
+	} else if g.isMudletClient(evt.UserId) {
+		g.mudletUsers[evt.UserId] = true
+		isMudletUser = true
+	}
+
+	if !isMudletUser {
+		return events.Continue
+	}
+
+	// Load rooms and check for zone change
+	oldRoom := rooms.LoadRoom(evt.FromRoomId)
+	newRoom := rooms.LoadRoom(evt.ToRoomId)
+	if oldRoom == nil || newRoom == nil {
+		return events.Continue
+	}
+
+	// Update Discord status on zone change
+	if oldRoom.Zone != newRoom.Zone {
+		g.sendDiscordStatus(evt.UserId)
+	}
+
+	return events.Continue
+}
+
+// sendDiscordStatus sends the current Discord status information to the client
+func (g *GMCPMudletModule) sendDiscordStatus(userId int) {
+	if userId < 1 {
+		return
+	}
+
+	// Get the user record to access character details
+	user := users.GetByUserId(userId)
+	if user == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord status", "userId", userId)
+		return
+	}
+
+	// Get the current room
+	room := rooms.LoadRoom(user.Character.RoomId)
+	if room == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get room for Discord status", "userId", userId, "roomId", user.Character.RoomId)
+		return
+	}
+
+	// Create a payload for Discord.Status
+	discordStatusPayload := struct {
+		Details       string `json:"details"`
+		State         string `json:"state"`
+		Game          string `json:"game"`
+		LargeImageKey string `json:"large_image_key"`
+		SmallImageKey string `json:"small_image_key"`
+		PartySize     int    `json:"partysize"`
+		PartyMax      int    `json:"partymax"`
+	}{
+		Details:       g.config.DiscordDetails,
+		State:         fmt.Sprintf("Exploring %s", room.Zone),
+		Game:          g.config.DiscordGame,
+		LargeImageKey: g.config.DiscordLargeImageKey,
+		SmallImageKey: g.config.DiscordSmallImageKey,
+		PartySize:     0,
+		PartyMax:      10,
+	}
+
+	// Check if the user is in a party
+	if party := parties.Get(userId); party != nil {
+		// Only set party size if there are 2 or more members
+		if len(party.GetMembers()) >= 2 {
+			discordStatusPayload.PartySize = len(party.GetMembers())
+		}
+	}
+
+	// Send the External.Discord.Status message
+	events.AddToQueue(GMCPOut{
+		UserId:  userId,
+		Module:  "External.Discord.Status",
+		Payload: discordStatusPayload,
+	})
+
+	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Discord status update", "userId", userId, "zone", room.Zone)
+}
+
+// isMudletClient checks if the given user ID is using a Mudlet client
+func (g *GMCPMudletModule) isMudletClient(userId int) bool {
+	if userId < 1 {
+		return false
+	}
+
+	// First check our cache of known Mudlet users
+	if known, exists := g.mudletUsers[userId]; exists {
+		return known
+	}
+
+	// If not in cache, check the connection
+	connId := users.GetConnectionId(userId)
+	if connId == 0 {
+		return false
+	}
+
+	// Check the cache to see if this is a Mudlet client
+	if gmcpData, ok := gmcpModule.cache.Get(connId); ok && gmcpData.Client.IsMudlet {
+		// Store for future reference
+		g.mudletUsers[userId] = true
+		return true
+	}
+
+	return false
 }

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -513,29 +513,35 @@ func (g *GMCPMudletModule) sendMudletConfig(userId int) {
 		return
 	}
 
-	// Get Discord config values - only what we need for Discord.Info
-	appID, inviteURL, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
+	// Check if Discord.Info is enabled
+	enableInfo := user.GetConfigOption("discord_enable_info")
+	if enableInfo == nil || enableInfo.(bool) {
+		// Get Discord config values - only what we need for Discord.Info
+		appID, inviteURL, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
 
-	// Create a payload for Discord.Info - only applicationid and inviteurl
-	discordInfoPayload := struct {
-		ApplicationID string `json:"applicationid"`
-		InviteURL     string `json:"inviteurl"`
-	}{
-		ApplicationID: appID,
-		InviteURL:     inviteURL,
+		// Create a payload for Discord.Info - only applicationid and inviteurl
+		discordInfoPayload := struct {
+			ApplicationID string `json:"applicationid"`
+			InviteURL     string `json:"inviteurl"`
+		}{
+			ApplicationID: appID,
+			InviteURL:     inviteURL,
+		}
+
+		// Send the External.Discord.Info message
+		events.AddToQueue(GMCPOut{
+			UserId:  userId,
+			Module:  "External.Discord.Info",
+			Payload: discordInfoPayload,
+		})
+
+		// Send the Discord Status information with the config values we already have
+		g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
+	} else {
+		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Info package sending disabled for user", "userId", userId)
 	}
 
-	// Send the External.Discord.Info message
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "External.Discord.Info",
-		Payload: discordInfoPayload,
-	})
-
-	// Send the Discord Status information with the config values we already have
-	g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
-
-	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Mudlet package config and Discord info", "userId", userId)
+	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Mudlet package config", "userId", userId)
 }
 
 // sendDiscordStatusWithConfig sends the current Discord status information to the client using provided config values
@@ -548,6 +554,13 @@ func (g *GMCPMudletModule) sendDiscordStatusWithConfig(userId int, largeImageKey
 	user := users.GetByUserId(userId)
 	if user == nil {
 		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord status", "userId", userId)
+		return
+	}
+
+	// Check if Discord.Status is enabled
+	enableStatus := user.GetConfigOption("discord_enable_status")
+	if enableStatus != nil && !enableStatus.(bool) {
+		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Status package sending disabled for user", "userId", userId)
 		return
 	}
 
@@ -587,7 +600,11 @@ func (g *GMCPMudletModule) sendDiscordStatusWithConfig(userId int, largeImageKey
 			if detailsStr != "" {
 				detailsStr += " "
 			}
-			detailsStr += fmt.Sprintf("(lvl. %d)", user.Character.Level)
+			if showName.(bool) {
+				detailsStr += fmt.Sprintf("(lvl. %d)", user.Character.Level)
+			} else {
+				detailsStr += fmt.Sprintf("Level %d", user.Character.Level)
+			}
 		}
 	}
 
@@ -622,9 +639,9 @@ func (g *GMCPMudletModule) sendDiscordStatusWithConfig(userId int, largeImageKey
 			discordStatusPayload.PartySize = len(party.GetMembers())
 			discordStatusPayload.PartyMax = 10
 			if showArea.(bool) {
-				discordStatusPayload.State = fmt.Sprintf("Party in %s", room.Zone)
+				discordStatusPayload.State = fmt.Sprintf("Group in %s", room.Zone)
 			} else {
-				discordStatusPayload.State = "In a party"
+				discordStatusPayload.State = "In group"
 			}
 		}
 	}
@@ -692,26 +709,34 @@ func (g *GMCPMudletModule) discordStatusRequestHandler(e events.Event) events.Li
 	// Get Discord config values once
 	appID, inviteURL, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
 
-	// Create a payload for Discord.Info - only applicationid and inviteurl
-	discordInfoPayload := struct {
-		ApplicationID string `json:"applicationid"`
-		InviteURL     string `json:"inviteurl"`
-	}{
-		ApplicationID: appID,
-		InviteURL:     inviteURL,
-	}
+	// Check if Discord.Info is enabled
+	enableInfo := user.GetConfigOption("discord_enable_info")
+	if enableInfo == nil || enableInfo.(bool) {
+		// Create a payload for Discord.Info - only applicationid and inviteurl
+		discordInfoPayload := struct {
+			ApplicationID string `json:"applicationid"`
+			InviteURL     string `json:"inviteurl"`
+		}{
+			ApplicationID: appID,
+			InviteURL:     inviteURL,
+		}
 
-	// Send the External.Discord.Info message
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "External.Discord.Info",
-		Payload: discordInfoPayload,
-	})
+		// Send the External.Discord.Info message
+		events.AddToQueue(GMCPOut{
+			UserId:  userId,
+			Module:  "External.Discord.Info",
+			Payload: discordInfoPayload,
+		})
+
+		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Discord Info in response to request", "userId", userId)
+	} else {
+		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Info package sending disabled for user", "userId", userId)
+	}
 
 	// Also send Discord Status information with the config values we already have
 	g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
 
-	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Info and Status in response to request", "userId", userId)
+	mudlog.Info("GMCP", "type", "Mudlet", "action", "Processed Discord status request", "userId", userId)
 	return events.Continue
 }
 
@@ -740,37 +765,54 @@ func (g *GMCPMudletModule) discordMessageHandler(e events.Event) events.Listener
 	// Log the message for debugging
 	mudlog.Info("Mudlet GMCP Discord", "type", evt.Command, "userId", userId, "payload", string(evt.Payload))
 
+	// Get user record for checking settings
+	user := users.GetByUserId(userId)
+	if user == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord message handling", "userId", userId)
+		return events.Cancel
+	}
+
 	switch evt.Command {
 	case "Hello":
-		// Only send Discord.Info on Hello, as we don't have character info yet
-		discordInfoPayload := struct {
-			ApplicationID string `json:"applicationid"`
-			InviteURL     string `json:"inviteurl"`
-		}{
-			ApplicationID: g.config.DiscordApplicationID,
-			InviteURL:     g.config.DiscordInviteURL,
+		// Check if Discord.Info is enabled
+		enableInfo := user.GetConfigOption("discord_enable_info")
+		if enableInfo == nil || enableInfo.(bool) {
+			// Only send Discord.Info on Hello, as we don't have character info yet
+			discordInfoPayload := struct {
+				ApplicationID string `json:"applicationid"`
+				InviteURL     string `json:"inviteurl"`
+			}{
+				ApplicationID: g.config.DiscordApplicationID,
+				InviteURL:     g.config.DiscordInviteURL,
+			}
+
+			// Send the External.Discord.Info message
+			events.AddToQueue(GMCPOut{
+				UserId:  userId,
+				Module:  "External.Discord.Info",
+				Payload: discordInfoPayload,
+			})
+
+			mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Info in response to Hello", "userId", userId)
+		} else {
+			mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Info package sending disabled for user", "userId", userId)
 		}
-
-		// Send the External.Discord.Info message
-		events.AddToQueue(GMCPOut{
-			UserId:  userId,
-			Module:  "External.Discord.Info",
-			Payload: discordInfoPayload,
-		})
-
-		mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Info in response to Hello", "userId", userId)
 	case "Get":
-		// Get the user record to check if we have character info
-		user := users.GetByUserId(userId)
-		if user == nil || user.Character == nil {
+		// Check if Discord.Status is enabled
+		enableStatus := user.GetConfigOption("discord_enable_status")
+		if enableStatus == nil || enableStatus.(bool) {
 			// If we don't have character info yet, don't send anything
-			mudlog.Debug("GMCP", "type", "Mudlet", "action", "Ignoring Discord.Get request (no character info yet)", "userId", userId)
-			return events.Continue
-		}
+			if user.Character == nil {
+				mudlog.Debug("GMCP", "type", "Mudlet", "action", "Ignoring Discord.Get request (no character info yet)", "userId", userId)
+				return events.Continue
+			}
 
-		// We have character info, so send Discord.Status
-		g.sendDiscordStatus(userId)
-		mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Status in response to Get", "userId", userId)
+			// We have character info, so send Discord.Status
+			g.sendDiscordStatus(userId)
+			mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Status in response to Get", "userId", userId)
+		} else {
+			mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Status package sending disabled for user", "userId", userId)
+		}
 	case "Status":
 		// Client sent a status update - just log it for now
 		// No specific handling needed
@@ -873,33 +915,50 @@ func (g *GMCPMudletModule) showDiscordHelp(user *users.UserRecord) {
 	// Show current settings
 	user.SendText("\n<ansi fg=\"subtitle\">Current settings:</ansi>\n")
 
+	enableInfo := user.GetConfigOption("discord_enable_info")
+	if enableInfo == nil || enableInfo.(bool) {
+		user.SendText("  Info:   <ansi fg=\"green\">ENABLED</ansi>")
+	} else {
+		user.SendText("  Info:   <ansi fg=\"red\">DISABLED</ansi>")
+	}
+
+	enableStatus := user.GetConfigOption("discord_enable_status")
+	if enableStatus == nil || enableStatus.(bool) {
+		user.SendText("  Status: <ansi fg=\"green\">ENABLED</ansi>")
+	} else {
+		user.SendText("  Status: <ansi fg=\"red\">DISABLED</ansi>")
+	}
+
+	user.SendText("")
+
 	showArea := user.GetConfigOption("discord_show_area")
 	if showArea == nil || showArea.(bool) {
-		user.SendText("  Area:  <ansi fg=\"green\">ENABLED</ansi>")
+		user.SendText("  Area:   <ansi fg=\"green\">ENABLED</ansi>")
 	} else {
-		user.SendText("  Area:  <ansi fg=\"red\">DISABLED</ansi>")
+		user.SendText("  Area:   <ansi fg=\"red\">DISABLED</ansi>")
 	}
 
 	showParty := user.GetConfigOption("discord_show_party")
 	if showParty == nil || showParty.(bool) {
-		user.SendText("  Party: <ansi fg=\"green\">ENABLED</ansi>")
+		user.SendText("  Party:  <ansi fg=\"green\">ENABLED</ansi>")
 	} else {
-		user.SendText("  Party: <ansi fg=\"red\">DISABLED</ansi>")
+		user.SendText("  Party:  <ansi fg=\"red\">DISABLED</ansi>")
 	}
 
 	showName := user.GetConfigOption("discord_show_name")
 	if showName == nil || showName.(bool) {
-		user.SendText("  Name:  <ansi fg=\"green\">ENABLED</ansi>")
+		user.SendText("  Name:   <ansi fg=\"green\">ENABLED</ansi>")
 	} else {
-		user.SendText("  Name:  <ansi fg=\"red\">DISABLED</ansi>")
+		user.SendText("  Name:   <ansi fg=\"red\">DISABLED</ansi>")
 	}
 
 	showLevel := user.GetConfigOption("discord_show_level")
 	if showLevel == nil || showLevel.(bool) {
-		user.SendText("  Level: <ansi fg=\"green\">ENABLED</ansi>")
+		user.SendText("  Level:  <ansi fg=\"green\">ENABLED</ansi>")
 	} else {
-		user.SendText("  Level: <ansi fg=\"red\">DISABLED</ansi>")
+		user.SendText("  Level:  <ansi fg=\"red\">DISABLED</ansi>")
 	}
+
 	user.SendText("\n")
 }
 
@@ -979,6 +1038,93 @@ func (g *GMCPMudletModule) discordCommand(rest string, user *users.UserRecord, r
 					g.sendDiscordStatus(user.UserId)
 				default:
 					user.SendText("\nUsage: discord level on|off\n")
+				}
+			case "info":
+				if len(args) < 2 {
+					user.SendText("\nUsage: discord info on|off\n")
+					return true, nil
+				}
+				switch args[1] {
+				case "on":
+					user.SetConfigOption("discord_enable_info", true)
+					user.SendText("\n<ansi fg=\"green\">Discord.Info package sending enabled.</ansi>\n")
+
+					// Send the Info package immediately if enabled
+					appID, inviteURL, _, _, _, _, _ := g.getDiscordConfig()
+					discordInfoPayload := struct {
+						ApplicationID string `json:"applicationid"`
+						InviteURL     string `json:"inviteurl"`
+					}{
+						ApplicationID: appID,
+						InviteURL:     inviteURL,
+					}
+
+					events.AddToQueue(GMCPOut{
+						UserId:  user.UserId,
+						Module:  "External.Discord.Info",
+						Payload: discordInfoPayload,
+					})
+				case "off":
+					user.SetConfigOption("discord_enable_info", false)
+					user.SendText("\n<ansi fg=\"yellow\">Discord.Info package sending disabled.</ansi>\n")
+
+					// Send an empty Discord.Info package to reset client cache
+					emptyInfoPayload := struct {
+						ApplicationID string `json:"applicationid"`
+						InviteURL     string `json:"inviteurl"`
+					}{
+						ApplicationID: "",
+						InviteURL:     "",
+					}
+
+					events.AddToQueue(GMCPOut{
+						UserId:  user.UserId,
+						Module:  "External.Discord.Info",
+						Payload: emptyInfoPayload,
+					})
+				default:
+					user.SendText("\nUsage: discord info on|off\n")
+				}
+			case "status":
+				if len(args) < 2 {
+					user.SendText("\nUsage: discord status on|off\n")
+					return true, nil
+				}
+				switch args[1] {
+				case "on":
+					user.SetConfigOption("discord_enable_status", true)
+					user.SendText("\n<ansi fg=\"green\">Discord.Status package sending enabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				case "off":
+					user.SetConfigOption("discord_enable_status", false)
+					user.SendText("\n<ansi fg=\"yellow\">Discord.Status package sending disabled.</ansi>\n")
+
+					// Send an empty Discord.Status package to reset client cache
+					emptyStatusPayload := struct {
+						Details       string `json:"details"`
+						State         string `json:"state"`
+						Game          string `json:"game"`
+						LargeImageKey string `json:"large_image_key"`
+						SmallImageKey string `json:"small_image_key"`
+						StartTime     int64  `json:"starttime"`
+						PartySize     int    `json:"partysize,omitempty"`
+						PartyMax      int    `json:"partymax,omitempty"`
+					}{
+						Details:       "",
+						State:         "",
+						Game:          "",
+						LargeImageKey: "",
+						SmallImageKey: "",
+						StartTime:     0,
+					}
+
+					events.AddToQueue(GMCPOut{
+						UserId:  user.UserId,
+						Module:  "External.Discord.Status",
+						Payload: emptyStatusPayload,
+					})
+				default:
+					user.SendText("\nUsage: discord status on|off\n")
 				}
 			default:
 				// Show help for unknown commands

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -40,7 +40,6 @@ type MudletConfig struct {
 	DiscordLargeImageKey string `json:"discord_large_image_key" yaml:"discord_large_image_key"`
 	DiscordDetails       string `json:"discord_details" yaml:"discord_details"`
 	DiscordState         string `json:"discord_state" yaml:"discord_state"`
-	DiscordGame          string `json:"discord_game" yaml:"discord_game"`
 	DiscordSmallImageKey string `json:"discord_small_image_key" yaml:"discord_small_image_key"`
 }
 
@@ -75,72 +74,44 @@ type GMCPDiscordMessage struct {
 
 func (g GMCPDiscordMessage) Type() string { return `GMCPDiscordMessage` }
 
+// Default configuration values
+var defaultConfig = MudletConfig{
+	// Mapper configuration
+	MapperVersion: "1",
+	MapperURL:     "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/GoMudMapper.mpackage",
+
+	// UI configuration
+	UIVersion: "1",
+	UIURL:     "https://github.com/GoMudEngine/MudletUI/releases/latest/download/GoMudUI.mpackage",
+
+	// Map data configuration
+	MapVersion: "1",
+	MapURL:     "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/gomud.dat",
+
+	// Discord Rich Presence configuration
+	DiscordApplicationID: "1298377884154724412",           // Default GoMud Discord Server
+	DiscordInviteURL:     "https://discord.gg/FaauSYej3n", // Default GoMud Discord Server
+	DiscordDetails:       "Using GoMudEngine",
+	DiscordState:         "Exploring the world",
+	DiscordLargeImageKey: "server-icon",
+	DiscordSmallImageKey: "character-icon",
+}
+
 func init() {
-	// Set up a default configuration first
+	// Create module with basic structure
 	g := GMCPMudletModule{
-		plug: plugins.New(`gmcp.Mudlet`, `1.0`),
-		config: MudletConfig{
-			MapperVersion: "1",                                                                                         // Default value
-			MapperURL:     "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/GoMudMapper.mpackage", // Default value
-			UIVersion:     "1",                                                                                         // Default value
-			UIURL:         "https://github.com/GoMudEngine/MudletUI/releases/latest/download/GoMudUI.mpackage",         // Default value
-			MapVersion:    "1",                                                                                         // Default value
-			MapURL:        "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/gomud.dat",            // Default value
-			// Discord defaults
-			DiscordApplicationID: "1298377884154724412",           // Default value
-			DiscordInviteURL:     "https://discord.gg/FaauSYej3n", // Default value
-			DiscordLargeImageKey: "server-icon",                   // Default value
-			DiscordDetails:       "Playing on GoMud",              // Default value
-			DiscordState:         "Exploring the world",           // Default value
-			DiscordGame:          "GoMud",                         // Default value
-			DiscordSmallImageKey: "character-icon",                // Default value
-		},
-		mudletUsers: make(map[int]bool), // Initialize the mudletUsers map
+		plug:        plugins.New(`gmcp.Mudlet`, `1.0`),
+		mudletUsers: make(map[int]bool),
 	}
 
-	// Attach embedded filesystem without logging errors
-	_ = g.plug.AttachFileSystem(files)
+	// Attach filesystem with proper error handling
+	if err := g.plug.AttachFileSystem(files); err != nil {
+		panic(err)
+	}
 
-	// Load config values from plugin config system
-	if mapperVersion, ok := g.plug.Config.Get(`MapperVersion`).(string); ok {
-		g.config.MapperVersion = mapperVersion
-	}
-	if mapperURL, ok := g.plug.Config.Get(`MapperURL`).(string); ok {
-		g.config.MapperURL = mapperURL
-	}
-	if uiVersion, ok := g.plug.Config.Get(`UIVersion`).(string); ok {
-		g.config.UIVersion = uiVersion
-	}
-	if uiURL, ok := g.plug.Config.Get(`UIURL`).(string); ok {
-		g.config.UIURL = uiURL
-	}
-	if mapVersion, ok := g.plug.Config.Get(`MapVersion`).(string); ok {
-		g.config.MapVersion = mapVersion
-	}
-	if mapURL, ok := g.plug.Config.Get(`MapURL`).(string); ok {
-		g.config.MapURL = mapURL
-	}
-	if discordAppID, ok := g.plug.Config.Get(`DiscordApplicationID`).(string); ok {
-		g.config.DiscordApplicationID = discordAppID
-	}
-	if discordInviteURL, ok := g.plug.Config.Get(`DiscordInviteURL`).(string); ok {
-		g.config.DiscordInviteURL = discordInviteURL
-	}
-	if discordLargeImageKey, ok := g.plug.Config.Get(`DiscordLargeImageKey`).(string); ok {
-		g.config.DiscordLargeImageKey = discordLargeImageKey
-	}
-	if discordDetails, ok := g.plug.Config.Get(`DiscordDetails`).(string); ok {
-		g.config.DiscordDetails = discordDetails
-	}
-	if discordState, ok := g.plug.Config.Get(`DiscordState`).(string); ok {
-		g.config.DiscordState = discordState
-	}
-	if discordGame, ok := g.plug.Config.Get(`DiscordGame`).(string); ok {
-		g.config.DiscordGame = discordGame
-	}
-	if discordSmallImageKey, ok := g.plug.Config.Get(`DiscordSmallImageKey`).(string); ok {
-		g.config.DiscordSmallImageKey = discordSmallImageKey
-	}
+	// Register callbacks for load/save
+	g.plug.Callbacks.SetOnLoad(g.load)
+	g.plug.Callbacks.SetOnSave(g.save)
 
 	// Register event listeners
 	events.RegisterListener(events.PlayerSpawn{}, g.playerSpawnHandler)
@@ -148,11 +119,145 @@ func init() {
 	events.RegisterListener(GMCPDiscordStatusRequest{}, g.discordStatusRequestHandler)
 	events.RegisterListener(GMCPDiscordMessage{}, g.discordMessageHandler)
 	events.RegisterListener(events.RoomChange{}, g.roomChangeHandler)
+	events.RegisterListener(events.PartyUpdated{}, g.partyUpdateHandler)
 
-	// Register the Mudlet-specific user commands - set as hidden (true for first bool)
+	// Register the Mudlet-specific user commands
 	g.plug.AddUserCommand("mudletmap", g.sendMapCommand, true, false)
 	g.plug.AddUserCommand("mudletui", g.sendUICommand, false, false)
 	g.plug.AddUserCommand("checkclient", g.checkClientCommand, true, false)
+}
+
+// load handles loading configuration from the plugin's storage
+func (g *GMCPMudletModule) load() {
+	// Start with default values
+	g.config = defaultConfig
+
+	// Load individual config values
+	if mapperVersion, ok := g.plug.Config.Get(`mapper_version`).(string); ok {
+		g.config.MapperVersion = mapperVersion
+	}
+	if mapperURL, ok := g.plug.Config.Get(`mapper_url`).(string); ok {
+		g.config.MapperURL = mapperURL
+	}
+	if uiVersion, ok := g.plug.Config.Get(`ui_version`).(string); ok {
+		g.config.UIVersion = uiVersion
+	}
+	if uiURL, ok := g.plug.Config.Get(`ui_url`).(string); ok {
+		g.config.UIURL = uiURL
+	}
+	if mapVersion, ok := g.plug.Config.Get(`map_version`).(string); ok {
+		g.config.MapVersion = mapVersion
+	}
+	if mapURL, ok := g.plug.Config.Get(`map_url`).(string); ok {
+		g.config.MapURL = mapURL
+	}
+	if discordAppID, ok := g.plug.Config.Get(`discord_application_id`).(string); ok {
+		g.config.DiscordApplicationID = discordAppID
+	}
+	if discordInviteURL, ok := g.plug.Config.Get(`discord_invite_url`).(string); ok {
+		g.config.DiscordInviteURL = discordInviteURL
+	}
+	if discordLargeImageKey, ok := g.plug.Config.Get(`discord_large_image_key`).(string); ok {
+		g.config.DiscordLargeImageKey = discordLargeImageKey
+	}
+	if discordDetails, ok := g.plug.Config.Get(`discord_details`).(string); ok {
+		g.config.DiscordDetails = discordDetails
+	}
+	if discordState, ok := g.plug.Config.Get(`discord_state`).(string); ok {
+		g.config.DiscordState = discordState
+	}
+	if discordSmallImageKey, ok := g.plug.Config.Get(`discord_small_image_key`).(string); ok {
+		g.config.DiscordSmallImageKey = discordSmallImageKey
+	}
+}
+
+// save handles saving configuration to the plugin's storage
+func (g *GMCPMudletModule) save() {
+	g.plug.WriteStruct(`mudlet_config`, g.config)
+}
+
+// getMapperConfig returns the mapper configuration with defaults
+func (g *GMCPMudletModule) getMapperConfig() (version, url string) {
+	// Start with default values from defaultConfig
+	version = defaultConfig.MapperVersion
+	url = defaultConfig.MapperURL
+
+	// Check for overrides in plugin config
+	if v, ok := g.plug.Config.Get(`mapper_version`).(string); ok {
+		version = v
+	}
+	if u, ok := g.plug.Config.Get(`mapper_url`).(string); ok {
+		url = u
+	}
+	return
+}
+
+// getUIConfig returns the UI configuration with defaults
+func (g *GMCPMudletModule) getUIConfig() (version, url string) {
+	// Start with default values from defaultConfig
+	version = defaultConfig.UIVersion
+	url = defaultConfig.UIURL
+
+	// Check for overrides in plugin config
+	if v, ok := g.plug.Config.Get(`ui_version`).(string); ok {
+		version = v
+	}
+	if u, ok := g.plug.Config.Get(`ui_url`).(string); ok {
+		url = u
+	}
+	return
+}
+
+// getMapConfig returns the map configuration with defaults
+func (g *GMCPMudletModule) getMapConfig() (version, url string) {
+	// Start with default values from defaultConfig
+	version = defaultConfig.MapVersion
+	url = defaultConfig.MapURL
+
+	// Check for overrides in plugin config
+	if v, ok := g.plug.Config.Get(`map_version`).(string); ok {
+		version = v
+	}
+	if u, ok := g.plug.Config.Get(`map_url`).(string); ok {
+		url = u
+	}
+	return
+}
+
+// getDiscordConfig returns the Discord configuration with defaults
+func (g *GMCPMudletModule) getDiscordConfig() (appID, inviteURL, largeImageKey, details, state, game, smallImageKey string) {
+	// Start with default values from defaultConfig
+	appID = defaultConfig.DiscordApplicationID
+	inviteURL = defaultConfig.DiscordInviteURL
+	largeImageKey = defaultConfig.DiscordLargeImageKey
+	details = defaultConfig.DiscordDetails
+	state = defaultConfig.DiscordState
+	smallImageKey = defaultConfig.DiscordSmallImageKey
+
+	// Get game name from server config - this is the source of truth
+	game = configs.GetServerConfig().MudName.String()
+
+	// Check for overrides in plugin config
+	if id, ok := g.plug.Config.Get(`discord_application_id`).(string); ok {
+		appID = id
+	}
+	if url, ok := g.plug.Config.Get(`discord_invite_url`).(string); ok {
+		inviteURL = url
+	}
+	if key, ok := g.plug.Config.Get(`discord_large_image_key`).(string); ok {
+		largeImageKey = key
+	}
+	if d, ok := g.plug.Config.Get(`discord_details`).(string); ok {
+		details = d
+	}
+	if s, ok := g.plug.Config.Get(`discord_state`).(string); ok {
+		state = s
+	}
+	if key, ok := g.plug.Config.Get(`discord_small_image_key`).(string); ok {
+		smallImageKey = key
+	}
+
+	return
 }
 
 // sendUICommand is a user command that sends UI-related GMCP messages to Mudlet clients
@@ -232,13 +337,16 @@ func (g *GMCPMudletModule) sendMudletUIInstall(userId int) {
 		return
 	}
 
+	// Get UI config values
+	uiVersion, uiURL := g.getUIConfig()
+
 	// Create a payload for UI installation
 	payload := struct {
 		Version string `json:"version"`
 		URL     string `json:"url"`
 	}{
-		Version: g.config.UIVersion,
-		URL:     g.config.UIURL,
+		Version: uiVersion,
+		URL:     uiURL,
 	}
 
 	// Send the Client.GUI message
@@ -320,9 +428,12 @@ func (g *GMCPMudletModule) sendMudletMapConfig(userId int) {
 		return
 	}
 
+	// Get map config values
+	_, mapURL := g.getMapConfig()
+
 	// Create a payload for the Client.Map message
 	mapConfig := map[string]string{
-		"url": g.config.MapURL,
+		"url": mapURL,
 	}
 
 	// Send the Client.Map message
@@ -375,13 +486,16 @@ func (g *GMCPMudletModule) sendMudletConfig(userId int) {
 		return
 	}
 
+	// Get mapper config values
+	mapperVersion, mapperURL := g.getMapperConfig()
+
 	// Create a GUI payload with mapper version and url
 	guiPayload := struct {
 		Version string `json:"version"`
 		URL     string `json:"url"`
 	}{
-		Version: g.config.MapperVersion,
-		URL:     g.config.MapperURL,
+		Version: mapperVersion,
+		URL:     mapperURL,
 	}
 
 	// Send the Client.GUI message with mapper version and URL
@@ -398,13 +512,16 @@ func (g *GMCPMudletModule) sendMudletConfig(userId int) {
 		return
 	}
 
+	// Get Discord config values - only what we need for Discord.Info
+	appID, inviteURL, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
+
 	// Create a payload for Discord.Info - only applicationid and inviteurl
 	discordInfoPayload := struct {
 		ApplicationID string `json:"applicationid"`
 		InviteURL     string `json:"inviteurl"`
 	}{
-		ApplicationID: g.config.DiscordApplicationID,
-		InviteURL:     g.config.DiscordInviteURL,
+		ApplicationID: appID,
+		InviteURL:     inviteURL,
 	}
 
 	// Send the External.Discord.Info message
@@ -414,10 +531,74 @@ func (g *GMCPMudletModule) sendMudletConfig(userId int) {
 		Payload: discordInfoPayload,
 	})
 
-	// Send the Discord Status information
-	g.sendDiscordStatus(userId)
+	// Send the Discord Status information with the config values we already have
+	g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
 
 	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Mudlet package config and Discord info", "userId", userId)
+}
+
+// sendDiscordStatusWithConfig sends the current Discord status information to the client using provided config values
+func (g *GMCPMudletModule) sendDiscordStatusWithConfig(userId int, largeImageKey, details, state, game, smallImageKey string) {
+	if userId < 1 {
+		return
+	}
+
+	// Get the user record to access character details
+	user := users.GetByUserId(userId)
+	if user == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord status", "userId", userId)
+		return
+	}
+
+	// Get the current room
+	room := rooms.LoadRoom(user.Character.RoomId)
+	if room == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get room for Discord status", "userId", userId, "roomId", user.Character.RoomId)
+		return
+	}
+
+	// Create a payload for Discord.Status
+	discordStatusPayload := struct {
+		Details       string `json:"details"`
+		State         string `json:"state"`
+		Game          string `json:"game"`
+		LargeImageKey string `json:"large_image_key"`
+		SmallImageKey string `json:"small_image_key"`
+		StartTime     int64  `json:"starttime"`
+		PartySize     int    `json:"partysize,omitempty"`
+		PartyMax      int    `json:"partymax,omitempty"`
+	}{
+		Details:       details,
+		State:         fmt.Sprintf("Exploring %s", room.Zone),
+		Game:          game,
+		LargeImageKey: largeImageKey,
+		SmallImageKey: smallImageKey,
+		StartTime:     user.GetConnectTime().Unix(),
+	}
+
+	// Check if the user is in a party
+	if party := parties.Get(userId); party != nil {
+		// Set party size for any party (including solo parties)
+		discordStatusPayload.PartySize = len(party.GetMembers())
+		discordStatusPayload.PartyMax = 10
+		discordStatusPayload.State = fmt.Sprintf("Party in %s", room.Zone)
+	}
+
+	// Send the External.Discord.Status message
+	events.AddToQueue(GMCPOut{
+		UserId:  userId,
+		Module:  "External.Discord.Status",
+		Payload: discordStatusPayload,
+	})
+
+	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Discord status update", "userId", userId, "zone", room.Zone)
+}
+
+// sendDiscordStatus sends the current Discord status information to the client
+func (g *GMCPMudletModule) sendDiscordStatus(userId int) {
+	// Get Discord config values
+	_, _, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
+	g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
 }
 
 // checkClientCommand checks if the player is using Mudlet and shows information if they are
@@ -463,13 +644,16 @@ func (g *GMCPMudletModule) discordStatusRequestHandler(e events.Event) events.Li
 		return events.Cancel
 	}
 
+	// Get Discord config values once
+	appID, inviteURL, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
+
 	// Create a payload for Discord.Info - only applicationid and inviteurl
 	discordInfoPayload := struct {
 		ApplicationID string `json:"applicationid"`
 		InviteURL     string `json:"inviteurl"`
 	}{
-		ApplicationID: g.config.DiscordApplicationID,
-		InviteURL:     g.config.DiscordInviteURL,
+		ApplicationID: appID,
+		InviteURL:     inviteURL,
 	}
 
 	// Send the External.Discord.Info message
@@ -479,8 +663,8 @@ func (g *GMCPMudletModule) discordStatusRequestHandler(e events.Event) events.Li
 		Payload: discordInfoPayload,
 	})
 
-	// Also send Discord Status information
-	g.sendDiscordStatus(userId)
+	// Also send Discord Status information with the config values we already have
+	g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
 
 	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Info and Status in response to request", "userId", userId)
 	return events.Continue
@@ -590,63 +774,6 @@ func (g *GMCPMudletModule) roomChangeHandler(e events.Event) events.ListenerRetu
 	return events.Continue
 }
 
-// sendDiscordStatus sends the current Discord status information to the client
-func (g *GMCPMudletModule) sendDiscordStatus(userId int) {
-	if userId < 1 {
-		return
-	}
-
-	// Get the user record to access character details
-	user := users.GetByUserId(userId)
-	if user == nil {
-		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord status", "userId", userId)
-		return
-	}
-
-	// Get the current room
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get room for Discord status", "userId", userId, "roomId", user.Character.RoomId)
-		return
-	}
-
-	// Create a payload for Discord.Status
-	discordStatusPayload := struct {
-		Details       string `json:"details"`
-		State         string `json:"state"`
-		Game          string `json:"game"`
-		LargeImageKey string `json:"large_image_key"`
-		SmallImageKey string `json:"small_image_key"`
-		PartySize     int    `json:"partysize"`
-		PartyMax      int    `json:"partymax"`
-	}{
-		Details:       g.config.DiscordDetails,
-		State:         fmt.Sprintf("Exploring %s", room.Zone),
-		Game:          g.config.DiscordGame,
-		LargeImageKey: g.config.DiscordLargeImageKey,
-		SmallImageKey: g.config.DiscordSmallImageKey,
-		PartySize:     0,
-		PartyMax:      10,
-	}
-
-	// Check if the user is in a party
-	if party := parties.Get(userId); party != nil {
-		// Only set party size if there are 2 or more members
-		if len(party.GetMembers()) >= 2 {
-			discordStatusPayload.PartySize = len(party.GetMembers())
-		}
-	}
-
-	// Send the External.Discord.Status message
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "External.Discord.Status",
-		Payload: discordStatusPayload,
-	})
-
-	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Discord status update", "userId", userId, "zone", room.Zone)
-}
-
 // isMudletClient checks if the given user ID is using a Mudlet client
 func (g *GMCPMudletModule) isMudletClient(userId int) bool {
 	if userId < 1 {
@@ -672,4 +799,23 @@ func (g *GMCPMudletModule) isMudletClient(userId int) bool {
 	}
 
 	return false
+}
+
+// partyUpdateHandler handles party membership changes and updates Discord status
+func (g *GMCPMudletModule) partyUpdateHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(events.PartyUpdated)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "PartyUpdated", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	// Update Discord status for all users in the party
+	for _, userId := range evt.UserIds {
+		// Only send updates to Mudlet clients
+		if g.isMudletClient(userId) {
+			g.sendDiscordStatus(userId)
+		}
+	}
+
+	return events.Continue
 }

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -125,6 +125,7 @@ func init() {
 	g.plug.AddUserCommand("mudletmap", g.sendMapCommand, true, false)
 	g.plug.AddUserCommand("mudletui", g.sendUICommand, false, false)
 	g.plug.AddUserCommand("checkclient", g.checkClientCommand, true, false)
+	g.plug.AddUserCommand("discord", g.discordCommand, true, false)
 }
 
 // load handles loading configuration from the plugin's storage
@@ -557,6 +558,39 @@ func (g *GMCPMudletModule) sendDiscordStatusWithConfig(userId int, largeImageKey
 		return
 	}
 
+	// Check display preferences (default to true if not set)
+	showArea := user.GetConfigOption("discord_show_area")
+	if showArea == nil {
+		showArea = true
+	}
+	showParty := user.GetConfigOption("discord_show_party")
+	if showParty == nil {
+		showParty = true
+	}
+	showName := user.GetConfigOption("discord_show_name")
+	if showName == nil {
+		showName = true
+	}
+	showLevel := user.GetConfigOption("discord_show_level")
+	if showLevel == nil {
+		showLevel = true
+	}
+
+	// Build the details string based on preferences
+	detailsStr := details
+	if showName.(bool) || showLevel.(bool) {
+		detailsStr = ""
+		if showName.(bool) {
+			detailsStr = user.Character.Name
+		}
+		if showLevel.(bool) {
+			if detailsStr != "" {
+				detailsStr += " "
+			}
+			detailsStr += fmt.Sprintf("(lvl. %d)", user.Character.Level)
+		}
+	}
+
 	// Create a payload for Discord.Status
 	discordStatusPayload := struct {
 		Details       string `json:"details"`
@@ -568,20 +602,31 @@ func (g *GMCPMudletModule) sendDiscordStatusWithConfig(userId int, largeImageKey
 		PartySize     int    `json:"partysize,omitempty"`
 		PartyMax      int    `json:"partymax,omitempty"`
 	}{
-		Details:       details,
-		State:         fmt.Sprintf("Exploring %s", room.Zone),
+		Details:       detailsStr,
+		State:         "Exploring the world", // Default state
 		Game:          game,
 		LargeImageKey: largeImageKey,
 		SmallImageKey: smallImageKey,
 		StartTime:     user.GetConnectTime().Unix(),
 	}
 
+	// Only show area if enabled
+	if showArea.(bool) {
+		discordStatusPayload.State = fmt.Sprintf("Exploring %s", room.Zone)
+	}
+
 	// Check if the user is in a party
 	if party := parties.Get(userId); party != nil {
-		// Set party size for any party (including solo parties)
-		discordStatusPayload.PartySize = len(party.GetMembers())
-		discordStatusPayload.PartyMax = 10
-		discordStatusPayload.State = fmt.Sprintf("Party in %s", room.Zone)
+		// Only show party info if enabled
+		if showParty.(bool) {
+			discordStatusPayload.PartySize = len(party.GetMembers())
+			discordStatusPayload.PartyMax = 10
+			if showArea.(bool) {
+				discordStatusPayload.State = fmt.Sprintf("Party in %s", room.Zone)
+			} else {
+				discordStatusPayload.State = "In a party"
+			}
+		}
 	}
 
 	// Send the External.Discord.Status message
@@ -818,4 +863,139 @@ func (g *GMCPMudletModule) partyUpdateHandler(e events.Event) events.ListenerRet
 	}
 
 	return events.Continue
+}
+
+// showDiscordHelp displays the help text and current settings for the discord command
+func (g *GMCPMudletModule) showDiscordHelp(user *users.UserRecord) {
+	// Use the help system to show the discord help
+	usercommands.Help("discord", user, nil, 0)
+
+	// Show current settings
+	user.SendText("\n<ansi fg=\"subtitle\">Current settings:</ansi>\n")
+
+	showArea := user.GetConfigOption("discord_show_area")
+	if showArea == nil || showArea.(bool) {
+		user.SendText("  Area:  <ansi fg=\"green\">ENABLED</ansi>")
+	} else {
+		user.SendText("  Area:  <ansi fg=\"red\">DISABLED</ansi>")
+	}
+
+	showParty := user.GetConfigOption("discord_show_party")
+	if showParty == nil || showParty.(bool) {
+		user.SendText("  Party: <ansi fg=\"green\">ENABLED</ansi>")
+	} else {
+		user.SendText("  Party: <ansi fg=\"red\">DISABLED</ansi>")
+	}
+
+	showName := user.GetConfigOption("discord_show_name")
+	if showName == nil || showName.(bool) {
+		user.SendText("  Name:  <ansi fg=\"green\">ENABLED</ansi>")
+	} else {
+		user.SendText("  Name:  <ansi fg=\"red\">DISABLED</ansi>")
+	}
+
+	showLevel := user.GetConfigOption("discord_show_level")
+	if showLevel == nil || showLevel.(bool) {
+		user.SendText("  Level: <ansi fg=\"green\">ENABLED</ansi>")
+	} else {
+		user.SendText("  Level: <ansi fg=\"red\">DISABLED</ansi>")
+	}
+	user.SendText("\n")
+}
+
+// discordCommand handles the discord command for controlling Discord status display
+func (g *GMCPMudletModule) discordCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	// Only send if the client is Mudlet
+	connId := user.ConnectionId()
+	if gmcpData, ok := gmcpModule.cache.Get(connId); ok && gmcpData.Client.IsMudlet {
+		// Process command arguments
+		args := strings.Fields(rest)
+		if len(args) > 0 {
+			switch args[0] {
+			case "area":
+				if len(args) < 2 {
+					user.SendText("\nUsage: discord area on|off\n")
+					return true, nil
+				}
+				switch args[1] {
+				case "on":
+					user.SetConfigOption("discord_show_area", true)
+					user.SendText("\n<ansi fg=\"green\">Area display in Discord status enabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				case "off":
+					user.SetConfigOption("discord_show_area", false)
+					user.SendText("\n<ansi fg=\"yellow\">Area display in Discord status disabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				default:
+					user.SendText("\nUsage: discord area on|off\n")
+				}
+			case "party":
+				if len(args) < 2 {
+					user.SendText("\nUsage: discord party on|off\n")
+					return true, nil
+				}
+				switch args[1] {
+				case "on":
+					user.SetConfigOption("discord_show_party", true)
+					user.SendText("\n<ansi fg=\"green\">Party display in Discord status enabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				case "off":
+					user.SetConfigOption("discord_show_party", false)
+					user.SendText("\n<ansi fg=\"yellow\">Party display in Discord status disabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				default:
+					user.SendText("\nUsage: discord party on|off\n")
+				}
+			case "name":
+				if len(args) < 2 {
+					user.SendText("\nUsage: discord name on|off\n")
+					return true, nil
+				}
+				switch args[1] {
+				case "on":
+					user.SetConfigOption("discord_show_name", true)
+					user.SendText("\n<ansi fg=\"green\">Character name display in Discord status enabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				case "off":
+					user.SetConfigOption("discord_show_name", false)
+					user.SendText("\n<ansi fg=\"yellow\">Character name display in Discord status disabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				default:
+					user.SendText("\nUsage: discord name on|off\n")
+				}
+			case "level":
+				if len(args) < 2 {
+					user.SendText("\nUsage: discord level on|off\n")
+					return true, nil
+				}
+				switch args[1] {
+				case "on":
+					user.SetConfigOption("discord_show_level", true)
+					user.SendText("\n<ansi fg=\"green\">Level display in Discord status enabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				case "off":
+					user.SetConfigOption("discord_show_level", false)
+					user.SendText("\n<ansi fg=\"yellow\">Level display in Discord status disabled.</ansi>\n")
+					g.sendDiscordStatus(user.UserId)
+				default:
+					user.SendText("\nUsage: discord level on|off\n")
+				}
+			default:
+				// Show help for unknown commands
+				g.showDiscordHelp(user)
+			}
+		} else {
+			// No arguments provided - show help
+			g.showDiscordHelp(user)
+		}
+
+		// Return true to indicate the command was handled
+		return true, nil
+	} else {
+		// Client is not Mudlet
+		user.SendText("\n<ansi fg=\"red\">This command is only available for Mudlet clients.</ansi> You are currently using: " + gmcpData.Client.Name + "\n")
+	}
+
+	// Command was handled
+	return true, nil
 }

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -74,29 +74,6 @@ type GMCPDiscordMessage struct {
 
 func (g GMCPDiscordMessage) Type() string { return `GMCPDiscordMessage` }
 
-// Default configuration values
-var defaultConfig = MudletConfig{
-	// Mapper configuration
-	MapperVersion: "1",
-	MapperURL:     "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/GoMudMapper.mpackage",
-
-	// UI configuration
-	UIVersion: "1",
-	UIURL:     "https://github.com/GoMudEngine/MudletUI/releases/latest/download/GoMudUI.mpackage",
-
-	// Map data configuration
-	MapVersion: "1",
-	MapURL:     "https://github.com/GoMudEngine/MudletMapper/releases/latest/download/gomud.dat",
-
-	// Discord Rich Presence configuration
-	DiscordApplicationID: "1298377884154724412",           // Default GoMud Discord Server
-	DiscordInviteURL:     "https://discord.gg/FaauSYej3n", // Default GoMud Discord Server
-	DiscordDetails:       "Using GoMudEngine",
-	DiscordState:         "Exploring the world",
-	DiscordLargeImageKey: "server-icon",
-	DiscordSmallImageKey: "character-icon",
-}
-
 func init() {
 	// Create module with basic structure
 	g := GMCPMudletModule{
@@ -115,6 +92,7 @@ func init() {
 
 	// Register event listeners
 	events.RegisterListener(events.PlayerSpawn{}, g.playerSpawnHandler)
+	events.RegisterListener(events.PlayerDespawn{}, g.playerDespawnHandler)
 	events.RegisterListener(GMCPMudletDetected{}, g.mudletDetectedHandler)
 	events.RegisterListener(GMCPDiscordStatusRequest{}, g.discordStatusRequestHandler)
 	events.RegisterListener(GMCPDiscordMessage{}, g.discordMessageHandler)
@@ -128,48 +106,29 @@ func init() {
 	g.plug.AddUserCommand("discord", g.discordCommand, true, false)
 }
 
+// Helper function to load a config string from the plugin's configuration
+func loadConfigString(p *plugins.Plugin, key string) string {
+	if val, ok := p.Config.Get(key).(string); ok {
+		return val
+	}
+	return ""
+}
+
 // load handles loading configuration from the plugin's storage
 func (g *GMCPMudletModule) load() {
-	// Start with default values
-	g.config = defaultConfig
-
-	// Load individual config values
-	if mapperVersion, ok := g.plug.Config.Get(`mapper_version`).(string); ok {
-		g.config.MapperVersion = mapperVersion
-	}
-	if mapperURL, ok := g.plug.Config.Get(`mapper_url`).(string); ok {
-		g.config.MapperURL = mapperURL
-	}
-	if uiVersion, ok := g.plug.Config.Get(`ui_version`).(string); ok {
-		g.config.UIVersion = uiVersion
-	}
-	if uiURL, ok := g.plug.Config.Get(`ui_url`).(string); ok {
-		g.config.UIURL = uiURL
-	}
-	if mapVersion, ok := g.plug.Config.Get(`map_version`).(string); ok {
-		g.config.MapVersion = mapVersion
-	}
-	if mapURL, ok := g.plug.Config.Get(`map_url`).(string); ok {
-		g.config.MapURL = mapURL
-	}
-	if discordAppID, ok := g.plug.Config.Get(`discord_application_id`).(string); ok {
-		g.config.DiscordApplicationID = discordAppID
-	}
-	if discordInviteURL, ok := g.plug.Config.Get(`discord_invite_url`).(string); ok {
-		g.config.DiscordInviteURL = discordInviteURL
-	}
-	if discordLargeImageKey, ok := g.plug.Config.Get(`discord_large_image_key`).(string); ok {
-		g.config.DiscordLargeImageKey = discordLargeImageKey
-	}
-	if discordDetails, ok := g.plug.Config.Get(`discord_details`).(string); ok {
-		g.config.DiscordDetails = discordDetails
-	}
-	if discordState, ok := g.plug.Config.Get(`discord_state`).(string); ok {
-		g.config.DiscordState = discordState
-	}
-	if discordSmallImageKey, ok := g.plug.Config.Get(`discord_small_image_key`).(string); ok {
-		g.config.DiscordSmallImageKey = discordSmallImageKey
-	}
+	// Load config values directly from embedded config or overrides
+	g.config.MapperVersion = loadConfigString(g.plug, "mapper_version")
+	g.config.MapperURL = loadConfigString(g.plug, "mapper_url")
+	g.config.UIVersion = loadConfigString(g.plug, "ui_version")
+	g.config.UIURL = loadConfigString(g.plug, "ui_url")
+	g.config.MapVersion = loadConfigString(g.plug, "map_version")
+	g.config.MapURL = loadConfigString(g.plug, "map_url")
+	g.config.DiscordApplicationID = loadConfigString(g.plug, "discord_application_id")
+	g.config.DiscordInviteURL = loadConfigString(g.plug, "discord_invite_url")
+	g.config.DiscordLargeImageKey = loadConfigString(g.plug, "discord_large_image_key")
+	g.config.DiscordDetails = loadConfigString(g.plug, "discord_details")
+	g.config.DiscordState = loadConfigString(g.plug, "discord_state")
+	g.config.DiscordSmallImageKey = loadConfigString(g.plug, "discord_small_image_key")
 }
 
 // save handles saving configuration to the plugin's storage
@@ -177,698 +136,14 @@ func (g *GMCPMudletModule) save() {
 	g.plug.WriteStruct(`mudlet_config`, g.config)
 }
 
-// getMapperConfig returns the mapper configuration with defaults
-func (g *GMCPMudletModule) getMapperConfig() (version, url string) {
-	// Start with default values from defaultConfig
-	version = defaultConfig.MapperVersion
-	url = defaultConfig.MapperURL
-
-	// Check for overrides in plugin config
-	if v, ok := g.plug.Config.Get(`mapper_version`).(string); ok {
-		version = v
-	}
-	if u, ok := g.plug.Config.Get(`mapper_url`).(string); ok {
-		url = u
-	}
-	return
-}
-
-// getUIConfig returns the UI configuration with defaults
-func (g *GMCPMudletModule) getUIConfig() (version, url string) {
-	// Start with default values from defaultConfig
-	version = defaultConfig.UIVersion
-	url = defaultConfig.UIURL
-
-	// Check for overrides in plugin config
-	if v, ok := g.plug.Config.Get(`ui_version`).(string); ok {
-		version = v
-	}
-	if u, ok := g.plug.Config.Get(`ui_url`).(string); ok {
-		url = u
-	}
-	return
-}
-
-// getMapConfig returns the map configuration with defaults
-func (g *GMCPMudletModule) getMapConfig() (version, url string) {
-	// Start with default values from defaultConfig
-	version = defaultConfig.MapVersion
-	url = defaultConfig.MapURL
-
-	// Check for overrides in plugin config
-	if v, ok := g.plug.Config.Get(`map_version`).(string); ok {
-		version = v
-	}
-	if u, ok := g.plug.Config.Get(`map_url`).(string); ok {
-		url = u
-	}
-	return
-}
-
-// getDiscordConfig returns the Discord configuration with defaults
-func (g *GMCPMudletModule) getDiscordConfig() (appID, inviteURL, largeImageKey, details, state, game, smallImageKey string) {
-	// Start with default values from defaultConfig
-	appID = defaultConfig.DiscordApplicationID
-	inviteURL = defaultConfig.DiscordInviteURL
-	largeImageKey = defaultConfig.DiscordLargeImageKey
-	details = defaultConfig.DiscordDetails
-	state = defaultConfig.DiscordState
-	smallImageKey = defaultConfig.DiscordSmallImageKey
-
-	// Get game name from server config - this is the source of truth
-	game = configs.GetServerConfig().MudName.String()
-
-	// Check for overrides in plugin config
-	if id, ok := g.plug.Config.Get(`discord_application_id`).(string); ok {
-		appID = id
-	}
-	if url, ok := g.plug.Config.Get(`discord_invite_url`).(string); ok {
-		inviteURL = url
-	}
-	if key, ok := g.plug.Config.Get(`discord_large_image_key`).(string); ok {
-		largeImageKey = key
-	}
-	if d, ok := g.plug.Config.Get(`discord_details`).(string); ok {
-		details = d
-	}
-	if s, ok := g.plug.Config.Get(`discord_state`).(string); ok {
-		state = s
-	}
-	if key, ok := g.plug.Config.Get(`discord_small_image_key`).(string); ok {
-		smallImageKey = key
-	}
-
-	return
-}
-
-// sendUICommand is a user command that sends UI-related GMCP messages to Mudlet clients
-func (g *GMCPMudletModule) sendUICommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
-	// Only send if the client is Mudlet
-	connId := user.ConnectionId()
-	if gmcpData, ok := gmcpModule.cache.Get(connId); ok && gmcpData.Client.IsMudlet {
-		// Process command arguments
-		args := strings.Fields(rest)
-		if len(args) > 0 {
-			switch args[0] {
-			case "install":
-				// Send UI install message
-				g.sendMudletUIInstall(user.UserId)
-				user.SendText("\n<ansi fg=\"green\">UI installation package sent to your Mudlet client.</ansi> If it doesn't install automatically, you may need to accept the installation prompt in Mudlet.\n")
-				// Set a flag to prevent the checkclient message from showing again
-				user.SetConfigOption("mudlet_ui_prompt_disabled", true)
-			case "remove":
-				// Send UI remove message
-				g.sendMudletUIRemove(user.UserId)
-				user.SendText("\n<ansi fg=\"yellow\">UI removal command sent to your Mudlet client.</ansi>\n")
-			case "update":
-				// Send UI update message
-				g.sendMudletUIUpdate(user.UserId)
-				user.SendText("\n<ansi fg=\"cyan\">Manual UI update check sent to your Mudlet client.</ansi>\n")
-			case "hide":
-				// Set a flag to prevent the checkclient message from showing again
-				user.SetConfigOption("mudlet_ui_prompt_disabled", true)
-				user.SendText("\n<ansi fg=\"green\">The Mudlet UI prompt has been hidden.</ansi> You won't see these messages again when logging in.\n")
-				user.SendText("You can use <ansi fg=\"command\">mudletui show</ansi> in the future if you want to see the prompts again.\n")
-			case "show":
-				// Remove the flag to allow the checkclient message to show again
-				user.SetConfigOption("mudlet_ui_prompt_disabled", false)
-				user.SendText("\n<ansi fg=\"green\">The Mudlet UI prompt has been re-enabled.</ansi> You'll see these messages again when logging in.\n")
-				user.SendText("You can use <ansi fg=\"command\">mudletui hide</ansi> in the future if you want to hide the prompts again.\n")
-			default:
-				// Unknown command
-				user.SendText("\nUsage: mudletui install|remove|update|hide|show\n\nType '<ansi fg=\"command\">help mudletui</ansi>' for more information.\n")
-			}
-		} else {
-			// No arguments provided - show status and available commands
-			mudName := configs.GetServerConfig().MudName.String()
-
-			// Check current status of prompt display
-			promptDisabled := user.GetConfigOption("mudlet_ui_prompt_disabled")
-			promptStatus := "<ansi fg=\"green\">ENABLED</ansi>"
-			if promptDisabled != nil && promptDisabled.(bool) {
-				promptStatus = "<ansi fg=\"red\">HIDDEN</ansi>"
-			}
-
-			user.SendText("\n<ansi fg=\"cyan-bold\">" + mudName + " Mudlet UI Management</ansi>\n")
-			user.SendText("<ansi fg=\"yellow-bold\">Status:</ansi>\n")
-			user.SendText("  Login message display: " + promptStatus + "\n")
-			user.SendText("<ansi fg=\"yellow-bold\">Available Commands:</ansi>\n")
-			user.SendText("  <ansi fg=\"command\">mudletui install</ansi> - Install the Mudlet UI package\n")
-			user.SendText("  <ansi fg=\"command\">mudletui remove</ansi>  - Remove the Mudlet UI package\n")
-			user.SendText("  <ansi fg=\"command\">mudletui update</ansi>  - Manually check for updates to the Mudlet UI package\n")
-			user.SendText("  <ansi fg=\"command\">mudletui hide</ansi>    - Hide login messages\n")
-			user.SendText("  <ansi fg=\"command\">mudletui show</ansi>    - Enable login messages\n\n")
-			user.SendText("For more information, type <ansi fg=\"command\">help mudletui</ansi>\n")
-		}
-
-		// Return true to indicate the command was handled
-		return true, nil
-	} else {
-		// Client is not Mudlet
-		user.SendText("\n<ansi fg=\"red\">This command is only available for Mudlet clients.</ansi> You are currently using: " + gmcpData.Client.Name + "\n")
-	}
-
-	// Command was handled
-	return true, nil
-}
-
-// sendMudletUIInstall sends the UI installation GMCP message
-func (g *GMCPMudletModule) sendMudletUIInstall(userId int) {
-	if userId < 1 {
-		return
-	}
-
-	// Get UI config values
-	uiVersion, uiURL := g.getUIConfig()
-
-	// Create a payload for UI installation
-	payload := struct {
-		Version string `json:"version"`
-		URL     string `json:"url"`
-	}{
-		Version: uiVersion,
-		URL:     uiURL,
-	}
-
-	// Send the Client.GUI message
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "Client.GUI",
-		Payload: payload,
-	})
-
-	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet UI install config", "userId", userId)
-}
-
-// sendMudletUIRemove sends the UI remove GMCP message
-func (g *GMCPMudletModule) sendMudletUIRemove(userId int) {
-	if userId < 1 {
-		return
-	}
-
-	// Create a payload for UI removal
-	payload := struct {
-		GoMudUI string `json:"gomudui"`
-	}{
-		GoMudUI: "remove",
-	}
-
-	// Send the Client.GUI message
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "Client.GUI",
-		Payload: payload,
-	})
-
-	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet UI remove command", "userId", userId)
-}
-
-// sendMudletUIUpdate sends the UI update GMCP message
-func (g *GMCPMudletModule) sendMudletUIUpdate(userId int) {
-	if userId < 1 {
-		return
-	}
-
-	// Create a payload for UI update
-	payload := struct {
-		GoMudUI string `json:"gomudui"`
-	}{
-		GoMudUI: "update",
-	}
-
-	// Send the Client.GUI message
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "Client.GUI",
-		Payload: payload,
-	})
-
-	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet UI update command", "userId", userId)
-}
-
-// sendMapCommand is a user command that sends the map URL to Mudlet clients
-func (g *GMCPMudletModule) sendMapCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
-	// Only send if the client is Mudlet
-	connId := user.ConnectionId()
-	if gmcpData, ok := gmcpModule.cache.Get(connId); ok && gmcpData.Client.IsMudlet {
-		// Send the map URL
-		g.sendMudletMapConfig(user.UserId)
-
-		// Return true to indicate the command was handled (but don't show any output to the user)
-		return true, nil
-	}
-
-	// Return false to indicate the command wasn't handled (if not a Mudlet client)
-	// This allows other handlers to potentially process it
-	return false, nil
-}
-
-// sendMudletMapConfig sends the Mudlet map configuration via GMCP
-func (g *GMCPMudletModule) sendMudletMapConfig(userId int) {
-	if userId < 1 {
-		return
-	}
-
-	// Get map config values
-	_, mapURL := g.getMapConfig()
-
-	// Create a payload for the Client.Map message
-	mapConfig := map[string]string{
-		"url": mapURL,
-	}
-
-	// Send the Client.Map message
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "Client.Map",
-		Payload: mapConfig,
-	})
-
-	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet map config", "userId", userId)
-}
-
-// playerSpawnHandler sends Mudlet-specific GMCP when a player connects
-func (g *GMCPMudletModule) playerSpawnHandler(e events.Event) events.ListenerReturn {
-	evt, typeOk := e.(events.PlayerSpawn)
-	if !typeOk {
-		mudlog.Error("Event", "Expected Type", "PlayerSpawn", "Actual Type", e.Type())
-		return events.Cancel
-	}
-
-	// Check if the client is Mudlet
-	if gmcpData, ok := gmcpModule.cache.Get(evt.ConnectionId); ok {
-		if gmcpData.Client.IsMudlet {
-			// Send Mudlet-specific GMCP
-			g.sendMudletConfig(evt.UserId)
-		}
-	}
-
-	return events.Continue
-}
-
-// mudletDetectedHandler handles the event when a Mudlet client is detected
-func (g *GMCPMudletModule) mudletDetectedHandler(e events.Event) events.ListenerReturn {
-	evt, typeOk := e.(GMCPMudletDetected)
-	if !typeOk {
-		mudlog.Error("Event", "Expected Type", "GMCPMudletDetected", "Actual Type", e.Type())
-		return events.Cancel
-	}
-
-	if evt.UserId > 0 {
-		g.sendMudletConfig(evt.UserId)
-	}
-
-	return events.Continue
-}
-
-// sendMudletConfig sends the Mudlet configuration via GMCP
-func (g *GMCPMudletModule) sendMudletConfig(userId int) {
-	if userId < 1 {
-		return
-	}
-
-	// Get mapper config values
-	mapperVersion, mapperURL := g.getMapperConfig()
-
-	// Create a GUI payload with mapper version and url
-	guiPayload := struct {
-		Version string `json:"version"`
-		URL     string `json:"url"`
-	}{
-		Version: mapperVersion,
-		URL:     mapperURL,
-	}
-
-	// Send the Client.GUI message with mapper version and URL
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "Client.GUI",
-		Payload: guiPayload,
-	})
-
-	// Get the user record to access character details
-	user := users.GetByUserId(userId)
-	if user == nil {
-		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord info", "userId", userId)
-		return
-	}
-
-	// Check if Discord.Info is enabled
-	enableInfo := user.GetConfigOption("discord_enable_info")
-	if enableInfo == nil || enableInfo.(bool) {
-		// Get Discord config values - only what we need for Discord.Info
-		appID, inviteURL, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
-
-		// Create a payload for Discord.Info - only applicationid and inviteurl
-		discordInfoPayload := struct {
-			ApplicationID string `json:"applicationid"`
-			InviteURL     string `json:"inviteurl"`
-		}{
-			ApplicationID: appID,
-			InviteURL:     inviteURL,
-		}
-
-		// Send the External.Discord.Info message
-		events.AddToQueue(GMCPOut{
-			UserId:  userId,
-			Module:  "External.Discord.Info",
-			Payload: discordInfoPayload,
-		})
-
-		// Send the Discord Status information with the config values we already have
-		g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
-	} else {
-		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Info package sending disabled for user", "userId", userId)
-	}
-
-	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Mudlet package config", "userId", userId)
-}
-
-// sendDiscordStatusWithConfig sends the current Discord status information to the client using provided config values
-func (g *GMCPMudletModule) sendDiscordStatusWithConfig(userId int, largeImageKey, details, state, game, smallImageKey string) {
-	if userId < 1 {
-		return
-	}
-
-	// Get the user record to access character details
-	user := users.GetByUserId(userId)
-	if user == nil {
-		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord status", "userId", userId)
-		return
-	}
-
-	// Check if Discord.Status is enabled
-	enableStatus := user.GetConfigOption("discord_enable_status")
-	if enableStatus != nil && !enableStatus.(bool) {
-		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Status package sending disabled for user", "userId", userId)
-		return
-	}
-
-	// Get the current room
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get room for Discord status", "userId", userId, "roomId", user.Character.RoomId)
-		return
-	}
-
-	// Check display preferences (default to true if not set)
-	showArea := user.GetConfigOption("discord_show_area")
-	if showArea == nil {
-		showArea = true
-	}
-	showParty := user.GetConfigOption("discord_show_party")
-	if showParty == nil {
-		showParty = true
-	}
-	showName := user.GetConfigOption("discord_show_name")
-	if showName == nil {
-		showName = true
-	}
-	showLevel := user.GetConfigOption("discord_show_level")
-	if showLevel == nil {
-		showLevel = true
-	}
-
-	// Build the details string based on preferences
-	detailsStr := details
-	if showName.(bool) || showLevel.(bool) {
-		detailsStr = ""
-		if showName.(bool) {
-			detailsStr = user.Character.Name
-		}
-		if showLevel.(bool) {
-			if detailsStr != "" {
-				detailsStr += " "
-			}
-			if showName.(bool) {
-				detailsStr += fmt.Sprintf("(lvl. %d)", user.Character.Level)
-			} else {
-				detailsStr += fmt.Sprintf("Level %d", user.Character.Level)
-			}
-		}
-	}
-
-	// Create a payload for Discord.Status
-	discordStatusPayload := struct {
-		Details       string `json:"details"`
-		State         string `json:"state"`
-		Game          string `json:"game"`
-		LargeImageKey string `json:"large_image_key"`
-		SmallImageKey string `json:"small_image_key"`
-		StartTime     int64  `json:"starttime"`
-		PartySize     int    `json:"partysize,omitempty"`
-		PartyMax      int    `json:"partymax,omitempty"`
-	}{
-		Details:       detailsStr,
-		State:         "Exploring the world", // Default state
-		Game:          game,
-		LargeImageKey: largeImageKey,
-		SmallImageKey: smallImageKey,
-		StartTime:     user.GetConnectTime().Unix(),
-	}
-
-	// Only show area if enabled
-	if showArea.(bool) {
-		discordStatusPayload.State = fmt.Sprintf("Exploring %s", room.Zone)
-	}
-
-	// Check if the user is in a party
-	if party := parties.Get(userId); party != nil {
-		// Only show party info if enabled
-		if showParty.(bool) {
-			discordStatusPayload.PartySize = len(party.GetMembers())
-			discordStatusPayload.PartyMax = 10
-			if showArea.(bool) {
-				discordStatusPayload.State = fmt.Sprintf("Group in %s", room.Zone)
-			} else {
-				discordStatusPayload.State = "In group"
-			}
-		}
-	}
-
-	// Send the External.Discord.Status message
-	events.AddToQueue(GMCPOut{
-		UserId:  userId,
-		Module:  "External.Discord.Status",
-		Payload: discordStatusPayload,
-	})
-
-	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Discord status update", "userId", userId, "zone", room.Zone)
-}
-
-// sendDiscordStatus sends the current Discord status information to the client
-func (g *GMCPMudletModule) sendDiscordStatus(userId int) {
-	// Get Discord config values
-	_, _, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
-	g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
-}
-
-// checkClientCommand checks if the player is using Mudlet and shows information if they are
-func (g *GMCPMudletModule) checkClientCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
-	// Get the connection ID and check if the client is Mudlet
-	connId := user.ConnectionId()
-	if gmcpData, ok := gmcpModule.cache.Get(connId); ok && gmcpData.Client.IsMudlet {
-		// Check if the user has disabled the prompt
-		promptDisabled := user.GetConfigOption("mudlet_ui_prompt_disabled")
-		if promptDisabled != nil && promptDisabled.(bool) {
-			// User has disabled the prompt, so don't show the message
-			return true, nil
-		}
-
-		// Show a brief intro message
-		user.SendText("\n\n<ansi fg=\"cyan-bold\">We have detected you are using Mudlet as a client.</ansi>\n")
-
-		// Use the standard help system to show the mudletui help
-		usercommands.Help("mudletui", user, room, flags)
-
-		// Command was handled
-		return true, nil
-	}
-
-	// Client is not Mudlet - return true but don't show any message
-	// (Return true anyway to avoid command showing up in help)
-	return true, nil
-}
-
-// discordStatusRequestHandler handles the GMCPDiscordStatusRequest event
-func (g *GMCPMudletModule) discordStatusRequestHandler(e events.Event) events.ListenerReturn {
-	evt, typeOk := e.(GMCPDiscordStatusRequest)
-	if !typeOk {
-		mudlog.Error("Event", "Expected Type", "GMCPDiscordStatusRequest", "Actual Type", e.Type())
-		return events.Cancel
-	}
-
-	// Get the user record to access character details
-	userId := evt.UserId
-	user := users.GetByUserId(userId)
-	if user == nil {
-		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord info/status", "userId", userId)
-		return events.Cancel
-	}
-
-	// Get Discord config values once
-	appID, inviteURL, largeImageKey, details, state, game, smallImageKey := g.getDiscordConfig()
-
-	// Check if Discord.Info is enabled
-	enableInfo := user.GetConfigOption("discord_enable_info")
-	if enableInfo == nil || enableInfo.(bool) {
-		// Create a payload for Discord.Info - only applicationid and inviteurl
-		discordInfoPayload := struct {
-			ApplicationID string `json:"applicationid"`
-			InviteURL     string `json:"inviteurl"`
-		}{
-			ApplicationID: appID,
-			InviteURL:     inviteURL,
-		}
-
-		// Send the External.Discord.Info message
-		events.AddToQueue(GMCPOut{
-			UserId:  userId,
-			Module:  "External.Discord.Info",
-			Payload: discordInfoPayload,
-		})
-
-		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Discord Info in response to request", "userId", userId)
-	} else {
-		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Info package sending disabled for user", "userId", userId)
-	}
-
-	// Also send Discord Status information with the config values we already have
-	g.sendDiscordStatusWithConfig(userId, largeImageKey, details, state, game, smallImageKey)
-
-	mudlog.Info("GMCP", "type", "Mudlet", "action", "Processed Discord status request", "userId", userId)
-	return events.Continue
-}
-
-// discordMessageHandler handles Discord-related GMCP messages from clients
-func (g *GMCPMudletModule) discordMessageHandler(e events.Event) events.ListenerReturn {
-	evt, typeOk := e.(GMCPDiscordMessage)
-	if !typeOk {
-		mudlog.Error("Event", "Expected Type", "GMCPDiscordMessage", "Actual Type", e.Type())
-		return events.Cancel
-	}
-
-	// Try to find the user ID associated with this connection
-	userId := 0
-	for _, user := range users.GetAllActiveUsers() {
-		if user.ConnectionId() == evt.ConnectionId {
-			userId = user.UserId
-			break
-		}
-	}
-
-	if userId == 0 {
-		// No user associated with this connection
-		return events.Cancel
-	}
-
-	// Log the message for debugging
-	mudlog.Info("Mudlet GMCP Discord", "type", evt.Command, "userId", userId, "payload", string(evt.Payload))
-
-	// Get user record for checking settings
-	user := users.GetByUserId(userId)
-	if user == nil {
-		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord message handling", "userId", userId)
-		return events.Cancel
-	}
-
-	switch evt.Command {
-	case "Hello":
-		// Check if Discord.Info is enabled
-		enableInfo := user.GetConfigOption("discord_enable_info")
-		if enableInfo == nil || enableInfo.(bool) {
-			// Only send Discord.Info on Hello, as we don't have character info yet
-			discordInfoPayload := struct {
-				ApplicationID string `json:"applicationid"`
-				InviteURL     string `json:"inviteurl"`
-			}{
-				ApplicationID: g.config.DiscordApplicationID,
-				InviteURL:     g.config.DiscordInviteURL,
-			}
-
-			// Send the External.Discord.Info message
-			events.AddToQueue(GMCPOut{
-				UserId:  userId,
-				Module:  "External.Discord.Info",
-				Payload: discordInfoPayload,
-			})
-
-			mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Info in response to Hello", "userId", userId)
-		} else {
-			mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Info package sending disabled for user", "userId", userId)
-		}
-	case "Get":
-		// Check if Discord.Status is enabled
-		enableStatus := user.GetConfigOption("discord_enable_status")
-		if enableStatus == nil || enableStatus.(bool) {
-			// If we don't have character info yet, don't send anything
-			if user.Character == nil {
-				mudlog.Debug("GMCP", "type", "Mudlet", "action", "Ignoring Discord.Get request (no character info yet)", "userId", userId)
-				return events.Continue
-			}
-
-			// We have character info, so send Discord.Status
-			g.sendDiscordStatus(userId)
-			mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Discord Status in response to Get", "userId", userId)
-		} else {
-			mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Status package sending disabled for user", "userId", userId)
-		}
-	case "Status":
-		// Client sent a status update - just log it for now
-		// No specific handling needed
-	}
-
-	return events.Continue
-}
-
-// roomChangeHandler handles the RoomChange event to update Discord status when players change areas/zones
-func (g *GMCPMudletModule) roomChangeHandler(e events.Event) events.ListenerReturn {
-	evt, typeOk := e.(events.RoomChange)
-	if !typeOk {
-		return events.Cancel
-	}
-
-	// Only handle player movements (not mobs)
-	if evt.UserId == 0 || evt.MobInstanceId > 0 {
-		return events.Continue
-	}
-
-	// Check if this is a Mudlet client
-	isMudletUser := false
-	if known, exists := g.mudletUsers[evt.UserId]; exists && known {
-		isMudletUser = true
-	} else if g.isMudletClient(evt.UserId) {
-		g.mudletUsers[evt.UserId] = true
-		isMudletUser = true
-	}
-
-	if !isMudletUser {
-		return events.Continue
-	}
-
-	// Load rooms and check for zone change
-	oldRoom := rooms.LoadRoom(evt.FromRoomId)
-	newRoom := rooms.LoadRoom(evt.ToRoomId)
-	if oldRoom == nil || newRoom == nil {
-		return events.Continue
-	}
-
-	// Update Discord status on zone change
-	if oldRoom.Zone != newRoom.Zone {
-		g.sendDiscordStatus(evt.UserId)
-	}
-
-	return events.Continue
-}
-
-// isMudletClient checks if the given user ID is using a Mudlet client
+// Helper function to check if a user is using a Mudlet client
 func (g *GMCPMudletModule) isMudletClient(userId int) bool {
 	if userId < 1 {
 		return false
 	}
 
 	// First check our cache of known Mudlet users
-	if known, exists := g.mudletUsers[userId]; exists {
+	if known, ok := g.mudletUsers[userId]; ok {
 		return known
 	}
 
@@ -888,7 +163,403 @@ func (g *GMCPMudletModule) isMudletClient(userId int) bool {
 	return false
 }
 
-// partyUpdateHandler handles party membership changes and updates Discord status
+// Helper function to get user config option with default boolean value
+func getUserBoolOption(user *users.UserRecord, key string, defaultValue bool) bool {
+	val := user.GetConfigOption(key)
+	if val == nil {
+		return defaultValue
+	}
+	if boolVal, ok := val.(bool); ok {
+		return boolVal
+	}
+	return defaultValue
+}
+
+// Helper to send GMCP event
+func sendGMCP(userId int, module string, payload interface{}) {
+	if userId < 1 {
+		return
+	}
+	events.AddToQueue(GMCPOut{
+		UserId:  userId,
+		Module:  module,
+		Payload: payload,
+	})
+}
+
+// Helper function to create and send Discord Info message
+func (g *GMCPMudletModule) sendDiscordInfo(userId int) {
+	if userId < 1 {
+		return
+	}
+
+	user := users.GetByUserId(userId)
+	if user == nil {
+		return
+	}
+
+	// Check if Discord.Info is enabled
+	if !getUserBoolOption(user, "discord_enable_info", true) {
+		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Info package sending disabled for user", "userId", userId)
+		return
+	}
+
+	// Send Discord Info payload
+	payload := struct {
+		ApplicationID string `json:"applicationid"`
+		InviteURL     string `json:"inviteurl"`
+	}{
+		ApplicationID: g.config.DiscordApplicationID,
+		InviteURL:     g.config.DiscordInviteURL,
+	}
+
+	sendGMCP(userId, "External.Discord.Info", payload)
+	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Discord Info", "userId", userId)
+}
+
+// sendDiscordStatus sends the current Discord status information
+func (g *GMCPMudletModule) sendDiscordStatus(userId int) {
+	if userId < 1 {
+		return
+	}
+
+	// Get the user record
+	user := users.GetByUserId(userId)
+	if user == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get user record for Discord status", "userId", userId)
+		return
+	}
+
+	// Check if Discord.Status is enabled
+	if !getUserBoolOption(user, "discord_enable_status", true) {
+		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Discord.Status package sending disabled for user", "userId", userId)
+		return
+	}
+
+	// Get the current room
+	room := rooms.LoadRoom(user.Character.RoomId)
+	if room == nil {
+		mudlog.Error("GMCP", "type", "Mudlet", "action", "Failed to get room for Discord status", "userId", userId, "roomId", user.Character.RoomId)
+		return
+	}
+
+	// Check display preferences
+	showArea := getUserBoolOption(user, "discord_show_area", true)
+	showParty := getUserBoolOption(user, "discord_show_party", true)
+	showName := getUserBoolOption(user, "discord_show_name", true)
+	showLevel := getUserBoolOption(user, "discord_show_level", true)
+
+	// Build the details string based on preferences
+	detailsStr := g.config.DiscordDetails
+	if showName || showLevel {
+		detailsStr = ""
+		if showName {
+			detailsStr = user.Character.Name
+		}
+		if showLevel {
+			if detailsStr != "" {
+				detailsStr += " "
+			}
+			if showName {
+				detailsStr += fmt.Sprintf("(lvl. %d)", user.Character.Level)
+			} else {
+				detailsStr += fmt.Sprintf("Level %d", user.Character.Level)
+			}
+		}
+	}
+
+	// Create Discord Status payload
+	payload := struct {
+		Details       string `json:"details"`
+		State         string `json:"state"`
+		Game          string `json:"game"`
+		LargeImageKey string `json:"large_image_key"`
+		SmallImageKey string `json:"small_image_key"`
+		StartTime     int64  `json:"starttime"`
+		PartySize     int    `json:"partysize,omitempty"`
+		PartyMax      int    `json:"partymax,omitempty"`
+	}{
+		Details:       detailsStr,
+		State:         g.config.DiscordState,
+		Game:          configs.GetServerConfig().MudName.String(),
+		LargeImageKey: g.config.DiscordLargeImageKey,
+		SmallImageKey: g.config.DiscordSmallImageKey,
+		StartTime:     user.GetConnectTime().Unix(),
+	}
+
+	// Show area if enabled
+	if showArea {
+		payload.State = fmt.Sprintf("Exploring %s", room.Zone)
+	}
+
+	// Show party info if enabled and in a party
+	if party := parties.Get(userId); party != nil && showParty {
+		payload.PartySize = len(party.GetMembers())
+		payload.PartyMax = 10
+		if showArea {
+			payload.State = fmt.Sprintf("Group in %s", room.Zone)
+		} else {
+			payload.State = "In group"
+		}
+	}
+
+	// Send the Discord Status message
+	sendGMCP(userId, "External.Discord.Status", payload)
+	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Discord status update", "userId", userId, "zone", room.Zone)
+}
+
+// Send empty Discord status to clear it
+func (g *GMCPMudletModule) clearDiscordStatus(userId int) {
+	payload := struct {
+		Details       string `json:"details"`
+		State         string `json:"state"`
+		Game          string `json:"game"`
+		LargeImageKey string `json:"large_image_key"`
+		SmallImageKey string `json:"small_image_key"`
+	}{
+		Details:       "",
+		State:         "",
+		Game:          "",
+		LargeImageKey: "",
+		SmallImageKey: "",
+	}
+
+	sendGMCP(userId, "External.Discord.Status", payload)
+}
+
+// Send Mudlet map configuration
+func (g *GMCPMudletModule) sendMudletMapConfig(userId int) {
+	if userId < 1 {
+		return
+	}
+
+	mapConfig := map[string]string{
+		"url": g.config.MapURL,
+	}
+
+	sendGMCP(userId, "Client.Map", mapConfig)
+	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet map config", "userId", userId)
+}
+
+// Send Mudlet UI package installation message
+func (g *GMCPMudletModule) sendMudletUIInstall(userId int) {
+	if userId < 1 {
+		return
+	}
+
+	payload := struct {
+		Version string `json:"version"`
+		URL     string `json:"url"`
+	}{
+		Version: g.config.UIVersion,
+		URL:     g.config.UIURL,
+	}
+
+	sendGMCP(userId, "Client.GUI", payload)
+	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet UI install config", "userId", userId)
+}
+
+// Send Mudlet UI package removal message
+func (g *GMCPMudletModule) sendMudletUIRemove(userId int) {
+	if userId < 1 {
+		return
+	}
+
+	payload := struct {
+		GoMudUI string `json:"gomudui"`
+	}{
+		GoMudUI: "remove",
+	}
+
+	sendGMCP(userId, "Client.GUI", payload)
+	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet UI remove command", "userId", userId)
+}
+
+// Send Mudlet UI package update message
+func (g *GMCPMudletModule) sendMudletUIUpdate(userId int) {
+	if userId < 1 {
+		return
+	}
+
+	payload := struct {
+		GoMudUI string `json:"gomudui"`
+	}{
+		GoMudUI: "update",
+	}
+
+	sendGMCP(userId, "Client.GUI", payload)
+	mudlog.Debug("GMCP", "type", "Mudlet", "action", "Sent Mudlet UI update command", "userId", userId)
+}
+
+// Send mapper configuration to Mudlet client
+func (g *GMCPMudletModule) sendMudletConfig(userId int) {
+	if userId < 1 {
+		return
+	}
+
+	// Send mapper info
+	payload := struct {
+		Version string `json:"version"`
+		URL     string `json:"url"`
+	}{
+		Version: g.config.MapperVersion,
+		URL:     g.config.MapperURL,
+	}
+	sendGMCP(userId, "Client.GUI", payload)
+
+	// Get the user record
+	user := users.GetByUserId(userId)
+	if user == nil {
+		return
+	}
+
+	// Send Discord info if enabled
+	g.sendDiscordInfo(userId)
+
+	// Send Discord status
+	g.sendDiscordStatus(userId)
+
+	mudlog.Info("GMCP", "type", "Mudlet", "action", "Sent Mudlet package config", "userId", userId)
+}
+
+// playerSpawnHandler handles when a player connects
+func (g *GMCPMudletModule) playerSpawnHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(events.PlayerSpawn)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "PlayerSpawn", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	// Check if the client is Mudlet
+	if gmcpData, ok := gmcpModule.cache.Get(evt.ConnectionId); ok && gmcpData.Client.IsMudlet {
+		// Send Mudlet-specific GMCP
+		g.sendMudletConfig(evt.UserId)
+	}
+
+	return events.Continue
+}
+
+// playerDespawnHandler handles when a player disconnects
+func (g *GMCPMudletModule) playerDespawnHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(events.PlayerDespawn)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "PlayerDespawn", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	// Clean up the mudletUsers map entry for this user
+	if evt.UserId > 0 {
+		delete(g.mudletUsers, evt.UserId)
+		mudlog.Debug("GMCP", "type", "Mudlet", "action", "Cleaned up Mudlet user entry", "userId", evt.UserId)
+	}
+
+	return events.Continue
+}
+
+// mudletDetectedHandler handles when a Mudlet client is detected
+func (g *GMCPMudletModule) mudletDetectedHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(GMCPMudletDetected)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "GMCPMudletDetected", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	if evt.UserId > 0 {
+		g.sendMudletConfig(evt.UserId)
+	}
+
+	return events.Continue
+}
+
+// discordStatusRequestHandler handles Discord status requests
+func (g *GMCPMudletModule) discordStatusRequestHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(GMCPDiscordStatusRequest)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "GMCPDiscordStatusRequest", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	// Send both Discord info and status
+	g.sendDiscordInfo(evt.UserId)
+	g.sendDiscordStatus(evt.UserId)
+
+	mudlog.Info("GMCP", "type", "Mudlet", "action", "Processed Discord status request", "userId", evt.UserId)
+	return events.Continue
+}
+
+// discordMessageHandler handles Discord-related GMCP messages
+func (g *GMCPMudletModule) discordMessageHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(GMCPDiscordMessage)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "GMCPDiscordMessage", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	// Find the user ID for this connection
+	userId := 0
+	for _, user := range users.GetAllActiveUsers() {
+		if user.ConnectionId() == evt.ConnectionId {
+			userId = user.UserId
+			break
+		}
+	}
+
+	if userId == 0 {
+		return events.Cancel
+	}
+
+	// Log the message
+	mudlog.Info("Mudlet GMCP Discord", "type", evt.Command, "userId", userId, "payload", string(evt.Payload))
+
+	// Handle different Discord commands
+	switch evt.Command {
+	case "Hello":
+		g.sendDiscordInfo(userId)
+	case "Get":
+		user := users.GetByUserId(userId)
+		if user != nil && user.Character != nil {
+			events.AddToQueue(GMCPDiscordStatusRequest{
+				UserId: userId,
+			})
+		}
+	}
+
+	return events.Continue
+}
+
+// roomChangeHandler updates Discord status when players change areas
+func (g *GMCPMudletModule) roomChangeHandler(e events.Event) events.ListenerReturn {
+	evt, typeOk := e.(events.RoomChange)
+	if !typeOk {
+		return events.Cancel
+	}
+
+	// Only handle player movements (not mobs)
+	if evt.UserId == 0 || evt.MobInstanceId > 0 {
+		return events.Continue
+	}
+
+	// Check if this is a Mudlet client
+	if !g.isMudletClient(evt.UserId) {
+		return events.Continue
+	}
+
+	// Load rooms and check for zone change
+	oldRoom := rooms.LoadRoom(evt.FromRoomId)
+	newRoom := rooms.LoadRoom(evt.ToRoomId)
+	if oldRoom == nil || newRoom == nil {
+		return events.Continue
+	}
+
+	// Update Discord status on zone change
+	if oldRoom.Zone != newRoom.Zone {
+		g.sendDiscordStatus(evt.UserId)
+	}
+
+	return events.Continue
+}
+
+// partyUpdateHandler updates Discord status for party members
 func (g *GMCPMudletModule) partyUpdateHandler(e events.Event) events.ListenerReturn {
 	evt, typeOk := e.(events.PartyUpdated)
 	if !typeOk {
@@ -896,9 +567,8 @@ func (g *GMCPMudletModule) partyUpdateHandler(e events.Event) events.ListenerRet
 		return events.Cancel
 	}
 
-	// Update Discord status for all users in the party
+	// Update Discord status for all Mudlet users in the party
 	for _, userId := range evt.UserIds {
-		// Only send updates to Mudlet clients
 		if g.isMudletClient(userId) {
 			g.sendDiscordStatus(userId)
 		}
@@ -907,241 +577,209 @@ func (g *GMCPMudletModule) partyUpdateHandler(e events.Event) events.ListenerRet
 	return events.Continue
 }
 
-// showDiscordHelp displays the help text and current settings for the discord command
-func (g *GMCPMudletModule) showDiscordHelp(user *users.UserRecord) {
-	// Use the help system to show the discord help
-	usercommands.Help("discord", user, nil, 0)
-
-	// Show current settings
-	user.SendText("\n<ansi fg=\"subtitle\">Current settings:</ansi>\n")
-
-	enableInfo := user.GetConfigOption("discord_enable_info")
-	if enableInfo == nil || enableInfo.(bool) {
-		user.SendText("  Info:   <ansi fg=\"green\">ENABLED</ansi>")
+// Helper function for handling command toggles
+func (g *GMCPMudletModule) handleToggleCommand(user *users.UserRecord, settingName string, value bool, enableMsg string, disableMsg string) {
+	user.SetConfigOption(settingName, value)
+	if value {
+		user.SendText("\n<ansi fg=\"green\">" + enableMsg + "</ansi>\n")
 	} else {
-		user.SendText("  Info:   <ansi fg=\"red\">DISABLED</ansi>")
+		user.SendText("\n<ansi fg=\"yellow\">" + disableMsg + "</ansi>\n")
 	}
 
-	enableStatus := user.GetConfigOption("discord_enable_status")
-	if enableStatus == nil || enableStatus.(bool) {
-		user.SendText("  Status: <ansi fg=\"green\">ENABLED</ansi>")
-	} else {
-		user.SendText("  Status: <ansi fg=\"red\">DISABLED</ansi>")
+	// Update Discord status if this was a Discord-related setting
+	if strings.HasPrefix(settingName, "discord_") {
+		g.sendDiscordStatus(user.UserId)
 	}
-
-	user.SendText("")
-
-	showArea := user.GetConfigOption("discord_show_area")
-	if showArea == nil || showArea.(bool) {
-		user.SendText("  Area:   <ansi fg=\"green\">ENABLED</ansi>")
-	} else {
-		user.SendText("  Area:   <ansi fg=\"red\">DISABLED</ansi>")
-	}
-
-	showParty := user.GetConfigOption("discord_show_party")
-	if showParty == nil || showParty.(bool) {
-		user.SendText("  Party:  <ansi fg=\"green\">ENABLED</ansi>")
-	} else {
-		user.SendText("  Party:  <ansi fg=\"red\">DISABLED</ansi>")
-	}
-
-	showName := user.GetConfigOption("discord_show_name")
-	if showName == nil || showName.(bool) {
-		user.SendText("  Name:   <ansi fg=\"green\">ENABLED</ansi>")
-	} else {
-		user.SendText("  Name:   <ansi fg=\"red\">DISABLED</ansi>")
-	}
-
-	showLevel := user.GetConfigOption("discord_show_level")
-	if showLevel == nil || showLevel.(bool) {
-		user.SendText("  Level:  <ansi fg=\"green\">ENABLED</ansi>")
-	} else {
-		user.SendText("  Level:  <ansi fg=\"red\">DISABLED</ansi>")
-	}
-
-	user.SendText("\n")
 }
 
-// discordCommand handles the discord command for controlling Discord status display
-func (g *GMCPMudletModule) discordCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+// sendUICommand handles UI-related commands
+func (g *GMCPMudletModule) sendUICommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	// Only proceed if client is Mudlet
+	connId := user.ConnectionId()
+	if gmcpData, ok := gmcpModule.cache.Get(connId); !ok || !gmcpData.Client.IsMudlet {
+		user.SendText("\n<ansi fg=\"red\">This command is only available for Mudlet clients.</ansi> You are currently using: " + gmcpData.Client.Name + "\n")
+		return true, nil
+	}
+
+	// Process arguments
+	args := strings.Fields(rest)
+	if len(args) == 0 {
+		// No arguments - show status and help
+		mudName := configs.GetServerConfig().MudName.String()
+
+		// Check prompt display status
+		var promptStatus string
+		if getUserBoolOption(user, "mudlet_ui_prompt_disabled", false) {
+			promptStatus = "<ansi fg=\"red\">HIDDEN</ansi>"
+		} else {
+			promptStatus = "<ansi fg=\"green\">ENABLED</ansi>"
+		}
+
+		user.SendText("\n<ansi fg=\"cyan-bold\">" + mudName + " Mudlet UI Management</ansi>\n")
+		user.SendText("<ansi fg=\"yellow-bold\">Status:</ansi>\n")
+		user.SendText("  Login message display: " + promptStatus + "\n")
+		user.SendText("<ansi fg=\"yellow-bold\">Available Commands:</ansi>\n")
+		user.SendText("  <ansi fg=\"command\">mudletui install</ansi> - Install the Mudlet UI package\n")
+		user.SendText("  <ansi fg=\"command\">mudletui remove</ansi>  - Remove the Mudlet UI package\n")
+		user.SendText("  <ansi fg=\"command\">mudletui update</ansi>  - Manually check for updates to the Mudlet UI package\n")
+		user.SendText("  <ansi fg=\"command\">mudletui hide</ansi>    - Hide login messages\n")
+		user.SendText("  <ansi fg=\"command\">mudletui show</ansi>    - Enable login messages\n\n")
+		user.SendText("For more information, type <ansi fg=\"command\">help mudletui</ansi>\n")
+		return true, nil
+	}
+
+	// Handle specific commands
+	switch args[0] {
+	case "install":
+		g.sendMudletUIInstall(user.UserId)
+		user.SetConfigOption("mudlet_ui_prompt_disabled", true)
+		user.SendText("\n<ansi fg=\"green\">UI installation package sent to your Mudlet client.</ansi> If it doesn't install automatically, you may need to accept the installation prompt in Mudlet.\n")
+
+	case "remove":
+		g.sendMudletUIRemove(user.UserId)
+		user.SendText("\n<ansi fg=\"yellow\">UI removal command sent to your Mudlet client.</ansi>\n")
+
+	case "update":
+		g.sendMudletUIUpdate(user.UserId)
+		user.SendText("\n<ansi fg=\"cyan\">Manual UI update check sent to your Mudlet client.</ansi>\n")
+
+	case "hide":
+		g.handleToggleCommand(user, "mudlet_ui_prompt_disabled", true,
+			"The Mudlet UI prompt has been hidden.",
+			"")
+		user.SendText("You can use <ansi fg=\"command\">mudletui show</ansi> in the future if you want to see the prompts again.\n")
+
+	case "show":
+		g.handleToggleCommand(user, "mudlet_ui_prompt_disabled", false,
+			"The Mudlet UI prompt has been re-enabled.",
+			"")
+		user.SendText("You can use <ansi fg=\"command\">mudletui hide</ansi> in the future if you want to hide the prompts again.\n")
+
+	default:
+		user.SendText("\nUsage: mudletui install|remove|update|hide|show\n\nType '<ansi fg=\"command\">help mudletui</ansi>' for more information.\n")
+	}
+
+	return true, nil
+}
+
+// sendMapCommand sends map configuration
+func (g *GMCPMudletModule) sendMapCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
 	// Only send if the client is Mudlet
 	connId := user.ConnectionId()
 	if gmcpData, ok := gmcpModule.cache.Get(connId); ok && gmcpData.Client.IsMudlet {
-		// Process command arguments
-		args := strings.Fields(rest)
-		if len(args) > 0 {
-			switch args[0] {
-			case "area":
-				if len(args) < 2 {
-					user.SendText("\nUsage: discord area on|off\n")
-					return true, nil
-				}
-				switch args[1] {
-				case "on":
-					user.SetConfigOption("discord_show_area", true)
-					user.SendText("\n<ansi fg=\"green\">Area display in Discord status enabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				case "off":
-					user.SetConfigOption("discord_show_area", false)
-					user.SendText("\n<ansi fg=\"yellow\">Area display in Discord status disabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				default:
-					user.SendText("\nUsage: discord area on|off\n")
-				}
-			case "party":
-				if len(args) < 2 {
-					user.SendText("\nUsage: discord party on|off\n")
-					return true, nil
-				}
-				switch args[1] {
-				case "on":
-					user.SetConfigOption("discord_show_party", true)
-					user.SendText("\n<ansi fg=\"green\">Party display in Discord status enabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				case "off":
-					user.SetConfigOption("discord_show_party", false)
-					user.SendText("\n<ansi fg=\"yellow\">Party display in Discord status disabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				default:
-					user.SendText("\nUsage: discord party on|off\n")
-				}
-			case "name":
-				if len(args) < 2 {
-					user.SendText("\nUsage: discord name on|off\n")
-					return true, nil
-				}
-				switch args[1] {
-				case "on":
-					user.SetConfigOption("discord_show_name", true)
-					user.SendText("\n<ansi fg=\"green\">Character name display in Discord status enabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				case "off":
-					user.SetConfigOption("discord_show_name", false)
-					user.SendText("\n<ansi fg=\"yellow\">Character name display in Discord status disabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				default:
-					user.SendText("\nUsage: discord name on|off\n")
-				}
-			case "level":
-				if len(args) < 2 {
-					user.SendText("\nUsage: discord level on|off\n")
-					return true, nil
-				}
-				switch args[1] {
-				case "on":
-					user.SetConfigOption("discord_show_level", true)
-					user.SendText("\n<ansi fg=\"green\">Level display in Discord status enabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				case "off":
-					user.SetConfigOption("discord_show_level", false)
-					user.SendText("\n<ansi fg=\"yellow\">Level display in Discord status disabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				default:
-					user.SendText("\nUsage: discord level on|off\n")
-				}
-			case "info":
-				if len(args) < 2 {
-					user.SendText("\nUsage: discord info on|off\n")
-					return true, nil
-				}
-				switch args[1] {
-				case "on":
-					user.SetConfigOption("discord_enable_info", true)
-					user.SendText("\n<ansi fg=\"green\">Discord.Info package sending enabled.</ansi>\n")
+		g.sendMudletMapConfig(user.UserId)
+		return true, nil
+	}
+	return false, nil
+}
 
-					// Send the Info package immediately if enabled
-					appID, inviteURL, _, _, _, _, _ := g.getDiscordConfig()
-					discordInfoPayload := struct {
-						ApplicationID string `json:"applicationid"`
-						InviteURL     string `json:"inviteurl"`
-					}{
-						ApplicationID: appID,
-						InviteURL:     inviteURL,
-					}
-
-					events.AddToQueue(GMCPOut{
-						UserId:  user.UserId,
-						Module:  "External.Discord.Info",
-						Payload: discordInfoPayload,
-					})
-				case "off":
-					user.SetConfigOption("discord_enable_info", false)
-					user.SendText("\n<ansi fg=\"yellow\">Discord.Info package sending disabled.</ansi>\n")
-
-					// Send an empty Discord.Info package to reset client cache
-					emptyInfoPayload := struct {
-						ApplicationID string `json:"applicationid"`
-						InviteURL     string `json:"inviteurl"`
-					}{
-						ApplicationID: "",
-						InviteURL:     "",
-					}
-
-					events.AddToQueue(GMCPOut{
-						UserId:  user.UserId,
-						Module:  "External.Discord.Info",
-						Payload: emptyInfoPayload,
-					})
-				default:
-					user.SendText("\nUsage: discord info on|off\n")
-				}
-			case "status":
-				if len(args) < 2 {
-					user.SendText("\nUsage: discord status on|off\n")
-					return true, nil
-				}
-				switch args[1] {
-				case "on":
-					user.SetConfigOption("discord_enable_status", true)
-					user.SendText("\n<ansi fg=\"green\">Discord.Status package sending enabled.</ansi>\n")
-					g.sendDiscordStatus(user.UserId)
-				case "off":
-					user.SetConfigOption("discord_enable_status", false)
-					user.SendText("\n<ansi fg=\"yellow\">Discord.Status package sending disabled.</ansi>\n")
-
-					// Send an empty Discord.Status package to reset client cache
-					emptyStatusPayload := struct {
-						Details       string `json:"details"`
-						State         string `json:"state"`
-						Game          string `json:"game"`
-						LargeImageKey string `json:"large_image_key"`
-						SmallImageKey string `json:"small_image_key"`
-						StartTime     int64  `json:"starttime"`
-						PartySize     int    `json:"partysize,omitempty"`
-						PartyMax      int    `json:"partymax,omitempty"`
-					}{
-						Details:       "",
-						State:         "",
-						Game:          "",
-						LargeImageKey: "",
-						SmallImageKey: "",
-						StartTime:     0,
-					}
-
-					events.AddToQueue(GMCPOut{
-						UserId:  user.UserId,
-						Module:  "External.Discord.Status",
-						Payload: emptyStatusPayload,
-					})
-				default:
-					user.SendText("\nUsage: discord status on|off\n")
-				}
-			default:
-				// Show help for unknown commands
-				g.showDiscordHelp(user)
-			}
-		} else {
-			// No arguments provided - show help
-			g.showDiscordHelp(user)
+// checkClientCommand checks if client is Mudlet and shows info
+func (g *GMCPMudletModule) checkClientCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	// Check if client is Mudlet
+	connId := user.ConnectionId()
+	if gmcpData, ok := gmcpModule.cache.Get(connId); ok && gmcpData.Client.IsMudlet {
+		// Skip if prompt is disabled
+		if getUserBoolOption(user, "mudlet_ui_prompt_disabled", false) {
+			return true, nil
 		}
 
-		// Return true to indicate the command was handled
-		return true, nil
-	} else {
-		// Client is not Mudlet
+		// Show Mudlet help
+		user.SendText("\n\n<ansi fg=\"cyan-bold\">We have detected you are using Mudlet as a client.</ansi>\n")
+		usercommands.Help("mudletui", user, room, flags)
+	}
+	return true, nil
+}
+
+// discordCommand handles Discord-related settings
+func (g *GMCPMudletModule) discordCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	// Only proceed if client is Mudlet
+	connId := user.ConnectionId()
+	if gmcpData, ok := gmcpModule.cache.Get(connId); !ok || !gmcpData.Client.IsMudlet {
 		user.SendText("\n<ansi fg=\"red\">This command is only available for Mudlet clients.</ansi> You are currently using: " + gmcpData.Client.Name + "\n")
+		return true, nil
 	}
 
-	// Command was handled
+	// Process arguments
+	args := strings.Fields(rest)
+	if len(args) == 0 {
+		user.SendText("\nUsage: discord area on|off|party on|off|name on|off|level on|off|info on|off|status on|off\n")
+		return true, nil
+	}
+
+	// Handle different settings
+	if len(args) >= 2 {
+		switch args[0] {
+		case "area":
+			if args[1] == "on" {
+				g.handleToggleCommand(user, "discord_show_area", true, "Area display in Discord status enabled.", "")
+			} else if args[1] == "off" {
+				g.handleToggleCommand(user, "discord_show_area", false, "Area display in Discord status disabled.", "")
+			} else {
+				user.SendText("\nUsage: discord area on|off\n")
+			}
+
+		case "party":
+			if args[1] == "on" {
+				g.handleToggleCommand(user, "discord_show_party", true, "Party display in Discord status enabled.", "")
+			} else if args[1] == "off" {
+				g.handleToggleCommand(user, "discord_show_party", false, "Party display in Discord status disabled.", "")
+			} else {
+				user.SendText("\nUsage: discord party on|off\n")
+			}
+
+		case "name":
+			if args[1] == "on" {
+				g.handleToggleCommand(user, "discord_show_name", true, "Character name display in Discord status enabled.", "")
+			} else if args[1] == "off" {
+				g.handleToggleCommand(user, "discord_show_name", false, "Character name display in Discord status disabled.", "")
+			} else {
+				user.SendText("\nUsage: discord name on|off\n")
+			}
+
+		case "level":
+			if args[1] == "on" {
+				g.handleToggleCommand(user, "discord_show_level", true, "Level display in Discord status enabled.", "")
+			} else if args[1] == "off" {
+				g.handleToggleCommand(user, "discord_show_level", false, "Level display in Discord status disabled.", "")
+			} else {
+				user.SendText("\nUsage: discord level on|off\n")
+			}
+
+		case "info":
+			if args[1] == "on" {
+				g.handleToggleCommand(user, "discord_enable_info", true, "Discord.Info package sending enabled.", "")
+				g.sendDiscordInfo(user.UserId)
+			} else if args[1] == "off" {
+				g.handleToggleCommand(user, "discord_enable_info", false, "Discord.Info package sending disabled.", "")
+				// Send empty Discord.Info payload
+				sendGMCP(user.UserId, "External.Discord.Info", struct {
+					ApplicationID string `json:"applicationid"`
+					InviteURL     string `json:"inviteurl"`
+				}{
+					ApplicationID: "",
+					InviteURL:     "",
+				})
+			} else {
+				user.SendText("\nUsage: discord info on|off\n")
+			}
+
+		case "status":
+			if args[1] == "on" {
+				g.handleToggleCommand(user, "discord_enable_status", true, "Discord.Status package sending enabled.", "")
+				g.sendDiscordStatus(user.UserId)
+			} else if args[1] == "off" {
+				g.handleToggleCommand(user, "discord_enable_status", false, "Discord.Status package sending disabled.", "")
+				g.clearDiscordStatus(user.UserId)
+			} else {
+				user.SendText("\nUsage: discord status on|off\n")
+			}
+
+		default:
+			user.SendText("\nUsage: discord area on|off|party on|off|name on|off|level on|off|info on|off|status on|off\n")
+		}
+	} else {
+		user.SendText("\nUsage: discord area on|off|party on|off|name on|off|level on|off|info on|off|status on|off\n")
+	}
+
 	return true, nil
 }


### PR DESCRIPTION
# Description

This adds the ability for the game to send Rich Presence information to Discord.

<img width="290" alt="Screenshot 2025-05-10 at 12 46 06" src="https://github.com/user-attachments/assets/412a6d97-3517-421e-b5b8-86e09fb90024" />

This will also add a better Discord integration directly in Mudlet:

<img width="529" alt="Screenshot 2025-05-10 at 12 50 34" src="https://github.com/user-attachments/assets/ee1e4535-fd88-4dc2-903e-78d494a1361d" />

By default it sends the following information:
```
DiscordApplicationID: "1298377884154724412",           // Default GoMud Discord Server
DiscordInviteURL:     "https://discord.gg/FaauSYej3n", // Default GoMud Discord Server
DiscordDetails:       "Using GoMudEngine",
DiscordState:         "Exploring the world",
DiscordLargeImageKey: "server-icon",                   // GoMud Discord Icon
DiscordSmallImageKey: "character-icon",                // Hover icon (not used)
```
As well as player name, level, area, party information and connection time.

The game name used in Discord comes from the application id or if not sent, the game name in config.yaml

Added "discord" user command to enable or disable certain information:
```
  discord               - Shows current settings and available commands
  
  discord info on|off   - Enable/disable Discord application info
  discord status on|off - Enable/disable Discord status updates

  discord area on|off   - Show/hide current area in status
  discord party on|off  - Show/hide party information
  discord name on|off   - Show/hide character name
  discord level on|off  - Show/hide character level
```
Everything is saved on the player, and kept across sessions.

Added helpfile in the Integration category. Here we have potential for other integrations to be placed.

This gmcp information could potentially be used by the web-client as well, to send information to Discord if activated.

I snuck in some beautification and alignment on the other helpfiles for gmcp and Mudlet - that is why they are also in this PR.