### PR TITLE
Fixed infinite leveling bug when race TNLScale is 0 or missing

### DIFF
--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -1381,6 +1381,10 @@ func (c *Character) RecalculateStats() {
 
 	if raceInfo := races.GetRace(c.RaceId); raceInfo != nil {
 		c.TNLScale = raceInfo.TNLScale
+		// Safety check: ensure TNLScale is never 0
+		if c.TNLScale == 0 {
+			c.TNLScale = 1.0
+		}
 		c.Stats.Strength.Base = raceInfo.Stats.Strength.Base
 		c.Stats.Speed.Base = raceInfo.Stats.Speed.Base
 		c.Stats.Smarts.Base = raceInfo.Stats.Smarts.Base

--- a/internal/races/races.go
+++ b/internal/races/races.go
@@ -113,6 +113,11 @@ func (r *Race) Validate() error {
 		r.Damage.FormatDiceRoll()
 	}
 
+	// Ensure TNLScale is never 0, default to 1.0
+	if r.TNLScale == 0 {
+		r.TNLScale = 1.0
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Added validation to ensure TNLScale defaults to 1.0 when not specified or set to 0.

This can happen if a race for some reason is missing the tnlscale field or if it is set to 0 by mistake.

This prevents XPTL() from returning 0 experience required for next level, which was causing infinite leveling.

Changes:
  - Added TNLScale validation in Race.Validate() to default to 1.0 if 0
  - Added safety check in Character.RecalculateStats() as additional protection