### PR TITLE
Content and Scripting additions

### DIFF
--- a/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
+++ b/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
@@ -54,6 +54,7 @@ ActorObjects are the basic object that represents Users and NPCs
   - [ActorObject.GetMobKills(mobId int) int](#actorobjectgetmobkillsmobid-int-int)
   - [ActorObject.GetRaceKills(raceName string) int](#actorobjectgetracekillsracename-string-int)
   - [ActorObject.GetHealth() int](#actorobjectgethealth-int)
+  - [ActorObject.SetHealth(amt int)](#actorobjectsethealthamt-int)
   - [ActorObject.GetHealthMax() int](#actorobjectgethealthmax-int)
   - [ActorObject.GetHealthPct() float](#actorobjectgethealthpct-float)
   - [ActorObject.GetMana() int](#actorobjectgetmana-int)
@@ -439,6 +440,14 @@ Returns the number of times the actor has killed a certain race of mob
 
 ## [ActorObject.GetHealth() int](/internal/scripting/actor_func.go)
 Returns current actor health
+
+## [ActorObject.SetHealth(amt int)](/internal/scripting/actor_func.go)
+Sets actor health to a specific amount. If this exceeds their maximum health, sets to their maximum health.
+
+|  Argument | Explanation |
+| --- | --- |
+| amt | number of hitpoints to set them to |
+
 
 ## [ActorObject.GetHealthMax() int](/internal/scripting/actor_func.go)
 Returns current actor max health

--- a/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
+++ b/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
@@ -87,6 +87,7 @@ ActorObjects are the basic object that represents Users and NPCs
   - [ActorObject.TimerSet(name string, period string)](#actorobjecttimersetname-string-period-string)
   - [ActorObject.TimerExpired(name string) bool](#actorobjecttimerexpiredname-string-bool)
   - [ActorObject.TimerExists(name string) bool](#actorobjecttimerexistsname-string-bool)
+  - [ActorObject.AddEventLog(category string, message string)](#actorobjectaddeventlogcategory-string-message-string)
 
 
 
@@ -586,3 +587,10 @@ Returns true if the specified timer has expired or doesn't exist.
 Returns true if the specified timer exists. 
 Set timers always exist until they are checked for expiration with `TimerExpired(name string)`
 
+## [ActorObject.AddEventLog(category string, message string)](/internal/scripting/actor_func.go)
+Adds a line to the users Event Log (`history`)
+
+|  Argument | Explanation |
+| --- | --- |
+| category | A short single word category  |
+| message | A single line describing the event |

--- a/_datafiles/guides/building/scripting/SCRIPTING_MOBS.md
+++ b/_datafiles/guides/building/scripting/SCRIPTING_MOBS.md
@@ -203,3 +203,13 @@ NOTE: You can safely start a new path with `mob.Command('pathto 123')` before re
 | mob | [ActorObject](FUNCTIONS_ACTORS.md) |
 | room | [RoomObject](FUNCTIONS_ROOMS.md) |
 | eventDetails.status | `start`, `waypoint`, or `end` |
+
+`onPlayerDowned()` is called when a player is downed (not killed), and this mob aggro'd on them.
+NOTE: If `true` is returned, will ensure this script only runs once for this type of MobId - for example, only one of the two guards in the room.
+
+|  Argument | Explanation |
+| --- | --- |
+| mob | [ActorObject](FUNCTIONS_ACTORS.md) |
+| user | [ActorObject](FUNCTIONS_ACTORS.md) |
+| room | [RoomObject](FUNCTIONS_ROOMS.md) |
+

--- a/_datafiles/world/default/mobs/frostfang/10-ivar_froststeel.yaml
+++ b/_datafiles/world/default/mobs/frostfang/10-ivar_froststeel.yaml
@@ -4,6 +4,8 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 idlecommands:
   - 'say type <ansi fg="command">list</ansi> to see my wares'
   - 'say If you''re looking to sell something, I may be interested... as long as it''s not too special or unique'

--- a/_datafiles/world/default/mobs/frostfang/11-brynja_snowdeal.yaml
+++ b/_datafiles/world/default/mobs/frostfang/11-brynja_snowdeal.yaml
@@ -4,6 +4,8 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 idlecommands:
   - 'say type <ansi fg="command">list</ansi> to see my wares'
   - 'say If you''re looking to sell something, I may be interested... as long as it''s not too special or unique'

--- a/_datafiles/world/default/mobs/frostfang/2-guard.yaml
+++ b/_datafiles/world/default/mobs/frostfang/2-guard.yaml
@@ -4,7 +4,9 @@ itemdropchance: 2
 hostile: false
 maxwander: 20
 groups: 
-  - frostfang-npc
+  - frostfang-law
+combatcommands:
+  - 'callforhelp 5:puts their fingers to their mouth and whistle loudly.'
 activitylevel: 20
 character:
   name: guard

--- a/_datafiles/world/default/mobs/frostfang/26-frostfang_citizen.yaml
+++ b/_datafiles/world/default/mobs/frostfang/26-frostfang_citizen.yaml
@@ -4,6 +4,8 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 activitylevel: 30
 maxwander: 5
 idlecommands:

--- a/_datafiles/world/default/mobs/frostfang/3-captain_of_the_guard.yaml
+++ b/_datafiles/world/default/mobs/frostfang/3-captain_of_the_guard.yaml
@@ -4,7 +4,9 @@ itemdropchance: 2
 hostile: false
 maxwander: 20
 groups: 
-  - frostfang-npc
+  - frostfang-law
+combatcommands:
+  - 'callforhelp 5:puts their fingers to their mouth and whistle loudly.'
 idlecommands:
   - 'emote mumbles something about the weather'
   - 'wander'

--- a/_datafiles/world/default/mobs/frostfang/39-elara.yaml
+++ b/_datafiles/world/default/mobs/frostfang/39-elara.yaml
@@ -5,6 +5,8 @@ hostile: false
 maxwander: 0
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 activitylevel: 20
 character:
   name: elara

--- a/_datafiles/world/default/mobs/frostfang/40-rodric.yaml
+++ b/_datafiles/world/default/mobs/frostfang/40-rodric.yaml
@@ -7,6 +7,8 @@ idlecommands:
   - 'wander'
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 activitylevel: 20
 character:
   name: Rodric

--- a/_datafiles/world/default/mobs/frostfang/42-master_at_arms.yaml
+++ b/_datafiles/world/default/mobs/frostfang/42-master_at_arms.yaml
@@ -5,6 +5,8 @@ hostile: false
 maxwander: 0
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 idlecommands:
   - 'emote checks the edge of their blade.'
   - 'emote inspects the training equipment'

--- a/_datafiles/world/default/mobs/frostfang/5-armorer.yaml
+++ b/_datafiles/world/default/mobs/frostfang/5-armorer.yaml
@@ -4,6 +4,8 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 idlecommands:
   - 'say type <ansi fg="command">list</ansi> to see my wares'
   - 'say If you''re looking to sell something, I may be interested... as long as it''s not too special or unique'

--- a/_datafiles/world/default/mobs/frostfang/50-moilyn_the_wizard.yaml
+++ b/_datafiles/world/default/mobs/frostfang/50-moilyn_the_wizard.yaml
@@ -4,6 +4,8 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 idlecommands:
   - 'say type <ansi fg="command">list</ansi> to see what magical objects I have for sale'
 activitylevel: 10

--- a/_datafiles/world/default/mobs/frostfang/6-trainer.yaml
+++ b/_datafiles/world/default/mobs/frostfang/6-trainer.yaml
@@ -4,6 +4,8 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 idlecommands:
   - 'say I can help you <ansi fg="command">train</ansi> new skills!'
   - 'say There are other trainers to be found in the world, with other skills to teach you.'

--- a/_datafiles/world/default/mobs/frostfang/7-wench.yaml
+++ b/_datafiles/world/default/mobs/frostfang/7-wench.yaml
@@ -4,6 +4,8 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 idlecommands:
   - 'say You can <ansi fg="command">sleep</ansi> here for a bit here to refresh.'
   - 'say If you''re hungry check the <ansi fg="command">list</ansi> of food for sale.'

--- a/_datafiles/world/default/mobs/frostfang/8-king.yaml
+++ b/_datafiles/world/default/mobs/frostfang/8-king.yaml
@@ -4,6 +4,8 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
+combatcommands:
+  - 'callforhelp 7:guard:calls for the guards.'
 character:
   name: king
   description: 'Seated upon his regal throne, the King of Frostfang carries the weight of his kingdom with a quiet dignity. His attire is a rich tapestry of royal blues and silvers, adorned with intricate embroidery that tells the story of his lineage and the battles fought to protect his realm. A heavy, ermine-trimmed cloak drapes over his shoulders, signifying his status and the responsibilities that come with it. His crown, a delicate circlet of silver and sapphires, rests atop his brow, glinting softly in the dim light of the throne room.'

--- a/_datafiles/world/default/mobs/frostfang/9-kings_guard.yaml
+++ b/_datafiles/world/default/mobs/frostfang/9-kings_guard.yaml
@@ -4,7 +4,9 @@ itemdropchance: 2
 hostile: false
 maxwander: 2
 groups: 
-  - frostfang-npc
+  - frostfang-law
+combatcommands:
+  - 'callforhelp 5:puts their fingers to their mouth and whistle loudly.'
 character:
   name: king's guard
   description: 'The King''s Guard stands resolute, a formidable perception in the royal throne room. Clad in meticulously maintained armor that gleams under the soft lighting, they exude an air of unwavering loyalty and strength. The guard''s helmet obscures their face, adding an element of mystery and intimidation, while their posture remains erect and vigilant, ready to spring into action at a moment''s notice. A well-polished broadsword hangs at their side, its perception a silent promise to defend the king and the kingdom with their life.'

--- a/_datafiles/world/default/mobs/frostfang/scripts/2-guard.js
+++ b/_datafiles/world/default/mobs/frostfang/scripts/2-guard.js
@@ -65,3 +65,17 @@ function onPath(mob, room, eventDetails) {
     }
 
 }
+
+
+function onPlayerDowned(mob, user, room) {
+    
+    user.SendText(mob.GetCharacterName(true) + " approaches you from behind, striking you with the pommel of their sword.");
+    user.SendText("The last thing you remember hearing is the jingling of chains as you black out.");
+
+    room.SendText(mob.GetCharacterName(true) + " approaches " + user.GetCharacterName(true) + " from behind, striking them with the pommel of their sword.", user.UserId());
+    room.SendText(mob.GetCharacterName(true) + " places " + user.GetCharacterName(true) + " in chains, and sends them away with a deputy to put them in jail.", user.UserId());
+
+    user.MoveRoom(1003);
+
+    return true;
+}

--- a/_datafiles/world/default/rooms/frostfang/1003.js
+++ b/_datafiles/world/default/rooms/frostfang/1003.js
@@ -3,6 +3,8 @@ const JAIL_TIME = "1 hour";
 
 function onEnter(user, room) {
 
+    user.SetHealth(1);
+    
     if ( !room.IsEphemeral() ) {
 
         var newRoomIds = CreateInstancesFromRoomIds( [room.RoomId()] );

--- a/_datafiles/world/default/rooms/frostfang/1003.js
+++ b/_datafiles/world/default/rooms/frostfang/1003.js
@@ -14,17 +14,23 @@ function onEnter(user, room) {
 
     }
     
-    user.TimerSet("jail", JAIL_TIME);
+    if ( !user.TimerExists("jail") ) {
 
-    room.SendText("");
-    room.SendText("<ansi fg=\"red-bold\">********************************************************************************</ansi>");
-    room.SendText("You hear a loud <ansi fg=\"red-bold\">!!!CLANK!!!</ansi>, and can immediately tell...");
-    room.SendText("The cell door is LOCKED from the other side!");
-    room.SendText('You hear someone shout, <ansi fg="saytext-mob">"Maybe an hour in a cell will cool you off!"</ansi>');
-    room.SendText("<ansi fg=\"red-bold\">********************************************************************************</ansi>");
-    room.SendText("");
+        user.AddEventLog(`jail`, `Thrown in jail`);
 
-    user.Command("look", 1);
+        user.TimerSet("jail", JAIL_TIME);
+
+        room.SendText("");
+        room.SendText("<ansi fg=\"red-bold\">********************************************************************************</ansi>");
+        room.SendText("You hear a loud <ansi fg=\"red-bold\">!!!CLANK!!!</ansi>, and can immediately tell...");
+        room.SendText("The cell door is LOCKED from the other side!");
+        room.SendText('You hear someone shout, <ansi fg="saytext-mob">"Maybe an hour in a cell will cool you off!"</ansi>');
+        room.SendText("<ansi fg=\"red-bold\">********************************************************************************</ansi>");
+        room.SendText("");
+        
+        user.Command("look", 1);
+        
+    }
 
     return false;
 }
@@ -35,8 +41,9 @@ function onIdle(room) {
         var playersInRoom = room.GetPlayers();
         for( var i in playersInRoom ) {
             if ( playersInRoom[i].TimerExpired("jail") ) {
-                room.SendText("You hear a loud CLANK, and the cell door is UNLOCKED from the other side.");
+                room.SendText("You hear a loud <ansi fg=\"red-bold\">!!!KA-LUNK!!!</ansi>, and the cell door is UNLOCKED from the other side.");
                 room.SetLocked("cell door", false);
+                playersInRoom[i].AddEventLog(`jail`, `Released from jail`);
             }
         }
     }

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -1242,7 +1242,12 @@ func (c *Character) ApplyHealthChange(healthChange int) int {
 	newHealth := c.Health + healthChange
 	if newHealth < 0 {
 		c.CancelBuffsWithFlag(buffs.CancelIfCombat)
-		if newHealth < -10 {
+
+		// If they haven't dropped yet, require a drop before going straight to death.
+		// Don't allow players to drop under -5 in a single hit.
+		if newHealth < -5 && oldHealth > 0 {
+			newHealth = -5
+		} else if newHealth <= -10 {
 			newHealth = -10
 		}
 	} else if newHealth > c.HealthMax.Value {

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -244,6 +244,13 @@ type LevelUp struct {
 
 func (l LevelUp) Type() string { return `LevelUp` }
 
+type PlayerDrop struct {
+	UserId int
+	RoomId int
+}
+
+func (l PlayerDrop) Type() string { return `PlayerDrop` }
+
 type PlayerDeath struct {
 	UserId        int
 	RoomId        int

--- a/internal/hooks/Message_SendMessages.go
+++ b/internal/hooks/Message_SendMessages.go
@@ -21,8 +21,6 @@ func Message_SendMessage(e events.Event) events.ListenerReturn {
 		return events.Continue
 	}
 
-	//mudlog.Debug("Message{}", "userId", message.UserId, "roomId", message.RoomId, "length", len(message.Text), "IsCommunication", message.IsCommunication)
-
 	if message.UserId > 0 {
 
 		if user := users.GetByUserId(message.UserId); user != nil {

--- a/internal/hooks/NewRound_DoCombat.go
+++ b/internal/hooks/NewRound_DoCombat.go
@@ -1075,18 +1075,15 @@ func handleAffected(affectedPlayerIds []int, affectedMobInstanceIds []int) {
 		if user := users.GetByUserId(userId); user != nil {
 
 			if user.Character.Health <= -10 {
+
 				user.Command(`suicide`) // suicide drops all money/items and transports to land of the dead.
+
 			} else if user.Character.Health < 1 {
 
-				user.SendText(`<ansi fg="red">you drop to the ground!</ansi>`)
-
-				if room := rooms.LoadRoom(user.Character.RoomId); room != nil {
-					room.SendText(
-						fmt.Sprintf(`<ansi fg="username">%s</ansi> <ansi fg="red">drops to the ground!</ansi>`, user.Character.Name),
-						user.UserId)
-				}
+				events.AddToQueue(events.PlayerDrop{UserId: user.UserId, RoomId: user.Character.RoomId})
 
 			}
+
 		}
 	}
 

--- a/internal/hooks/PlayerDrop_HandlePlayerDrop.go
+++ b/internal/hooks/PlayerDrop_HandlePlayerDrop.go
@@ -1,0 +1,66 @@
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/mobs"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/scripting"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+//
+// Some clean up
+//
+
+func HandlePlayerDrop(e events.Event) events.ListenerReturn {
+
+	evt, typeOk := e.(events.PlayerDrop)
+	if !typeOk {
+		mudlog.Error("Event", "Expected Type", "PlayerDrop", "Actual Type", e.Type())
+		return events.Cancel
+	}
+
+	user := users.GetByUserId(evt.UserId)
+	if user == nil {
+		mudlog.Error("HandlePlayerDrop", "error", fmt.Sprintf(`user %d not found`, evt.UserId))
+		return events.Cancel
+	}
+
+	user.SendText(`<ansi fg="red">you drop to the ground!</ansi>`)
+
+	room := rooms.LoadRoom(evt.RoomId)
+	if room == nil {
+		return events.Continue
+	}
+
+	room.SendText(
+		fmt.Sprintf(`<ansi fg="username">%s</ansi> <ansi fg="red">drops to the ground!</ansi>`, user.Character.Name),
+		user.UserId)
+
+	// Loop through all mobs in the room. If any hate the player, try onPlayerDowned()
+	skipMobIds := map[int]struct{}{}
+	for _, mobInstanceId := range room.GetMobs() {
+		mob := mobs.GetInstance(mobInstanceId)
+		if mob == nil {
+			continue
+		}
+
+		if _, ok := skipMobIds[int(mob.MobId)]; ok {
+			continue
+		}
+
+		if !mob.HasAttackedPlayer(user.UserId) {
+			continue
+		}
+
+		if isUnique, _ := scripting.TryPlayerDownedEvent(mobInstanceId, user.UserId); isUnique {
+			skipMobIds[int(mob.MobId)] = struct{}{}
+		}
+
+	}
+
+	return events.Continue
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -70,6 +70,7 @@ func RegisterListeners() {
 	// User Settings change
 	events.RegisterListener(events.UserSettingChanged{}, ClearSettingCaches)
 
+	events.RegisterListener(events.PlayerDrop{}, HandlePlayerDrop)
 	events.RegisterListener(events.WebClientCommand{}, WebClientCommand_SendWebClientCommand)
 
 	events.RegisterListener(events.CharacterCreated{}, BroadcastNewChar)

--- a/internal/mobcommands/attack.go
+++ b/internal/mobcommands/attack.go
@@ -110,6 +110,9 @@ func Attack(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 		if u != nil {
 
+			// Track that they've attacked this player
+			mob.PlayerAttacked(attackPlayerId)
+
 			mob.Character.SetAggro(attackPlayerId, 0, characters.DefaultAttack)
 
 			if !isSneaking {

--- a/internal/mobcommands/attack.go
+++ b/internal/mobcommands/attack.go
@@ -42,6 +42,50 @@ func Attack(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 				}
 			}
 		}
+	} else if rest[0] == '*' { // choose a target at random. Friend or foe.
+
+		if rest == `*` { // * ANYONE
+
+			allMobs := []int{}
+			allPlayers := room.GetPlayers()
+			for _, mobInstanceId := range room.GetMobs() {
+				if mobInstanceId == mob.InstanceId {
+					continue
+				}
+				allMobs = append(allMobs, mobInstanceId)
+			}
+
+			randomSelection := util.Rand(len(allMobs) + len(allPlayers))
+
+			if randomSelection < len(allMobs) {
+				attackMobInstanceId = allMobs[randomSelection]
+			} else {
+				randomSelection -= len(allMobs)
+				attackPlayerId = allPlayers[randomSelection]
+			}
+
+		} else if rest == `*mob` { // *mob ANY MOB
+
+			allMobs := []int{}
+			for _, mobInstanceId := range room.GetMobs() {
+				if mobInstanceId == mob.InstanceId {
+					continue
+				}
+				allMobs = append(allMobs, mobInstanceId)
+			}
+
+			if len(allMobs) > 0 {
+				attackMobInstanceId = allMobs[util.Rand(len(allMobs))]
+			}
+
+		} else { // *user etc. ANY PLAYER
+
+			if allPlayers := room.GetPlayers(); len(allPlayers) > 0 {
+				attackPlayerId = allPlayers[util.Rand(len(allPlayers))]
+			}
+
+		}
+
 	} else {
 		attackPlayerId, attackMobInstanceId = room.FindByName(rest)
 	}

--- a/internal/mobcommands/callforhelp.go
+++ b/internal/mobcommands/callforhelp.go
@@ -14,6 +14,10 @@ import (
 // Format should be:
 // callforhelp blows his horn
 // "blows his horn" will be emoted to the room
+// Other valid formats:
+// callforhelp 5:blows a horn, calling for help
+// callforhelp 5:guard:blows a horn, calling for help
+// callforhelp guard:blows a horn, calling for help
 func CallForHelp(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	calledForHelp := false
@@ -33,6 +37,19 @@ func CallForHelp(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		}
 	}
 
+	mobNameSearch := ``
+	// "callforhelp 5:guard:blows a horn, calling for help"
+	// "callforhelp guard:blows a horn, calling for help"
+	if i := strings.Index(rest, ":"); i >= 0 {
+		mobNameSearch = strings.ToLower(strings.TrimSpace(rest[:i]))
+
+		if i < len(rest)-1 {
+			rest = strings.TrimSpace(rest[i+1:])
+		} else {
+			rest = ``
+		}
+	}
+
 	m := mapper.GetMapper(room.RoomId)
 	roomList := m.FindRoomsInDistance(room.RoomId, maxRange, 0)
 
@@ -46,8 +63,14 @@ func CallForHelp(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 			if mobInfo := mobs.GetInstance(nearbyMobInstanceId); mobInfo != nil {
 
-				if !mobInfo.IsAlly(mob) { // Only help allies
-					continue
+				if mobNameSearch == `` {
+					if !mobInfo.ConsidersAnAlly(mob) { // Only help allies
+						continue
+					}
+				} else {
+					if mobNameSearch != strings.ToLower(mobInfo.Character.Name) {
+						continue
+					}
 				}
 
 				if !calledForHelp {

--- a/internal/mobcommands/callforhelp.go
+++ b/internal/mobcommands/callforhelp.go
@@ -2,7 +2,10 @@ package mobcommands
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/GoMudEngine/GoMud/internal/mapper"
 	"github.com/GoMudEngine/GoMud/internal/mobs"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
 )
@@ -13,29 +16,35 @@ import (
 // "blows his horn" will be emoted to the room
 func CallForHelp(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	if mob.Character.Aggro == nil || mob.Character.Aggro.UserId == 0 {
-		return false, fmt.Errorf(`mob %d has no aggro`, mob.InstanceId)
-	}
-
 	calledForHelp := false
 
-	for _, roomInfo := range room.Exits {
-		adjRoom := rooms.LoadRoom(roomInfo.RoomId)
-		if adjRoom.MobCt() < 1 {
+	maxRange := 1
+	// Can prefix callforhelp string with a number and : to force range.
+	// "callforhelp 5:blows a horn, calling for help"
+	if i := strings.Index(rest, ":"); i >= 0 {
+		newRangeStr := strings.TrimSpace(rest[:i])
+		if newRange, err := strconv.Atoi(newRangeStr); err == nil {
+			maxRange = newRange
+			if i < len(rest)-1 {
+				rest = strings.TrimSpace(rest[i+1:])
+			} else {
+				rest = ``
+			}
+		}
+	}
+
+	m := mapper.GetMapper(room.RoomId)
+	roomList := m.FindRoomsInDistance(room.RoomId, maxRange, 0)
+
+	for _, roomId := range roomList {
+		testRoom := rooms.LoadRoom(roomId)
+		if testRoom == nil {
 			continue
 		}
 
-		exitIntoRoom := adjRoom.FindExitTo(room.RoomId)
-		if exitIntoRoom == `` {
-			continue
-		}
+		for _, nearbyMobInstanceId := range testRoom.GetMobs(rooms.FindNeutral, rooms.FindHostile) {
 
-		for _, nearbyMobInstanceId := range adjRoom.GetMobs(rooms.FindNeutral, rooms.FindHostile) {
 			if mobInfo := mobs.GetInstance(nearbyMobInstanceId); mobInfo != nil {
-
-				//if mobInfo.MaxWander == 0 { // Mobs that do not wander at all won't heed the call
-				//	continue
-				//}
 
 				if !mobInfo.IsAlly(mob) { // Only help allies
 					continue
@@ -51,10 +60,20 @@ func CallForHelp(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 					}
 				}
 
-				mobInfo.Command(fmt.Sprintf(`go %s`, exitIntoRoom))
-				mobInfo.Command(fmt.Sprintf(`attack @%d`, mob.Character.Aggro.UserId))
+				_, randomRoomId := room.GetRandomExit()
+
+				if randomRoomId > 0 {
+					mobInfo.Command(fmt.Sprintf(`go %d`, randomRoomId), 1.0)
+				}
+
+				mobInfo.Command(fmt.Sprintf(`go %d`, room.RoomId), 1.0)
+
+				if mob.Character.Aggro != nil && mob.Character.Aggro.UserId > 0 {
+					mobInfo.Command(fmt.Sprintf(`attack @%d`, mob.Character.Aggro.UserId), 0.25)
+				}
 			}
 		}
+
 	}
 
 	return true, nil

--- a/internal/mobcommands/shout.go
+++ b/internal/mobcommands/shout.go
@@ -2,7 +2,6 @@ package mobcommands
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/GoMudEngine/GoMud/internal/buffs"
 	"github.com/GoMudEngine/GoMud/internal/mobs"
@@ -12,8 +11,6 @@ import (
 func Shout(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	isSneaking := mob.Character.HasBuffFlag(buffs.Hidden)
-
-	rest = strings.ToUpper(rest)
 
 	if isSneaking {
 		room.SendText(fmt.Sprintf(`someone shouts, "<ansi fg="saytext-mob">%s</ansi>"`, rest))

--- a/internal/mobs/mobs.go
+++ b/internal/mobs/mobs.go
@@ -587,7 +587,7 @@ func (m *Mob) GetIdleCommand() string {
 	return ``
 }
 
-func (r *Mob) IsAlly(m *Mob) bool {
+func (r *Mob) ConsidersAnAlly(m *Mob) bool {
 
 	if m.MobId == r.MobId {
 		return true // Auto ally with own kind
@@ -598,10 +598,12 @@ func (r *Mob) IsAlly(m *Mob) bool {
 	}
 
 	// If they both belong to factions/groups, check for matches
-	if len(m.Groups) > 0 && len(r.Groups) > 0 {
+	// Could conver tthis to a look up map.
+	// Only a couple entries likely, so maybe not worth it.
+	if len(r.Groups) > 0 {
 		// Look for a group match
-		for _, testGroup := range m.Groups {
-			for _, targetGroup := range r.Groups {
+		for _, targetGroup := range r.Groups {
+			for _, testGroup := range m.Groups {
 				if testGroup == targetGroup {
 					return true
 				}
@@ -625,6 +627,7 @@ func (r *Mob) Validate() error {
 	}
 
 	r.Character.Validate()
+
 	return nil
 }
 

--- a/internal/mobs/mobs.go
+++ b/internal/mobs/mobs.go
@@ -75,9 +75,10 @@ type Mob struct {
 	QuestFlags      []string `yaml:"questflags,omitempty,flow"` // What quest flags are set on this mob?
 	BuffIds         []int    `yaml:"buffids,omitempty"`         // Buff Id's this mob always has upon spawn
 	tempDataStore   map[string]any
-	conversationId  int       // Identifier of conversation currently involved in.
-	Path            PathQueue `yaml:"-"` // a pre-calculated path the mob is following.
-	lastCommandTurn uint64    // The last turn a command was scheduled for
+	conversationId  int              // Identifier of conversation currently involved in.
+	Path            PathQueue        `yaml:"-"` // a pre-calculated path the mob is following.
+	lastCommandTurn uint64           // The last turn a command was scheduled for
+	playersAttacked map[int]struct{} // all players this mob has attacked at some point
 }
 
 func MobInstanceExists(instanceId int) bool {
@@ -102,6 +103,7 @@ func GetAllMobNames() []string {
 func TrackRecentDeath(instanceId int) {
 	recentlyDied[instanceId] = int(util.GetRoundCount())
 }
+
 func RecentlyDied(instanceId int) bool {
 
 	if len(recentlyDied) > 30 {
@@ -256,6 +258,21 @@ func (m *Mob) AddBuff(buffId int, source string) {
 		Source:        source,
 	})
 
+}
+
+func (m *Mob) PlayerAttacked(userId int) {
+	if m.playersAttacked == nil {
+		m.playersAttacked = map[int]struct{}{}
+	}
+	m.playersAttacked[userId] = struct{}{}
+}
+
+func (m *Mob) HasAttackedPlayer(userId int) bool {
+	if m.playersAttacked == nil {
+		return false
+	}
+	_, ok := m.playersAttacked[userId]
+	return ok
 }
 
 func (m *Mob) InConversation() bool {

--- a/internal/scripting/actor_func.go
+++ b/internal/scripting/actor_func.go
@@ -579,6 +579,13 @@ func (a ScriptActor) GetRaceKills(race string) int {
 	return raceKills[race]
 }
 
+func (a ScriptActor) SetHealth(amt int) {
+	a.characterRecord.Health = amt
+	if a.characterRecord.Health > a.characterRecord.HealthMax.Value {
+		a.characterRecord.Health = a.characterRecord.HealthMax.Value
+	}
+}
+
 func (a ScriptActor) GetHealth() int {
 	return a.characterRecord.Health
 }

--- a/internal/scripting/actor_func.go
+++ b/internal/scripting/actor_func.go
@@ -402,6 +402,12 @@ func (a ScriptActor) UpdateItem(itm ScriptItem) {
 	a.userRecord.Character.UpdateItem(itm.originalItem, *itm.itemRecord)
 }
 
+func (a ScriptActor) AddEventLog(category string, message string) {
+	if a.userRecord != nil {
+		a.userRecord.EventLog.Add(category, message)
+	}
+}
+
 func (a ScriptActor) GiveItem(itm any) {
 
 	var sItem *ScriptItem

--- a/internal/usercommands/attack.go
+++ b/internal/usercommands/attack.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/parties"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
 	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
 )
 
 func Attack(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
@@ -83,6 +84,50 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 					}
 				}
 			}
+		}
+
+	} else if rest[0] == '*' { // choose a target at random. Friend or foe.
+
+		if rest == `*` { // * ANYONE
+
+			allMobs := room.GetMobs()
+			allPlayers := []int{}
+			for _, userId := range room.GetPlayers() {
+				if userId == user.UserId {
+					continue
+				}
+				allPlayers = append(allPlayers, userId)
+			}
+
+			randomSelection := util.Rand(len(allMobs) + len(allPlayers))
+
+			if randomSelection < len(allMobs) {
+				attackMobInstanceId = allMobs[randomSelection]
+			} else {
+				randomSelection -= len(allMobs)
+				attackPlayerId = allPlayers[randomSelection]
+			}
+
+		} else if rest == `*mob` { // *mob ANY MOB
+
+			if allMobs := room.GetMobs(); len(allMobs) > 0 {
+				attackMobInstanceId = allMobs[util.Rand(len(allMobs))]
+			}
+
+		} else { // *user etc. ANY PLAYER
+
+			allPlayers := []int{}
+			for _, userId := range room.GetPlayers() {
+				if userId == user.UserId {
+					continue
+				}
+				allPlayers = append(allPlayers, userId)
+			}
+
+			if len(allPlayers) > 0 {
+				attackPlayerId = allPlayers[util.Rand(len(allPlayers))]
+			}
+
 		}
 
 	} else {

--- a/internal/usercommands/go.go
+++ b/internal/usercommands/go.go
@@ -67,7 +67,6 @@ func Go(rest string, user *users.UserRecord, room *rooms.Room, flags events.Even
 
 		exitInfo, _ := room.GetExitInfo(exitName)
 
-		fmt.Println(exitInfo.Lock.IsLocked())
 		if exitInfo.Lock.IsLocked() {
 
 			lockId := fmt.Sprintf(`%d-%s`, room.RoomId, exitName)

--- a/world.go
+++ b/world.go
@@ -1076,29 +1076,6 @@ func (w *World) Kick(userId int, reason string) {
 	connections.Kick(user.ConnectionId(), reason)
 }
 
-// Handle dropped players
-func (w *World) HandleDroppedPlayers(droppedPlayers []int) {
-
-	if len(droppedPlayers) == 0 {
-		return
-	}
-
-	for _, userId := range droppedPlayers {
-		if user := users.GetByUserId(userId); user != nil {
-
-			user.SendText(`<ansi fg="red">you drop to the ground!</ansi>`)
-
-			if room := rooms.LoadRoom(user.Character.RoomId); room != nil {
-				room.SendText(
-					fmt.Sprintf(`<ansi fg="username">%s</ansi> <ansi fg="red">drops to the ground!</ansi>`, user.Character.Name),
-					user.UserId)
-			}
-		}
-	}
-
-	return
-}
-
 // Should only handle sending messages out to users
 func (w *World) EventLoop() {
 


### PR DESCRIPTION
# Description

Guards now send players to jail if they down them.

## Changes

- Mobs have `onPlayerDowned()` events now.
- Added a wildcard option for attacking: `attack *`, `attack *mob`, `attack *player`, which selects randomly.
- Scripting `Actor.SetHealth()`
- Scripting `Actor.AddEventLog()`
- Players being dropped is now a `PlayerDrop{}` event.
- `callforhelp` command accepts a distance specifier now: `callforhelp 4:sounds the alarm` will call for help for allies within 4 coordinate rooms away (Manhattan calculated)
- Guards in Frostfang now send players to jail if they defeat them.
- Guards sometimes call for help if in combat
- mob `go` command accepts a RoomId argument now, to semi-teleport to the room specified.

## Example:

<img width="754" alt="image" src="https://github.com/user-attachments/assets/340be926-d362-476a-ac24-35179c47defe" />



