### PR TITLE
Responding to user when they set a room property

### DIFF
--- a/internal/usercommands/admin.room.go
+++ b/internal/usercommands/admin.room.go
@@ -410,6 +410,7 @@ func Room(rest string, user *users.UserRecord, liveRoom *rooms.Room, flags event
 			return false, fmt.Errorf("room %d not found", roomId)
 		}
 
+		user.SendText(fmt.Sprintf("Room %s set to %s.", propertyName, propertyValue))
 	} else {
 		user.SendText(fmt.Sprintf(`Invalid room command: <ansi fg="command">%s</ansi>`, roomCmd))
 	}


### PR DESCRIPTION
# Description

Currently when a user sets a room property, such as `room set title "Hello!"` they do not receive any response back letting them know the property was set.

## Changes

Provide a bullet point list of noteworthy changes in this Pull Request:

- Sending the user text letting them know that the property was set on the room (following a similar format as exists for room exits).
