### PR TITLE
swapping around  and  to avoid null ptr deref

### DIFF
--- a/internal/rooms/roommanager.go
+++ b/internal/rooms/roommanager.go
@@ -696,10 +696,10 @@ func CreateZone(zoneName string) (roomId int, err error) {
 		return 0, err
 	}
 
+	addRoomToMemory(newRoom)
+
 	// save to the flat file
 	SaveRoomTemplate(*newRoom)
-
-	addRoomToMemory(newRoom)
 
 	// write room to the folder under the new ID
 	return newRoom.RoomId, nil


### PR DESCRIPTION
# Description

Addressing issue #388 by swapping around the `addRoomToMemory` and `SaveRoomTemplate` function calls in the `CreateZone` function.

## Changes

Provide a bullet point list of noteworthy changes in this Pull Request:

- Calling `addRoomToMemory` before `SaveRoomTemplate` in `CreateZone`.
