### PR TITLE
Fixed unreachable code in MutatorList.SkipInstanceSave

### DIFF
--- a/internal/mutators/mutators.go
+++ b/internal/mutators/mutators.go
@@ -46,7 +46,6 @@ type Mutator struct {
 // This is a special function used for when room instance data is saved
 // It handles checking for special equality cases that the normal reflect.DeepEqual() doesn't handle the way we want.
 func (m MutatorList) SkipInstanceSave(other any) bool {
-	return false
 	m2, ok := other.(MutatorList)
 	if !ok {
 		return false

--- a/internal/mutators/mutators.go
+++ b/internal/mutators/mutators.go
@@ -43,33 +43,6 @@ type Mutator struct {
 	DespawnedRound uint64 `yaml:"despawnedround,omitempty"` // Track when it decayed to nothing.
 }
 
-// This is a special function used for when room instance data is saved
-// It handles checking for special equality cases that the normal reflect.DeepEqual() doesn't handle the way we want.
-func (m MutatorList) SkipInstanceSave(other any) bool {
-	m2, ok := other.(MutatorList)
-	if !ok {
-		return false
-	}
-
-	if len(m) != len(m2) { // length different?
-		return false
-	}
-
-	for i, _ := range m {
-
-		if m[i].MutatorId != m2[i].MutatorId {
-			return false
-		}
-
-		if m[i].Removable() != m2[i].Removable() {
-			return false
-		}
-
-	}
-
-	return true
-}
-
 type TextModifier struct {
 	Behavior     TextBehavior `yaml:"behavior,omitempty"`     // prepend, append or replace?
 	Text         string       `yaml:"text,omitempty"`         // The text that will be injected somehow

--- a/internal/rooms/save_and_load.go
+++ b/internal/rooms/save_and_load.go
@@ -236,10 +236,6 @@ func SaveRoomTemplate(roomTpl Room) error {
 	return nil
 }
 
-type SaveEqualityChecker interface {
-	SkipInstanceSave(other any) bool // Should we skip due to everything looking the same?
-}
-
 // See: D. SAVING ROOMS INSTANCES
 func SaveRoomInstance(r Room) error {
 
@@ -275,12 +271,6 @@ func SaveRoomInstance(r Room) error {
 
 		rVal2 := rVal.Field(i)
 		tplVal2 := tplVal.Field(i)
-
-		if iface, ok := rVal2.Interface().(SaveEqualityChecker); ok {
-			if iface.SkipInstanceSave(tplVal2.Interface()) {
-				continue
-			}
-		}
 
 		if reflect.DeepEqual(rVal2.Interface(), tplVal2.Interface()) {
 			continue


### PR DESCRIPTION
Removed early return statement that made the entire function body unreachable. This function is part of the SaveEqualityChecker interface used when saving room instances to determine if mutator lists differ from their templates.

This may be intential but prevents "make build" from successfully running "go vet".

I thought I'd address it just in case someone else runs into problems compiling using "make build".

If the early return false is intentional just reject this, but then we might want to remove the function altogether.