### PR TITLE
Miscellaneous small bugs reported

### DIFF
--- a/_datafiles/html/public/webclient.html
+++ b/_datafiles/html/public/webclient.html
@@ -11,9 +11,9 @@
         // For some reason safari acts weird if we don't reset this first.
         wcIframe.width = "0px"; 
         wcIframe.height = "0px";
-        // Set proper height/width
-        wcIframe.width = contentContainer.offsetWidth;
-        wcIframe.height = contentContainer.offsetHeight;
+        // Set proper height/width - use clientWidth/clientHeight to get inner dimensions
+        wcIframe.width = contentContainer.clientWidth;
+        wcIframe.height = contentContainer.clientHeight;
         
     }
     window.addEventListener("load", resizeClientIFrame);

--- a/_datafiles/html/public/webclient.html
+++ b/_datafiles/html/public/webclient.html
@@ -11,8 +11,17 @@
         // For some reason safari acts weird if we don't reset this first.
         wcIframe.width = "0px"; 
         wcIframe.height = "0px";
-        // Set proper height/width - use clientWidth/clientHeight to get inner dimensions
-        wcIframe.width = contentContainer.clientWidth;
+        
+        // Calculate scrollbar width
+        const outer = document.createElement('div');
+        outer.style.cssText = 'visibility:hidden;overflow:scroll';
+        document.body.appendChild(outer);
+        outer.appendChild(document.createElement('div'));
+        const scrollbarWidth = outer.offsetWidth - outer.firstChild.offsetWidth;
+        document.body.removeChild(outer);
+        
+        // Set proper height/width - subtract scrollbar width to prevent cropping
+        wcIframe.width = contentContainer.clientWidth - scrollbarWidth;
         wcIframe.height = contentContainer.clientHeight;
         
     }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -231,6 +231,8 @@ func SplitString(input string, lineWidth int) []string {
 
 		if currentLine != "" {
 			result = append(result, currentLine)
+			currentLine = ""
+			currentLen = 0
 		}
 	}
 

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -273,6 +273,23 @@ func TestSplitString(t *testing.T) {
 			},
 		},
 		{
+			"SplitString long text with line breaks",
+			args{
+				"You are now on the lawn.\nYou can smell the freshly cut grass in the " +
+					"dwindling heat of the autumn afternoon sun.\nYou can see a frisbee flying in the " +
+					"air, frozen mid-flight in this very sentence. Nearby, a group of picnickers pretends " +
+					"to study.",
+				79,
+			},
+			[]string{
+				"You are now on the lawn.",
+				"You can smell the freshly cut grass in the dwindling heat of the autumn",
+				"afternoon sun.",
+				"You can see a frisbee flying in the air, frozen mid-flight in this very",
+				"sentence. Nearby, a group of picnickers pretends to study.",
+			},
+		},
+		{
 			"SplitString wide charactors",
 			args{
 				`当你的感官与周围的静谧相适应时，你发现自己被吞噬在一个无法穿透的虚空中，一个黑` +


### PR DESCRIPTION
# Description

PR to capture fixing small bugs reported/discovered.

# Changes
* Fixing a bug where splitting room descriptions that already have line breaks causes duplication of line data.
* Webclient crops left side of text when in iframe (not present in /webclient-pure). This should fix it.

# Links
* https://github.com/GoMudEngine/GoMud/issues/418
* https://github.com/GoMudEngine/GoMud/issues/422

# Screenshots

## Description test

<img width="422" height="122" alt="image" src="https://github.com/user-attachments/assets/a388174e-b605-421d-acb6-ad0e700e77e0" />
