### PR TITLE
Added tests to buffs and badinputtracker packages

### DIFF
--- a/internal/badinputtracker/badinputtracker_test.go
+++ b/internal/badinputtracker/badinputtracker_test.go
@@ -1,0 +1,213 @@
+package badinputtracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrackBadCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		commands [][2]string
+		expected map[string]int
+	}{
+		{
+			name: "single command",
+			commands: [][2]string{
+				{"foo", "bar"},
+			},
+			expected: map[string]int{
+				"foo bar": 1,
+			},
+		},
+		{
+			name: "multiple commands same cmd/rest",
+			commands: [][2]string{
+				{"foo", "bar"},
+				{"foo", "bar"},
+			},
+			expected: map[string]int{
+				"foo bar": 2,
+			},
+		},
+		{
+			name: "multiple commands different rest",
+			commands: [][2]string{
+				{"foo", "bar"},
+				{"foo", "baz"},
+			},
+			expected: map[string]int{
+				"foo bar": 1,
+				"foo baz": 1,
+			},
+		},
+		{
+			name: "multiple commands different cmd",
+			commands: [][2]string{
+				{"foo", "bar"},
+				{"baz", "qux"},
+			},
+			expected: map[string]int{
+				"foo bar": 1,
+				"baz qux": 1,
+			},
+		},
+		{
+			name: "complex mix",
+			commands: [][2]string{
+				{"foo", "bar"},
+				{"foo", "bar"},
+				{"foo", "baz"},
+				{"baz", "qux"},
+				{"baz", "qux"},
+				{"baz", "qux"},
+			},
+			expected: map[string]int{
+				"foo bar": 2,
+				"foo baz": 1,
+				"baz qux": 3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Clear()
+			for _, pair := range tt.commands {
+				TrackBadCommand(pair[0], pair[1])
+			}
+			got := GetBadCommands()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+func TestGetBadCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func()
+		expected map[string]int
+	}{
+		{
+			name: "no commands tracked",
+			setup: func() {
+				Clear()
+			},
+			expected: map[string]int{},
+		},
+		{
+			name: "single command tracked",
+			setup: func() {
+				Clear()
+				TrackBadCommand("foo", "bar")
+			},
+			expected: map[string]int{
+				"foo bar": 1,
+			},
+		},
+		{
+			name: "multiple commands tracked",
+			setup: func() {
+				Clear()
+				TrackBadCommand("foo", "bar")
+				TrackBadCommand("foo", "baz")
+				TrackBadCommand("baz", "qux")
+			},
+			expected: map[string]int{
+				"foo bar": 1,
+				"foo baz": 1,
+				"baz qux": 1,
+			},
+		},
+		{
+			name: "increment counts for same command/rest",
+			setup: func() {
+				Clear()
+				TrackBadCommand("foo", "bar")
+				TrackBadCommand("foo", "bar")
+				TrackBadCommand("foo", "bar")
+			},
+			expected: map[string]int{
+				"foo bar": 3,
+			},
+		},
+		{
+			name: "mixed increment and new commands",
+			setup: func() {
+				Clear()
+				TrackBadCommand("foo", "bar")
+				TrackBadCommand("foo", "bar")
+				TrackBadCommand("foo", "baz")
+				TrackBadCommand("baz", "qux")
+				TrackBadCommand("baz", "qux")
+			},
+			expected: map[string]int{
+				"foo bar": 2,
+				"foo baz": 1,
+				"baz qux": 2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			got := GetBadCommands()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+func TestClear(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func()
+		expectLen int
+	}{
+		{
+			name: "clear after tracking commands",
+			setup: func() {
+				Clear()
+				TrackBadCommand("foo", "bar")
+				TrackBadCommand("baz", "qux")
+			},
+			expectLen: 0,
+		},
+		{
+			name: "clear with no commands tracked",
+			setup: func() {
+				Clear()
+			},
+			expectLen: 0,
+		},
+		{
+			name: "clear after multiple clears",
+			setup: func() {
+				Clear()
+				TrackBadCommand("foo", "bar")
+				Clear()
+				Clear()
+			},
+			expectLen: 0,
+		},
+		{
+			name: "clear after incrementing same command",
+			setup: func() {
+				Clear()
+				TrackBadCommand("foo", "bar")
+				TrackBadCommand("foo", "bar")
+				TrackBadCommand("foo", "bar")
+			},
+			expectLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			Clear()
+			got := GetBadCommands()
+			assert.Equal(t, tt.expectLen, len(got))
+			assert.Equal(t, map[string]int{}, got)
+		})
+	}
+}

--- a/internal/buffs/buffs_test.go
+++ b/internal/buffs/buffs_test.go
@@ -1,0 +1,454 @@
+package buffs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDurations(t *testing.T) {
+	type args struct {
+		buff *Buff
+		spec *BuffSpec
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantRounds int
+		wantTotal  int
+	}{
+		{
+			name: "Normal case",
+			args: args{
+				buff: &Buff{RoundCounter: 2},
+				spec: &BuffSpec{TriggerCount: 5, RoundInterval: 3},
+			},
+			wantRounds: 13, // (5*3)-2 = 15-2 = 13
+			wantTotal:  15,
+		},
+		{
+			name: "Zero rounds passed",
+			args: args{
+				buff: &Buff{RoundCounter: 0},
+				spec: &BuffSpec{TriggerCount: 4, RoundInterval: 2},
+			},
+			wantRounds: 8,
+			wantTotal:  8,
+		},
+		{
+			name: "All rounds passed",
+			args: args{
+				buff: &Buff{RoundCounter: 12},
+				spec: &BuffSpec{TriggerCount: 3, RoundInterval: 4},
+			},
+			wantRounds: 0, // (3*4)-12 = 12-12 = 0
+			wantTotal:  12,
+		},
+		{
+			name: "RoundCounter greater than total",
+			args: args{
+				buff: &Buff{RoundCounter: 10},
+				spec: &BuffSpec{TriggerCount: 2, RoundInterval: 4},
+			},
+			wantRounds: -2, // (2*4)-10 = 8-10 = -2
+			wantTotal:  8,
+		},
+		{
+			name: "Zero trigger count",
+			args: args{
+				buff: &Buff{RoundCounter: 1},
+				spec: &BuffSpec{TriggerCount: 0, RoundInterval: 5},
+			},
+			wantRounds: -1, // (0*5)-1 = 0-1 = -1
+			wantTotal:  0,
+		},
+		{
+			name: "Zero round interval",
+			args: args{
+				buff: &Buff{RoundCounter: 3},
+				spec: &BuffSpec{TriggerCount: 4, RoundInterval: 0},
+			},
+			wantRounds: -3, // (4*0)-3 = 0-3 = -3
+			wantTotal:  0,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gotRounds, gotTotal := GetDurations(tt.args.buff, tt.args.spec)
+			assert.Equal(t, tt.wantRounds, gotRounds)
+			assert.Equal(t, tt.wantTotal, gotTotal)
+		})
+	}
+}
+func TestBuffs_HasBuff(t *testing.T) {
+	type fields struct {
+		list    []*Buff
+		buffIds map[int]int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		arg    int
+		want   bool
+	}{
+		{
+			name: "Buff exists in buffIds",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1},
+					{BuffId: 2},
+				},
+				buffIds: map[int]int{1: 0, 2: 1},
+			},
+			arg:  1,
+			want: true,
+		},
+		{
+			name: "Buff does not exist in buffIds",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1},
+					{BuffId: 2},
+				},
+				buffIds: map[int]int{1: 0, 2: 1},
+			},
+			arg:  3,
+			want: false,
+		},
+		{
+			name: "Empty buffIds map",
+			fields: fields{
+				list:    []*Buff{},
+				buffIds: map[int]int{},
+			},
+			arg:  1,
+			want: false,
+		},
+		{
+			name: "BuffIds map is nil",
+			fields: fields{
+				list:    []*Buff{},
+				buffIds: nil,
+			},
+			arg:  1,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			bs := &Buffs{
+				List:    tt.fields.list,
+				buffIds: tt.fields.buffIds,
+			}
+			assert.Equal(t, tt.want, bs.HasBuff(tt.arg))
+		})
+	}
+}
+func TestBuffs_Started(t *testing.T) {
+	type fields struct {
+		list    []*Buff
+		buffIds map[int]int
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		arg          int
+		wantOnStart  bool
+		shouldChange bool
+	}{
+		{
+			name: "Buff exists and OnStartWaiting is true",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, OnStartWaiting: true},
+					{BuffId: 2, OnStartWaiting: true},
+				},
+				buffIds: map[int]int{1: 0, 2: 1},
+			},
+			arg:          1,
+			wantOnStart:  false,
+			shouldChange: true,
+		},
+		{
+			name: "Buff exists and OnStartWaiting is already false",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, OnStartWaiting: false},
+				},
+				buffIds: map[int]int{1: 0},
+			},
+			arg:          1,
+			wantOnStart:  false,
+			shouldChange: false,
+		},
+		{
+			name: "Buff does not exist",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, OnStartWaiting: true},
+				},
+				buffIds: map[int]int{1: 0},
+			},
+			arg:          2,
+			wantOnStart:  true,
+			shouldChange: false,
+		},
+		{
+			name: "Empty buffIds map",
+			fields: fields{
+				list:    []*Buff{},
+				buffIds: map[int]int{},
+			},
+			arg:          1,
+			wantOnStart:  false,
+			shouldChange: false,
+		},
+		{
+			name: "buffIds is nil",
+			fields: fields{
+				list:    []*Buff{},
+				buffIds: nil,
+			},
+			arg:          1,
+			wantOnStart:  false,
+			shouldChange: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			bs := &Buffs{
+				List:    tt.fields.list,
+				buffIds: tt.fields.buffIds,
+			}
+			if tt.shouldChange && len(bs.List) > 0 {
+				assert.True(t, bs.List[bs.buffIds[tt.arg]].OnStartWaiting)
+			}
+			bs.Started(tt.arg)
+			if idx, ok := bs.buffIds[tt.arg]; ok && idx < len(bs.List) {
+				assert.Equal(t, tt.wantOnStart, bs.List[idx].OnStartWaiting)
+			} else if len(bs.List) > 0 {
+				// If buff does not exist, original value should remain unchanged
+				assert.Equal(t, tt.wantOnStart, bs.List[0].OnStartWaiting)
+			}
+		})
+	}
+}
+func TestBuffs_TriggersLeft(t *testing.T) {
+	type fields struct {
+		list    []*Buff
+		buffIds map[int]int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		arg    int
+		want   int
+	}{
+		{
+			name: "Buff exists and has positive TriggersLeft",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, TriggersLeft: 3},
+					{BuffId: 2, TriggersLeft: 5},
+				},
+				buffIds: map[int]int{1: 0, 2: 1},
+			},
+			arg:  2,
+			want: 5,
+		},
+		{
+			name: "Buff exists and has zero TriggersLeft",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, TriggersLeft: 0},
+				},
+				buffIds: map[int]int{1: 0},
+			},
+			arg:  1,
+			want: 0,
+		},
+		{
+			name: "Buff exists and has negative TriggersLeft",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, TriggersLeft: -2},
+				},
+				buffIds: map[int]int{1: 0},
+			},
+			arg:  1,
+			want: -2,
+		},
+		{
+			name: "Buff does not exist in buffIds",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, TriggersLeft: 3},
+				},
+				buffIds: map[int]int{1: 0},
+			},
+			arg:  2,
+			want: 0,
+		},
+		{
+			name: "buffIds is nil",
+			fields: fields{
+				list:    []*Buff{{BuffId: 1, TriggersLeft: 7}},
+				buffIds: nil,
+			},
+			arg:  1,
+			want: 0,
+		},
+		{
+			name: "buffIds is empty map",
+			fields: fields{
+				list:    []*Buff{{BuffId: 1, TriggersLeft: 7}},
+				buffIds: map[int]int{},
+			},
+			arg:  1,
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			bs := &Buffs{
+				List:    tt.fields.list,
+				buffIds: tt.fields.buffIds,
+			}
+			assert.Equal(t, tt.want, bs.TriggersLeft(tt.arg))
+		})
+	}
+}
+func TestBuffs_RemoveBuff(t *testing.T) {
+	type fields struct {
+		list    []*Buff
+		buffIds map[int]int
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		arg          int
+		wantResult   bool
+		wantTriggers int
+		shouldModify bool
+	}{
+		{
+			name: "Buff exists and is removed",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, TriggersLeft: 5},
+					{BuffId: 2, TriggersLeft: 3},
+				},
+				buffIds: map[int]int{1: 0, 2: 1},
+			},
+			arg:          2,
+			wantResult:   true,
+			wantTriggers: TriggersLeftExpired,
+			shouldModify: true,
+		},
+		{
+			name: "Buff does not exist",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 1, TriggersLeft: 5},
+				},
+				buffIds: map[int]int{1: 0},
+			},
+			arg:          3,
+			wantResult:   false,
+			wantTriggers: 5,
+			shouldModify: false,
+		},
+		{
+			name: "buffIds is nil",
+			fields: fields{
+				list:    []*Buff{{BuffId: 1, TriggersLeft: 7}},
+				buffIds: nil,
+			},
+			arg:          1,
+			wantResult:   false,
+			wantTriggers: 7,
+			shouldModify: false,
+		},
+		{
+			name: "buffIds is empty map",
+			fields: fields{
+				list:    []*Buff{{BuffId: 1, TriggersLeft: 7}},
+				buffIds: map[int]int{},
+			},
+			arg:          1,
+			wantResult:   false,
+			wantTriggers: 7,
+			shouldModify: false,
+		},
+		{
+			name: "Multiple buffs, remove first",
+			fields: fields{
+				list: []*Buff{
+					{BuffId: 10, TriggersLeft: 2},
+					{BuffId: 20, TriggersLeft: 4},
+				},
+				buffIds: map[int]int{10: 0, 20: 1},
+			},
+			arg:          10,
+			wantResult:   true,
+			wantTriggers: TriggersLeftExpired,
+			shouldModify: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			bs := &Buffs{
+				List:    tt.fields.list,
+				buffIds: tt.fields.buffIds,
+			}
+			result := bs.RemoveBuff(tt.arg)
+			assert.Equal(t, tt.wantResult, result)
+			if idx, ok := bs.buffIds[tt.arg]; ok && tt.shouldModify {
+				assert.Equal(t, tt.wantTriggers, bs.List[idx].TriggersLeft)
+			} else if len(bs.List) > 0 {
+				// If not modified, original value should remain
+				assert.Equal(t, tt.wantTriggers, bs.List[0].TriggersLeft)
+			}
+		})
+	}
+}
+func TestBuff_Expired(t *testing.T) {
+	tests := []struct {
+		name         string
+		triggersLeft int
+		want         bool
+	}{
+		{
+			name:         "TriggersLeft is zero (expired)",
+			triggersLeft: 0,
+			want:         true,
+		},
+		{
+			name:         "TriggersLeft is negative (expired)",
+			triggersLeft: -1,
+			want:         true,
+		},
+		{
+			name:         "TriggersLeft is positive (not expired)",
+			triggersLeft: 3,
+			want:         false,
+		},
+		{
+			name:         "TriggersLeft is TriggersLeftUnlimited (not expired)",
+			triggersLeft: TriggersLeftUnlimited,
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Buff{TriggersLeft: tt.triggersLeft}
+			assert.Equal(t, tt.want, b.Expired())
+		})
+	}
+}

