### PR TITLE
`DeathRecoveryRoom` adjustments

### DIFF
--- a/internal/rooms/roommanager.go
+++ b/internal/rooms/roommanager.go
@@ -267,6 +267,15 @@ func MoveToRoom(userId int, toRoomId int, isSpawn ...bool) error {
 
 	cfg := configs.GetSpecialRoomsConfig()
 
+	// If they are being moved to the death recovery room
+	// Put them in their own instance of it.
+	deathRecoveryRoomId := int(cfg.DeathRecoveryRoom)
+	if toRoomId == deathRecoveryRoomId {
+		if newRooms, err := CreateEphemeralRoomIds(deathRecoveryRoomId); err == nil {
+			toRoomId = newRooms[deathRecoveryRoomId]
+		}
+	}
+
 	if toRoomId == StartRoomIdAlias {
 
 		// If "StartRoom" is set for MiscData on the char, use that.


### PR DESCRIPTION
# Description

This puts every player into a copy of the `DeathRecoveryRoom` when they die, instead of players sharing a room.

## Changes

- On death, players go to an ephemeral copy of the death recovery room.
- Fixed a small logic in auto-healing

