### PR TITLE
Move biome definitions to YAML configuration with hot reload support

### DIFF
--- a/_datafiles/world/default/biomes.yaml
+++ b/_datafiles/world/default/biomes.yaml
@@ -1,0 +1,153 @@
+# Default biome definitions for GoMud
+# Each biome has properties that affect gameplay and display
+
+biomes:
+  city:
+    name: City
+    symbol: "•"
+    description: "Cities are generally well protected. Law enforcement will attempt to subdue those who murder or steal. It's generally considered a safe area although it's not unknown for predators to hunt within their walls."
+    darkArea: false
+    litArea: true
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  fort:
+    name: Fort
+    symbol: "•"
+    description: "Forts are cities or dwellings that are fortified."
+    darkArea: false
+    litArea: true
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  road:
+    name: Road
+    symbol: "•"
+    description: "Roads are well worn paths, generally well traveled."
+    darkArea: false
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  house:
+    name: House
+    symbol: "⌂"
+    description: "Standard domiciles and other dwellings."
+    darkArea: false
+    litArea: true
+    requiredItemId: 0
+    usesItem: false
+    burns: true
+
+  shore:
+    name: Shore
+    symbol: "~"
+    description: "Where the land meets the water."
+    darkArea: false
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  water:
+    name: Deep Water
+    symbol: "≈"
+    description: "Deep water is dangerous to traverse without the appropriate equipment. Very easy to lose your footing, or go under."
+    darkArea: false
+    litArea: false
+    requiredItemId: 20030
+    usesItem: false
+    burns: false
+
+  forest:
+    name: Forest
+    symbol: "♣"
+    description: "Forests are generally green and verdant. All types of creatures lurk within them. Plenty of trees."
+    darkArea: false
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: true
+
+  mountains:
+    name: Mountains
+    symbol: "⩕"
+    description: "Mountains can be difficult to traverse."
+    darkArea: false
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  cliffs:
+    name: Cliffs
+    symbol: "▼"
+    description: "Steep, rocky areas that can be dangerous to navigate."
+    darkArea: false
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  swamp:
+    name: Swamp
+    symbol: "♨"
+    description: "Dark, wet, muddy. All sorts of creatures that creep and crawl inhabit swamps."
+    darkArea: true
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  snow:
+    name: Snow
+    symbol: "❄"
+    description: "Cold and wet."
+    darkArea: false
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  spiderweb:
+    name: Spiderweb
+    symbol: "🕸"
+    description: "Sticky strands of web that are strong enough to support a person. The domain of spiders. It's naturally quite dark due to the thick coating of web everywhere."
+    darkArea: true
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  cave:
+    name: Cave
+    symbol: "⌬"
+    description: "Dark areas underground."
+    darkArea: true
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  desert:
+    name: Desert
+    symbol: "*"
+    description: "Harsh and dry."
+    darkArea: false
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: false
+
+  farmland:
+    name: Farmland
+    symbol: ","
+    description: "Cultivated land used for growing crops."
+    darkArea: false
+    litArea: false
+    requiredItemId: 0
+    usesItem: false
+    burns: true

--- a/internal/usercommands/admin.reload.go
+++ b/internal/usercommands/admin.reload.go
@@ -27,6 +27,9 @@ func Reload(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 	case `items`:
 		items.LoadDataFiles()
 		user.SendText(`Items reloaded.`)
+	case `biomes`:
+		rooms.LoadBiomeDataFiles()
+		user.SendText(`Biomes reloaded.`)
 	case `translations`:
 		ok := language.ReloadTranslation()
 		if !ok {

--- a/main.go
+++ b/main.go
@@ -919,6 +919,15 @@ func loadAllDataFiles(isReload bool) {
 	// Force clear all cached VM's
 	scripting.PruneVMs(true)
 
+	// Load biomes before rooms since rooms reference biomes
+	rooms.LoadBiomeDataFiles()
+	// Validate biomes after loading
+	if warnings := rooms.ValidateBiomes(); len(warnings) > 0 {
+		for _, warning := range warnings {
+			mudlog.Warn("Biome validation", "warning", warning)
+		}
+	}
+
 	spells.LoadSpellFiles()
 	rooms.LoadDataFiles()
 	buffs.LoadDataFiles() // Load buffs before items for cost calculation reasons


### PR DESCRIPTION
## Summery

This PR refactors the biome system to move biome definitions from hardcoded values to external YAML configuration files, enabling dynamic loading and hot reloading of biome data.

### Key Changes

- External Configuration: Biomes are now defined in _datafiles/world/{worldname}/biomes.yaml instead of being hardcoded
- Hot Reload: Added support for reloading biomes at runtime via reload biomes admin command
- Backwards Compatibility: Falls back to hardcoded defaults if no biome files are found
- Improved Maintainability: Game designers can now modify biome properties without recompiling

### Technical Details

- Added BiomeConfig and BiomesFile structs for YAML unmarshaling
- Implemented LoadBiomeDataFiles() to load biomes from YAML files at startup
- Added biome validation to ensure required biomes exist
- Integrated biome loading into the main server initialization
- Extended the admin reload command to support biomes

### Benefits

- Easier world customization - biomes can be modified per world
- No server restart required for biome changes
- Consistent with existing pattern for items, mobs, and rooms
- Enables future biome features like environmental effects or resource generation