--- a/internal/buffs/buffspec.go
+++ b/internal/buffs/buffspec.go
@@ -96,10 +96,7 @@ func (b *BuffSpec) GetValue() int {
 		val += int(math.Abs(float64(v)))
 	}
 
-	freqVal := 5 - b.RoundInterval
-	if freqVal < 0 {
-		freqVal = 0
-	}
+	freqVal := max(5-b.RoundInterval, 0)
 	val += freqVal
 	val += len(b.Flags) * 5
 
@@ -150,7 +147,7 @@ func GetAllBuffIds() []int {
 	return results
 }
 
-// Searches for buffs whos name contain text and returns thehr Ids
+// Searches for buffs whos name contain text and returns their Ids
 func SearchBuffs(searchTerm string) []int {
 
 	searchTerm = strings.TrimSpace(strings.ToLower(searchTerm))

--- a/internal/buffs/buffspec.go
+++ b/internal/buffs/buffspec.go
@@ -147,7 +147,7 @@ func GetAllBuffIds() []int {
 	return results
 }
 
-// Searches for buffs whos name contain text and returns their Ids
+// Searches for buffs whose name contains text and returns their Ids
 func SearchBuffs(searchTerm string) []int {
 
 	searchTerm = strings.TrimSpace(strings.ToLower(searchTerm))

--- a/internal/buffs/buffspec_test.go
+++ b/internal/buffs/buffspec_test.go
@@ -1,0 +1,444 @@
+package buffs
+
+import (
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/statmods"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuffSpec_GetValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        BuffSpec
+		expectedVal int
+	}{
+		{
+			name: "No statmods, no flags, no triggercount",
+			spec: BuffSpec{
+				RoundInterval: 5,
+			},
+			expectedVal: 0,
+		},
+		{
+			name: "Statmods positive and negative, no flags, no triggercount",
+			spec: BuffSpec{
+				StatMods:      statmods.StatMods{"str": 3, "dex": -2},
+				RoundInterval: 5,
+			},
+			expectedVal: 5, // |3| + |−2| = 5, freqVal = 0, flags = 0
+		},
+		{
+			name: "Statmods, flags, no triggercount",
+			spec: BuffSpec{
+				StatMods:      statmods.StatMods{"str": 2},
+				Flags:         []Flag{NoCombat, Hidden},
+				RoundInterval: 3,
+			},
+			expectedVal: 2 + (5 - 3) + 2*5, // 2 + 2 + 10 = 14
+		},
+		{
+			name: "Statmods, flags, triggercount > 0",
+			spec: BuffSpec{
+				StatMods:      statmods.StatMods{"str": 1, "dex": 2},
+				Flags:         []Flag{NoCombat},
+				RoundInterval: 2,
+				TriggerCount:  3,
+			},
+			expectedVal: (1 + 2 + (5 - 2) + 1*5) * 3, // (3 + 3 + 5) * 3 = 11 * 3 = 33
+		},
+		{
+			name: "Negative RoundInterval",
+			spec: BuffSpec{
+				StatMods:      statmods.StatMods{"str": 2},
+				Flags:         []Flag{},
+				RoundInterval: 10,
+			},
+			expectedVal: 2, // freqVal = 5-10 = -5 -> 0, so 2+0+0=2
+		},
+		{
+			name: "Zero RoundInterval",
+			spec: BuffSpec{
+				StatMods:      statmods.StatMods{},
+				Flags:         []Flag{NoCombat},
+				RoundInterval: 0,
+			},
+			expectedVal: 0 + 5 + 5, // freqVal = 5-0=5, flags=1*5=5, total=10
+		},
+		{
+			name: "TriggerCount is 1 (should not multiply)",
+			spec: BuffSpec{
+				StatMods:      statmods.StatMods{"str": 2},
+				Flags:         []Flag{},
+				RoundInterval: 4,
+				TriggerCount:  1,
+			},
+			expectedVal: (2 + (5 - 4) + 0) * 1, // (2+1+0)*1=3
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val := tt.spec.GetValue()
+			assert.Equal(t, tt.expectedVal, val)
+		})
+	}
+}
+func TestBuffSpec_VisibleNameDesc(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     BuffSpec
+		wantName string
+		wantDesc string
+	}{
+		{
+			name: "Secret buff returns mysterious values",
+			spec: BuffSpec{
+				Secret:      true,
+				Name:        "Poison",
+				Description: "Deals damage over time",
+			},
+			wantName: "Mysterious Affliction",
+			wantDesc: "Unknown",
+		},
+		{
+			name: "Non-secret buff returns actual name and description",
+			spec: BuffSpec{
+				Secret:      false,
+				Name:        "Fast Healing",
+				Description: "Increases health recovery",
+			},
+			wantName: "Fast Healing",
+			wantDesc: "Increases health recovery",
+		},
+		{
+			name: "Empty name and description, not secret",
+			spec: BuffSpec{
+				Secret:      false,
+				Name:        "",
+				Description: "",
+			},
+			wantName: "",
+			wantDesc: "",
+		},
+		{
+			name: "Empty name and description, secret",
+			spec: BuffSpec{
+				Secret:      true,
+				Name:        "",
+				Description: "",
+			},
+			wantName: "Mysterious Affliction",
+			wantDesc: "Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotDesc := tt.spec.VisibleNameDesc()
+			assert.Equal(t, tt.wantName, gotName)
+			assert.Equal(t, tt.wantDesc, gotDesc)
+		})
+	}
+}
+func TestGetBuffSpec(t *testing.T) {
+	// Save and restore original buffs map
+	origBuffs := buffs
+	defer func() { buffs = origBuffs }()
+
+	// Setup test buffs
+	buffs = map[int]*BuffSpec{
+		1: {BuffId: 1, Name: "Test Buff 1"},
+		2: {BuffId: 2, Name: "Test Buff 2"},
+	}
+
+	tests := []struct {
+		name      string
+		inputId   int
+		wantBuff  *BuffSpec
+		wantFound bool
+	}{
+		{
+			name:      "Existing positive buffId",
+			inputId:   1,
+			wantBuff:  &BuffSpec{BuffId: 1, Name: "Test Buff 1"},
+			wantFound: true,
+		},
+		{
+			name:      "Existing negative buffId (should convert to positive)",
+			inputId:   -2,
+			wantBuff:  &BuffSpec{BuffId: 2, Name: "Test Buff 2"},
+			wantFound: true,
+		},
+		{
+			name:      "Non-existing buffId",
+			inputId:   99,
+			wantBuff:  nil,
+			wantFound: false,
+		},
+		{
+			name:      "Non-existing negative buffId",
+			inputId:   -99,
+			wantBuff:  nil,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetBuffSpec(tt.inputId)
+			if tt.wantFound {
+				assert.NotNil(t, got)
+				assert.Equal(t, tt.wantBuff.BuffId, got.BuffId)
+				assert.Equal(t, tt.wantBuff.Name, got.Name)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+func TestGetAllBuffIds(t *testing.T) {
+	origBuffs := buffs
+	defer func() { buffs = origBuffs }()
+
+	tests := []struct {
+		name       string
+		setupBuffs map[int]*BuffSpec
+		wantIds    []int
+	}{
+		{
+			name:       "No buffs",
+			setupBuffs: map[int]*BuffSpec{},
+			wantIds:    []int{},
+		},
+		{
+			name: "Single buff",
+			setupBuffs: map[int]*BuffSpec{
+				10: {BuffId: 10, Name: "Solo Buff"},
+			},
+			wantIds: []int{10},
+		},
+		{
+			name: "Multiple buffs",
+			setupBuffs: map[int]*BuffSpec{
+				1: {BuffId: 1, Name: "Buff One"},
+				2: {BuffId: 2, Name: "Buff Two"},
+				3: {BuffId: 3, Name: "Buff Three"},
+			},
+			wantIds: []int{1, 2, 3},
+		},
+		{
+			name: "Buffs with non-sequential IDs",
+			setupBuffs: map[int]*BuffSpec{
+				100: {BuffId: 100, Name: "Buff 100"},
+				5:   {BuffId: 5, Name: "Buff 5"},
+				42:  {BuffId: 42, Name: "Buff 42"},
+			},
+			wantIds: []int{100, 5, 42},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buffs = tt.setupBuffs
+			got := GetAllBuffIds()
+			assert.ElementsMatch(t, tt.wantIds, got)
+		})
+	}
+}
+func TestSearchBuffs(t *testing.T) {
+	origBuffs := buffs
+	defer func() { buffs = origBuffs }()
+
+	buffs = map[int]*BuffSpec{
+		1: {BuffId: 1, Name: "Fast Healing", Description: "Increases health recovery"},
+		2: {BuffId: 2, Name: "Poison", Description: "Deals damage over time"},
+		3: {BuffId: 3, Name: "Night Vision", Description: "See in the dark"},
+		4: {BuffId: 4, Name: "Hidden", Description: "Invisible to others"},
+		5: {BuffId: 5, Name: "Hydrated", Description: "Reduces thirst"},
+	}
+
+	tests := []struct {
+		name       string
+		searchTerm string
+		wantIds    []int
+	}{
+		{
+			name:       "Exact match on name",
+			searchTerm: "Poison",
+			wantIds:    []int{2},
+		},
+		{
+			name:       "Partial match on name (case-insensitive)",
+			searchTerm: "heal",
+			wantIds:    []int{1},
+		},
+		{
+			name:       "Partial match on description",
+			searchTerm: "damage",
+			wantIds:    []int{2},
+		},
+		{
+			name:       "Match multiple buffs by description",
+			searchTerm: "see",
+			wantIds:    []int{3},
+		},
+		{
+			name:       "Match multiple buffs by name",
+			searchTerm: "hid",
+			wantIds:    []int{4},
+		},
+		{
+			name:       "No matches",
+			searchTerm: "fire",
+			wantIds:    []int{},
+		},
+		{
+			name:       "Whitespace and case-insensitive",
+			searchTerm: "   nIgHt   ",
+			wantIds:    []int{3},
+		},
+		{
+			name:       "Empty search term returns all buffs",
+			searchTerm: "",
+			wantIds:    []int{1, 2, 3, 4, 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SearchBuffs(tt.searchTerm)
+			assert.ElementsMatch(t, tt.wantIds, got)
+		})
+	}
+}
+func TestBuffSpec_Id(t *testing.T) {
+	tests := []struct {
+		name   string
+		spec   BuffSpec
+		wantId int
+	}{
+		{
+			name:   "Positive BuffId",
+			spec:   BuffSpec{BuffId: 42},
+			wantId: 42,
+		},
+		{
+			name:   "Zero BuffId",
+			spec:   BuffSpec{BuffId: 0},
+			wantId: 0,
+		},
+		{
+			name:   "Negative BuffId",
+			spec:   BuffSpec{BuffId: -7},
+			wantId: -7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.spec.Id()
+			assert.Equal(t, tt.wantId, got)
+		})
+	}
+}
+func TestBuffSpec_Filename(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     BuffSpec
+		expected string
+	}{
+		{
+			name:     "Simple name",
+			spec:     BuffSpec{BuffId: 1, Name: "Fast Healing"},
+			expected: "1-fast_healing.yaml",
+		},
+		{
+			name:     "Name with special characters",
+			spec:     BuffSpec{BuffId: 42, Name: "Poison!@#"},
+			expected: "42-poison___.yaml",
+		},
+		{
+			name:     "Name with spaces and mixed case",
+			spec:     BuffSpec{BuffId: 7, Name: "Night Vision"},
+			expected: "7-night_vision.yaml",
+		},
+		{
+			name:     "Name with underscores and dashes",
+			spec:     BuffSpec{BuffId: 100, Name: "Hydrated_buff-test"},
+			expected: "100-hydrated_buff_test.yaml",
+		},
+		{
+			name:     "Empty name",
+			spec:     BuffSpec{BuffId: 5, Name: ""},
+			expected: "5-.yaml",
+		},
+		{
+			name:     "Name with leading/trailing spaces",
+			spec:     BuffSpec{BuffId: 8, Name: "  Hidden Buff  "},
+			expected: "8-__hidden_buff__.yaml",
+		},
+		{
+			name:     "Name with multiple spaces",
+			spec:     BuffSpec{BuffId: 9, Name: "Buff    With   Spaces"},
+			expected: "9-buff____with___spaces.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.spec.Filename()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+func TestBuffSpec_Filepath(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     BuffSpec
+		expected string
+	}{
+		{
+			name:     "Simple name",
+			spec:     BuffSpec{BuffId: 1, Name: "Fast Healing"},
+			expected: "1-fast_healing.yaml",
+		},
+		{
+			name:     "Name with special characters",
+			spec:     BuffSpec{BuffId: 42, Name: "Poison!@#"},
+			expected: "42-poison___.yaml",
+		},
+		{
+			name:     "Name with spaces and mixed case",
+			spec:     BuffSpec{BuffId: 7, Name: "Night Vision"},
+			expected: "7-night_vision.yaml",
+		},
+		{
+			name:     "Name with underscores and dashes",
+			spec:     BuffSpec{BuffId: 100, Name: "Hydrated_buff-test"},
+			expected: "100-hydrated_buff_test.yaml",
+		},
+		{
+			name:     "Empty name",
+			spec:     BuffSpec{BuffId: 5, Name: ""},
+			expected: "5-.yaml",
+		},
+		{
+			name:     "Name with leading/trailing spaces",
+			spec:     BuffSpec{BuffId: 8, Name: "  Hidden Buff  "},
+			expected: "8-__hidden_buff__.yaml",
+		},
+		{
+			name:     "Name with multiple spaces",
+			spec:     BuffSpec{BuffId: 9, Name: "Buff    With   Spaces"},
+			expected: "9-buff____with___spaces.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.spec.Filepath()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
# Description
Added generated tests to `buffs` and `badinputtracker` packages.

## Changes

Provide a bullet point list of noteworthy changes in this Pull Request:

- `github.com/GoMudEngine/GoMud/internal/buffs 0.306s  coverage: 25.8% of statements`
- `github.com/GoMudEngine/GoMud/internal/badinputtracker   0.351s  coverage: 100.0% of statements`