### PR TITLE
Adding a skill use event, disabling auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,29 +1,28 @@
-name: Auto Tag
+#name: Auto Tag
 
-on:
-  push:
-    branches:
-      - master
-      - '**'
+#on:
+#  push:
+#    branches:
+#      - master
+#      - '**'
 
-permissions:
-  contents: write
+#permissions:
+#  contents: write
 
-jobs:
-  tag:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Needed to access all tags
+#jobs:
+#  tag:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0  # Needed to access all tags
 
-      - name: Create tag using commit message
-        id: tagger
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          tag_prefix: 'v'
-          default_bump: 'patch'
-          default_prerelease_bump: 'prerelease'
-          dry_run: false  # Set to false for actual tagging in production
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
+#      - name: Create tag using commit message
+#        id: tagger
+#        uses: mathieudutour/github-tag-action@v6.1
+#        with:
+#          tag_prefix: 'v'
+#          default_bump: 'patch'
+#          default_prerelease_bump: 'prerelease'
+#          dry_run: false  # Set to false for actual tagging in production
+#          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/_datafiles/world/default/rooms/tutorial/901.js
+++ b/_datafiles/world/default/rooms/tutorial/901.js
@@ -57,12 +57,7 @@ function onCommand(cmd, rest, user, room) {
 
     switch (commandNow) {
         case 0:
-
-            if ( !user.HasItemId(firstItemId) ) {
-                itm = CreateItem(firstItemId);
-                user.GiveItem(itm);
-            }
-            
+           
             teacherMob.Command('say To see all of your characters stats, type <ansi fg="command">status</ansi>.', 1.0);
             break;
         case 1:
@@ -100,6 +95,12 @@ function onCommand(cmd, rest, user, room) {
 // If there is no book here, add the book item
 function onEnter(user, room) {
     room.SetLocked("west", true);
+    
+
+    if ( !user.HasItemId(firstItemId) ) {
+        itm = CreateItem(firstItemId);
+        user.GiveItem(itm);
+    }
     
     sendWorkingCommands(user);
     

--- a/_datafiles/world/empty/rooms/tutorial/901.js
+++ b/_datafiles/world/empty/rooms/tutorial/901.js
@@ -19,7 +19,6 @@ function onCommand(cmd, rest, user, room) {
 
     teacherMob = getTeacher(room);
 
-    var extraDelay = 0;
     // Make sure they are only doing stuff that's allowed.
 
     if ( cmd == "south" && !canGoSouth ) {
@@ -35,18 +34,15 @@ function onCommand(cmd, rest, user, room) {
     if ( teach_commands[commandNow] == fullCommand ) {
         
         teacherMob.Command("say Good job!", 1.0);
-        extraDelay = 1.0;
 
         if ( cmd == "status" ) {
-            teacherMob.Command('say You can see how much gold you carry, your Level, and even attributes like Strength and Smarts.', 2.0);
-            teacherMob.Command('say It\'s a lot of information, but you quickly learn to only pay attention to the important stuff.', 3.0);
-            extraDelay = 3.0;
+            teacherMob.Command('say You can see how much <ansi fg="yellow">Gold</ansi> you carry, your <ansi fg="yellow">Level</ansi>, and even attributes like <ansi fg="yellow">Strength</ansi> and <ansi fg="yellow">Smarts</ansi>.', 1.0);
+            teacherMob.Command('say It\'s a lot of information, but you\'ll quickly learn to only pay attention to the important stuff.', 1.0);
         }
 
         if ( cmd == "inventory" ) {
-            teacherMob.Command('say Hmm, it doesn\'t look like you\'re carrying much other than that sharp stick.', 2.0);
-            teacherMob.Command('say Remember, you can <ansi fg="command">look</ansi> at stuff you\'re carrying any time you want.', 3.0);
-            extraDelay = 3.0;
+            teacherMob.Command('say Hmm, it doesn\'t look like you\'re carrying much other than that <ansi fg="item">sharp stick</ansi>.', 1.0);
+            teacherMob.Command('say Remember, you can <ansi fg="command">look</ansi> at stuff you\'re carrying any time you want.', 1.0);
         }
 
         commandNow++;
@@ -61,30 +57,27 @@ function onCommand(cmd, rest, user, room) {
 
     switch (commandNow) {
         case 0:
-
-            if ( !user.HasItemId(firstItemId) ) {
-                itm = CreateItem(firstItemId);
-                user.GiveItem(itm);
-            }
-            
-            teacherMob.Command('say To see all of your characters stats, type <ansi fg="command">status</ansi>.', extraDelay+1.0);
+           
+            teacherMob.Command('say To see all of your characters stats, type <ansi fg="command">status</ansi>.', 1.0);
             break;
         case 1:
-            teacherMob.Command('say To only peek at your inventory, type <ansi fg="command">inventory</ansi>.', extraDelay+1.0);
+            teacherMob.Command('say To only peek at your inventory, type <ansi fg="command">inventory</ansi>.', 1.0);
             break;
         case 2:
-            teacherMob.Command('say As you solve quests and defeat enemies in combat, you\'ll gain experience points and your character will "Level up".', extraDelay+1.0);
-            teacherMob.Command('say For quick look at your progress, type <ansi fg="command">experience</ansi>.', extraDelay+2.0);
+            teacherMob.Command('say As you solve quests and defeat enemies in combat, you\'ll gain experience points and your character will "Level up".', 1.0);
+            teacherMob.Command('say For quick look at your progress, type <ansi fg="command">experience</ansi>.', 1.0);
             break;
         case 3:
             teacherMob.Command('emote touches you and you feel more focused.');
             user.GiveBuff(32, "training");
-            teacherMob.Command('say Sometimes you might become afflicted with a condition. Conditions can have good or bad effects.',extraDelay+1.0);
-            teacherMob.Command('say type <ansi fg="command">conditions</ansi> to see any statuses affecting you.', extraDelay+2.0);
+            teacherMob.Command('noop', 2);
+            teacherMob.Command('say Sometimes you might become afflicted with a condition. Conditions can have good or bad effects (and sometimes both!).',1.0);
+            teacherMob.Command('say type <ansi fg="command">conditions</ansi> to see any statuses affecting you.', 1.0);
             break;
         case 4:
             user.GiveBuff(-32, "training");
-            teacherMob.Command('say head <ansi fg="command">south</ansi> for the next lesson.', extraDelay+1.0);
+            teacherMob.Command('say Some special conditions might last indefinitely, such as natural abilities like night vision. Others may expire after enough time passes.', 1.0);
+            teacherMob.Command('say head <ansi fg="command">south</ansi> for the next lesson.', 1.0);
             canGoSouth = true;
             room.SetLocked("south", false);
             break;
@@ -103,6 +96,12 @@ function onCommand(cmd, rest, user, room) {
 function onEnter(user, room) {
     room.SetLocked("west", true);
     
+
+    if ( !user.HasItemId(firstItemId) ) {
+        itm = CreateItem(firstItemId);
+        user.GiveItem(itm);
+    }
+    
     sendWorkingCommands(user);
     
     teacherMob = getTeacher(room);
@@ -110,12 +109,9 @@ function onEnter(user, room) {
     teacherMob.Command('emote appears in a ' + UtilApplyColorPattern("flash of light!", "glowing"));
     
     teacherMob.Command('say Hi! I\'m here to teach you about inspecting your characters information.', 1.0);
-    teacherMob.Command('say To get a detailed view of a LOT of information all at once, type <ansi fg="command">status</ansi> and hit enter.', 2.0);
-
+    teacherMob.Command('say To get a detailed view of a LOT of information all at once, type <ansi fg="command">status</ansi> and hit enter.', 1.0);
     return true;
 }
-
-
 
 function onExit(user , room) {
     // Destroy the guide (cleanup)
@@ -123,8 +119,6 @@ function onExit(user , room) {
     canGoSouth = false;
     commandNow = 0;
 }
-
-
 
 function onLoad(room) {
     canGoSouth = false;
@@ -134,6 +128,7 @@ function onLoad(room) {
 function getTeacher(room) {
     var mobActor = room.GetMob(teacherMobId, true);
     mobActor.SetCharacterName(teacherName);
+
     return mobActor;
 }
 

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GoMudEngine/GoMud/internal/connections"
 	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/skills"
 	"github.com/GoMudEngine/GoMud/internal/stats"
 )
 
@@ -64,6 +65,15 @@ type Input struct {
 }
 
 func (i Input) Type() string { return `Input` }
+
+// When a skill is used by a player
+type SkillUsed struct {
+	UserId  int
+	Skill   skills.SkillTag
+	Details string // usually the specific sub-command of the skill
+}
+
+func (i SkillUsed) Type() string { return `SkillUsed` }
 
 // Messages that are intended to reach all users on the system
 type Broadcast struct {

--- a/internal/hooks/RoomChange_SpawnGuide.go
+++ b/internal/hooks/RoomChange_SpawnGuide.go
@@ -38,12 +38,12 @@ func SpawnGuide(e events.Event) events.ListenerReturn {
 	}
 
 	fromRoomOriginal := rooms.GetOriginalRoom(evt.FromRoomId)
-	if fromRoomOriginal >= 900 || fromRoomOriginal <= 999 {
+	if fromRoomOriginal >= 900 && fromRoomOriginal <= 999 {
 		return events.Continue
 	}
 
-	toRoomOriginal := rooms.GetOriginalRoom(evt.FromRoomId)
-	if toRoomOriginal >= 900 || toRoomOriginal <= 999 {
+	toRoomOriginal := rooms.GetOriginalRoom(evt.ToRoomId)
+	if toRoomOriginal >= 900 && toRoomOriginal <= 999 {
 		return events.Continue
 	}
 

--- a/internal/usercommands/appraise.go
+++ b/internal/usercommands/appraise.go
@@ -45,7 +45,7 @@ func Appraise(rest string, user *users.UserRecord, room *rooms.Room, flags event
 		}
 
 		details := inspectDetails{
-			InspectLevel: 2,
+			InspectLevel: 3,
 			Item:         &item,
 			ItemSpec:     &itemSpec,
 		}

--- a/internal/usercommands/skill.brawling.disarm.go
+++ b/internal/usercommands/skill.brawling.disarm.go
@@ -40,6 +40,9 @@ func Disarm(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 		}
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Brawling, `disarm`})
+
 	if attackMobInstanceId > 0 {
 
 		m := mobs.GetInstance(attackMobInstanceId)

--- a/internal/usercommands/skill.brawling.recover.go
+++ b/internal/usercommands/skill.brawling.recover.go
@@ -34,6 +34,9 @@ func Recover(rest string, user *users.UserRecord, room *rooms.Room, flags events
 		return true, nil
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Brawling, `recover`})
+
 	user.AddBuff(23, `skill`) // Warriors respite
 
 	return true, nil

--- a/internal/usercommands/skill.brawling.tackle.go
+++ b/internal/usercommands/skill.brawling.tackle.go
@@ -34,6 +34,9 @@ func Tackle(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 		return true, nil
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Brawling, `tackle`})
+
 	attackMobInstanceId := user.Character.Aggro.MobInstanceId
 	attackPlayerId := user.Character.Aggro.UserId
 

--- a/internal/usercommands/skill.brawling.throw.go
+++ b/internal/usercommands/skill.brawling.throw.go
@@ -53,6 +53,9 @@ func Throw(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 		return true, nil
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Brawling, `throw`})
+
 	targetPlayerId, targetMobId := room.FindByName(throwWhere)
 
 	if targetMobId > 0 {

--- a/internal/usercommands/skill.cast.go
+++ b/internal/usercommands/skill.cast.go
@@ -281,6 +281,10 @@ func Cast(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 		}
 
 		if continueCasting {
+
+			// Fire an event that a skill has been used
+			events.AddToQueue(events.SkillUsed{user.UserId, skills.Cast, spellInfo.SpellId})
+
 			user.Character.Mana -= spellInfo.Cost
 			events.AddToQueue(events.CharacterVitalsChanged{UserId: user.UserId})
 			user.Character.SetCast(spellInfo.WaitRounds, spellAggro)

--- a/internal/usercommands/skill.enchant.go
+++ b/internal/usercommands/skill.enchant.go
@@ -95,6 +95,9 @@ func Enchant(rest string, user *users.UserRecord, room *rooms.Room, flags events
 				return true, nil
 			}
 
+			// Fire an event that a skill has been used
+			events.AddToQueue(events.SkillUsed{user.UserId, skills.Enchant, `uncurse`})
+
 			user.Character.RemoveItem(matchItem)
 			matchItem.Uncurse()
 			user.Character.StoreItem(matchItem)
@@ -117,6 +120,9 @@ func Enchant(rest string, user *users.UserRecord, room *rooms.Room, flags events
 				user.SendText(`Type <ansi fg="command">help enchant</ansi> for more information on the enchant skill.`)
 				return true, nil
 			}
+
+			// Fire an event that a skill has been used
+			events.AddToQueue(events.SkillUsed{user.UserId, skills.Enchant, `remove`})
 
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> holds out their <ansi fg="itemname">%s</ansi> and slowly waves their hand over it. Runes appear to glow on the surface, which fade as they float away.`, user.Character.Name, matchItem.DisplayName()),
@@ -160,6 +166,9 @@ func Enchant(rest string, user *users.UserRecord, room *rooms.Room, flags events
 			)
 			return true, errors.New(`you're doing that too often`)
 		}
+
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Enchant, ``})
 
 		damageBonus := 0
 		defenseBonus := 0

--- a/internal/usercommands/skill.inspect.go
+++ b/internal/usercommands/skill.inspect.go
@@ -47,6 +47,9 @@ func Inspect(rest string, user *users.UserRecord, room *rooms.Room, flags events
 			return true, errors.New(`you're doing that too often`)
 		}
 
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Inspect, ``})
+
 		user.SendText(
 			fmt.Sprintf(`You inspect the <ansi fg="item">%s</ansi>.`, matchItem.DisplayName()),
 		)

--- a/internal/usercommands/skill.map.go
+++ b/internal/usercommands/skill.map.go
@@ -51,6 +51,9 @@ func Map(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		return true, errors.New(`you're doing that too often`)
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Map, ``})
+
 	// replace any non alpha/numeric characters in "rest"
 	zone := rest
 	roomId := 0

--- a/internal/usercommands/skill.peep.go
+++ b/internal/usercommands/skill.peep.go
@@ -54,6 +54,9 @@ func Peep(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 
 	if playerId > 0 || mobId > 0 {
 
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Peep, ``})
+
 		statusTxt := ""
 		invTxt := ""
 		dropTxt := ""

--- a/internal/usercommands/skill.portal.go
+++ b/internal/usercommands/skill.portal.go
@@ -95,6 +95,9 @@ func Portal(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 			return true, errors.New(`you're doing that too often`)
 		}
 
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Portal, ``})
+
 		// move to portalTargetRoomId
 		if err := rooms.MoveToRoom(user.UserId, portalTargetRoomId); err == nil {
 			user.SendText("You draw a quick symbol in the air with your finger, and the world warps around you. You seem to have moved.")
@@ -116,6 +119,10 @@ func Portal(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 	if skillLevel >= 3 {
 
 		if rest == "set" {
+
+			// Fire an event that a skill has been used
+			events.AddToQueue(events.SkillUsed{user.UserId, skills.Portal, `set`})
+
 			user.Character.SetSetting("portal", strconv.Itoa(user.Character.RoomId))
 
 			user.SendText("You enscribe a glowing pentagram on the ground with your finger, which then fades away. Your portals now lead to this area.")
@@ -126,6 +133,10 @@ func Portal(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 		}
 
 		if rest == "unset" || rest == "clear" {
+
+			// Fire an event that a skill has been used
+			events.AddToQueue(events.SkillUsed{user.UserId, skills.Portal, `unset`})
+
 			user.Character.SetSetting("portal", "")
 
 			user.SendText("You draw an arcane symbol in the air with your finger. Your portals now lead to their default location.")
@@ -239,6 +250,9 @@ func Portal(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 			targetRoom.SendText(
 				fmt.Sprintf("A %s suddenly appears!", glowingPortalColorized),
 			)
+
+			// Fire an event that a skill has been used
+			events.AddToQueue(events.SkillUsed{user.UserId, skills.Portal, `open`})
 
 			user.Character.SetSetting("portal:open", fmt.Sprintf("%d:%d", user.Character.RoomId, portalTargetRoomId))
 		}

--- a/internal/usercommands/skill.protection.aid.go
+++ b/internal/usercommands/skill.protection.aid.go
@@ -40,6 +40,9 @@ func Aid(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 
 	if aidPlayerId > 0 {
 
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Protection, `aid`})
+
 		p := users.GetByUserId(aidPlayerId)
 
 		if p != nil {

--- a/internal/usercommands/skill.protection.pray.go
+++ b/internal/usercommands/skill.protection.pray.go
@@ -54,6 +54,9 @@ func Pray(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 
 	if prayPlayerId > 0 {
 
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Protection, `pray`})
+
 		if prayPlayerId == user.UserId {
 			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> begins to pray.`, user.Character.Name), user.UserId)
 		} else {
@@ -79,6 +82,9 @@ func Pray(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 		}
 
 	} else if prayMobId > 0 {
+
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Protection, `pray`})
 
 		if mob := mobs.GetInstance(prayMobId); mob != nil {
 			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> puts his hand over <ansi fg="mobname">%s</ansi> and begins to pray.`, user.Character.Name, mob.Character.Name), user.UserId)

--- a/internal/usercommands/skill.protection.rank.go
+++ b/internal/usercommands/skill.protection.rank.go
@@ -37,6 +37,9 @@ func Rank(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 		party.SetRank(user.UserId, `middle`)
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Protection, `rank`})
+
 	user.SendText(fmt.Sprintf(`You are now fighting from the <ansi fg="magenta">%s</ansi> rank.`, party.GetRank(user.UserId)))
 	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> is now fighting from the <ansi fg="magenta">%s</ansi> rank.`, user.Character.Name, party.GetRank(user.UserId)), user.UserId)
 

--- a/internal/usercommands/skill.scribe.go
+++ b/internal/usercommands/skill.scribe.go
@@ -43,6 +43,9 @@ func Scribe(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 	scribeType := args[0]
 	rest = strings.Join(args[1:], " ")
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Scribe, ``})
+
 	if scribeType == "note" {
 		// Create a note item
 		noteItem := items.New(1)

--- a/internal/usercommands/skill.search.go
+++ b/internal/usercommands/skill.search.go
@@ -43,6 +43,9 @@ func Search(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 		return true, fmt.Errorf("you're doing that too often")
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Search, ``})
+
 	// 10% + 1% for every 2 smarts
 	searchOddsIn100 := 10 + int(math.Ceil(float64(user.Character.Stats.Perception.ValueAdj)/2))
 

--- a/internal/usercommands/skill.skulduggery.backstab.go
+++ b/internal/usercommands/skill.skulduggery.backstab.go
@@ -91,6 +91,9 @@ func Backstab(rest string, user *users.UserRecord, room *rooms.Room, flags event
 		return true, nil
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Skulduggery, `backstab`})
+
 	if attackMobInstanceId > 0 {
 
 		m := mobs.GetInstance(attackMobInstanceId)

--- a/internal/usercommands/skill.skulduggery.bump.go
+++ b/internal/usercommands/skill.skulduggery.bump.go
@@ -55,6 +55,9 @@ func Bump(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 		user.Character.CancelBuffsWithFlag(buffs.Hidden)
 	}
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Skulduggery, `bump`})
+
 	goldDropped := 0
 
 	if pickMobInstanceId > 0 {

--- a/internal/usercommands/skill.skulduggery.pickpocket.go
+++ b/internal/usercommands/skill.skulduggery.pickpocket.go
@@ -54,6 +54,9 @@ func Pickpocket(rest string, user *users.UserRecord, room *rooms.Room, flags eve
 
 	if pickMobInstanceId > 0 {
 
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Skulduggery, `pickpocket`})
+
 		m := mobs.GetInstance(pickMobInstanceId)
 
 		if m != nil {
@@ -147,6 +150,9 @@ func Pickpocket(rest string, user *users.UserRecord, room *rooms.Room, flags eve
 		}
 
 	} else if pickPlayerId > 0 {
+
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Skulduggery, `pickpocket`})
 
 		if p := users.GetByUserId(pickPlayerId); p != nil {
 

--- a/internal/usercommands/skill.skulduggery.sneak.go
+++ b/internal/usercommands/skill.skulduggery.sneak.go
@@ -40,5 +40,8 @@ func Sneak(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 
 	user.AddBuff(9, `skill`)
 
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Skulduggery, `sneak`})
+
 	return true, nil
 }

--- a/internal/usercommands/skill.tame.go
+++ b/internal/usercommands/skill.tame.go
@@ -69,6 +69,9 @@ func Tame(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 
 	if mobId > 0 {
 
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Tame, ``})
+
 		if mob := mobs.GetInstance(mobId); mob != nil {
 
 			if mob.Character.IsCharmed(user.UserId) {

--- a/internal/usercommands/skill.track.go
+++ b/internal/usercommands/skill.track.go
@@ -54,6 +54,9 @@ func Track(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 			return true, errors.New(`you're doing that too often`)
 		}
 
+		// Fire an event that a skill has been used
+		events.AddToQueue(events.SkillUsed{user.UserId, skills.Track, ``})
+
 		visitorData := make([]trackingInfo, 0)
 
 		for mId, timeLeft := range room.Visitors(rooms.VisitorMob) {
@@ -178,6 +181,9 @@ func Track(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 		return true, errors.New(`you're doing that too often`)
 
 	}
+
+	// Fire an event that a skill has been used
+	events.AddToQueue(events.SkillUsed{user.UserId, skills.Track, ``})
 
 	//
 	// At skill level 3, search the room and adjacent rooms for quarry


### PR DESCRIPTION
# Description

Adds an event that fires when skills are used. Skill is not cancellable via event, simply allows for extra handling of skill usage.

## Changes

- Added `SkillUsed` event type
- Removed auto-tag github workflow
- Fixing issue where player wasn't given sharp stick in tutorial
- Fixing issue where guide does not spawn for new players
