### PR TITLE
Fixed GMCP module configuration loading and YAML structure preservation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/GoMud/internal/util"
 	"gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 const (
@@ -287,6 +288,143 @@ func (c Config) AllConfigData(excludeStrings ...string) map[string]any {
 	return finalOutput
 }
 
+// marshalConfigWithOrder preserves the original file structure when updating config values
+func marshalConfigWithOrder(config map[string]any) ([]byte, error) {
+	// For backward compatibility, if there's no existing file to preserve structure from,
+	// just use the standard marshal
+	overridePath := overridePath()
+	existingBytes, err := os.ReadFile(util.FilePath(overridePath))
+	if err != nil {
+		// File doesn't exist yet, use standard marshal
+		return yaml.Marshal(config)
+	}
+
+	// Parse the existing file to preserve its structure
+	var rootNode yamlv3.Node
+	if err := yamlv3.Unmarshal(existingBytes, &rootNode); err != nil {
+		// If we can't parse it with v3, fall back to standard marshal
+		return yaml.Marshal(config)
+	}
+
+	// Update the node tree with new values from config map
+	updateNodeFromMap(&rootNode, config)
+
+	// Marshal back with preserved structure
+	return yamlv3.Marshal(&rootNode)
+}
+
+// updateNodeFromMap recursively updates a yaml.Node tree with values from a map
+// while preserving the node structure, comments, and order
+func updateNodeFromMap(node *yamlv3.Node, updates map[string]any) {
+	if node.Kind != yamlv3.DocumentNode {
+		return
+	}
+
+	// Process the document content
+	if len(node.Content) > 0 {
+		updateNodeContent(node.Content[0], updates)
+	}
+}
+
+// updateNodeContent handles updating the content of a node
+func updateNodeContent(node *yamlv3.Node, updates map[string]any) {
+	if node.Kind != yamlv3.MappingNode {
+		return
+	}
+
+	// Track which keys we've seen in the existing structure
+	seenKeys := make(map[string]bool)
+	newContent := make([]*yamlv3.Node, 0, len(node.Content))
+
+	// Update existing keys while preserving order
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		if keyNode.Kind == yamlv3.ScalarNode {
+			key := keyNode.Value
+
+			// Check if this key should still exist
+			if newValue, exists := updates[key]; exists {
+				seenKeys[key] = true
+				updateValueNode(valueNode, newValue)
+				newContent = append(newContent, keyNode, valueNode)
+			}
+			// If key doesn't exist in updates, it gets removed by not adding to newContent
+		}
+	}
+
+	// Add new keys that weren't in the original structure
+	for key, value := range updates {
+		if !seenKeys[key] {
+			// Add new key-value pair at the end
+			keyNode := &yamlv3.Node{
+				Kind:  yamlv3.ScalarNode,
+				Value: key,
+			}
+			valueNode := &yamlv3.Node{}
+			setNodeValue(valueNode, value)
+
+			newContent = append(newContent, keyNode, valueNode)
+		}
+	}
+
+	node.Content = newContent
+}
+
+// updateValueNode updates a value node with new data
+func updateValueNode(node *yamlv3.Node, value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		if node.Kind == yamlv3.MappingNode {
+			// Recursively update map nodes
+			updateNodeContent(node, v)
+		} else {
+			// Type changed, replace the node
+			setNodeValue(node, value)
+		}
+	case []any:
+		// Replace array values entirely (for simplicity)
+		setNodeValue(node, value)
+	default:
+		// Update scalar value
+		if node.Kind == yamlv3.ScalarNode {
+			node.Value = fmt.Sprintf("%v", value)
+		} else {
+			setNodeValue(node, value)
+		}
+	}
+}
+
+// setNodeValue sets a node to represent a value
+func setNodeValue(node *yamlv3.Node, value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		node.Kind = yamlv3.MappingNode
+		node.Content = make([]*yamlv3.Node, 0, len(v)*2)
+		for k, val := range v {
+			keyNode := &yamlv3.Node{
+				Kind:  yamlv3.ScalarNode,
+				Value: k,
+			}
+			valueNode := &yamlv3.Node{}
+			setNodeValue(valueNode, val)
+			node.Content = append(node.Content, keyNode, valueNode)
+		}
+	case []any:
+		node.Kind = yamlv3.SequenceNode
+		node.Content = make([]*yamlv3.Node, 0, len(v))
+		for _, item := range v {
+			itemNode := &yamlv3.Node{}
+			setNodeValue(itemNode, item)
+			node.Content = append(node.Content, itemNode)
+		}
+	default:
+		node.Kind = yamlv3.ScalarNode
+		node.Value = fmt.Sprintf("%v", value)
+	}
+}
+
 func SetVal(propertyPath string, newVal string) error {
 
 	propertyPath, propertyType := FindFullPath(propertyPath)
@@ -306,8 +444,8 @@ func SetVal(propertyPath string, newVal string) error {
 
 	overrides = unflattenMap(flatOverrides)
 
-	// save the new config.
-	writeBytes, err := yaml.Marshal(overrides)
+	// save the new config with better ordering
+	writeBytes, err := marshalConfigWithOrder(overrides)
 	if err != nil {
 		return err
 	}

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -998,15 +998,15 @@ func PreCacheMaps() {
 func validateRoomBiomes() {
 	missingBiomeCount := 0
 	invalidBiomeCount := 0
-	
+
 	for _, roomId := range rooms.GetAllRoomIds() {
 		room := rooms.LoadRoom(roomId)
 		if room == nil {
 			continue
 		}
-		
+
 		originalBiome := room.Biome
-		
+
 		// Check if room has no biome
 		if originalBiome == "" {
 			zoneBiome := rooms.GetZoneBiome(room.Zone)
@@ -1022,7 +1022,7 @@ func validateRoomBiomes() {
 			}
 		}
 	}
-	
+
 	if missingBiomeCount > 0 || invalidBiomeCount > 0 {
 		mudlog.Info("Biome validation complete", "missing", missingBiomeCount, "invalid", invalidBiomeCount)
 	}

--- a/internal/rooms/rooms.go
+++ b/internal/rooms/rooms.go
@@ -2198,7 +2198,6 @@ func (r *Room) Validate() error {
 		}
 	}
 
-
 	// Make sure all items are validated (and have uids)
 	for i := range r.Items {
 		r.Items[i].Validate()

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -108,9 +108,25 @@ func init() {
 
 // Helper function to load a config string from the plugin's configuration
 func loadConfigString(p *plugins.Plugin, key string) string {
-	if val, ok := p.Config.Get(key).(string); ok {
-		return val
+	// The GMCP config is loaded under the main "gmcp" namespace, not "gmcp.Mudlet"
+	// All GMCP sub-modules share the same configuration namespace
+	cfg := configs.GetConfig()
+	allConfig := cfg.AllConfigData()
+
+	fullKey := fmt.Sprintf("Modules.gmcp.%s", key)
+	if val, exists := allConfig[fullKey]; exists {
+		// Handle both string and numeric values
+		switch v := val.(type) {
+		case string:
+			if v != "" {
+				return v
+			}
+		case int, int64, float64:
+			// Convert numbers to string
+			return fmt.Sprintf("%v", v)
+		}
 	}
+
 	return ""
 }
 

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -108,22 +108,33 @@ func init() {
 
 // Helper function to load a config string from the plugin's configuration
 func loadConfigString(p *plugins.Plugin, key string) string {
-	// The GMCP config is loaded under the main "gmcp" namespace, not "gmcp.Mudlet"
-	// All GMCP sub-modules share the same configuration namespace
+	// The GMCP modules have a unique architecture where multiple plugins
+	// (gmcp, gmcp.Room, gmcp.Mudlet, etc.) share configuration.
+	// We check both possible locations:
+	// 1. Modules.gmcp.* - User overrides (preferred location)
+	// 2. Modules.gmcp_Mudlet.* - Plugin overlay defaults (dots become underscores)
+
 	cfg := configs.GetConfig()
 	allConfig := cfg.AllConfigData()
 
-	fullKey := fmt.Sprintf("Modules.gmcp.%s", key)
-	if val, exists := allConfig[fullKey]; exists {
-		// Handle both string and numeric values
-		switch v := val.(type) {
-		case string:
-			if v != "" {
-				return v
+	// Check user override location first (where users would naturally put it)
+	locations := []string{
+		fmt.Sprintf("Modules.gmcp.%s", key),        // User-friendly location
+		fmt.Sprintf("Modules.gmcp_Mudlet.%s", key), // Where overlay actually loads
+	}
+
+	for _, fullKey := range locations {
+		if val, exists := allConfig[fullKey]; exists {
+			// Handle both string and numeric values
+			switch v := val.(type) {
+			case string:
+				if v != "" {
+					return v
+				}
+			case int, int64, float64:
+				// Convert numbers to string
+				return fmt.Sprintf("%v", v)
 			}
-		case int, int64, float64:
-			// Convert numbers to string
-			return fmt.Sprintf("%v", v)
 		}
 	}
 

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -20,33 +20,9 @@ var (
 	files embed.FS
 )
 
-// MudletConfig holds the configuration for Mudlet clients
-type MudletConfig struct {
-	// Mapper configuration
-	MapperVersion string `json:"mapper_version" yaml:"mapper_version"`
-	MapperURL     string `json:"mapper_url" yaml:"mapper_url"`
-
-	// UI configuration
-	UIVersion string `json:"ui_version" yaml:"ui_version"`
-	UIURL     string `json:"ui_url" yaml:"ui_url"`
-
-	// Map data configuration
-	MapVersion string `json:"map_version" yaml:"map_version"`
-	MapURL     string `json:"map_url" yaml:"map_url"`
-
-	// Discord Rich Presence configuration
-	DiscordApplicationID string `json:"discord_application_id" yaml:"discord_application_id"`
-	DiscordInviteURL     string `json:"discord_invite_url" yaml:"discord_invite_url"`
-	DiscordLargeImageKey string `json:"discord_large_image_key" yaml:"discord_large_image_key"`
-	DiscordDetails       string `json:"discord_details" yaml:"discord_details"`
-	DiscordState         string `json:"discord_state" yaml:"discord_state"`
-	DiscordSmallImageKey string `json:"discord_small_image_key" yaml:"discord_small_image_key"`
-}
-
 // GMCPMudletModule handles Mudlet-specific GMCP functionality
 type GMCPMudletModule struct {
 	plug        *plugins.Plugin
-	config      MudletConfig
 	mudletUsers map[int]bool // Track which users are using Mudlet clients
 }
 
@@ -85,10 +61,6 @@ func init() {
 	if err := g.plug.AttachFileSystem(files); err != nil {
 		panic(err)
 	}
-
-	// Register callbacks for load/save
-	g.plug.Callbacks.SetOnLoad(g.load)
-	g.plug.Callbacks.SetOnSave(g.save)
 
 	// Register event listeners
 	events.RegisterListener(events.PlayerSpawn{}, g.playerSpawnHandler)
@@ -139,28 +111,6 @@ func loadConfigString(p *plugins.Plugin, key string) string {
 	}
 
 	return ""
-}
-
-// load handles loading configuration from the plugin's storage
-func (g *GMCPMudletModule) load() {
-	// Load config values directly from embedded config or overrides
-	g.config.MapperVersion = loadConfigString(g.plug, "mapper_version")
-	g.config.MapperURL = loadConfigString(g.plug, "mapper_url")
-	g.config.UIVersion = loadConfigString(g.plug, "ui_version")
-	g.config.UIURL = loadConfigString(g.plug, "ui_url")
-	g.config.MapVersion = loadConfigString(g.plug, "map_version")
-	g.config.MapURL = loadConfigString(g.plug, "map_url")
-	g.config.DiscordApplicationID = loadConfigString(g.plug, "discord_application_id")
-	g.config.DiscordInviteURL = loadConfigString(g.plug, "discord_invite_url")
-	g.config.DiscordLargeImageKey = loadConfigString(g.plug, "discord_large_image_key")
-	g.config.DiscordDetails = loadConfigString(g.plug, "discord_details")
-	g.config.DiscordState = loadConfigString(g.plug, "discord_state")
-	g.config.DiscordSmallImageKey = loadConfigString(g.plug, "discord_small_image_key")
-}
-
-// save handles saving configuration to the plugin's storage
-func (g *GMCPMudletModule) save() {
-	g.plug.WriteStruct(`mudlet_config`, g.config)
 }
 
 // Helper function to check if a user is using a Mudlet client
@@ -236,8 +186,8 @@ func (g *GMCPMudletModule) sendDiscordInfo(userId int) {
 		ApplicationID string `json:"applicationid"`
 		InviteURL     string `json:"inviteurl"`
 	}{
-		ApplicationID: g.config.DiscordApplicationID,
-		InviteURL:     g.config.DiscordInviteURL,
+		ApplicationID: loadConfigString(g.plug, "discord_application_id"),
+		InviteURL:     loadConfigString(g.plug, "discord_invite_url"),
 	}
 
 	sendGMCP(userId, "External.Discord.Info", payload)
@@ -277,7 +227,10 @@ func (g *GMCPMudletModule) sendDiscordStatus(userId int) {
 	showLevel := getUserBoolOption(user, "discord_show_level", true)
 
 	// Build the details string based on preferences
-	detailsStr := g.config.DiscordDetails
+	detailsStr := loadConfigString(g.plug, "discord_details")
+	if detailsStr == "" {
+		detailsStr = "Using GoMudEngine"
+	}
 	if showName || showLevel {
 		detailsStr = ""
 		if showName {
@@ -307,10 +260,10 @@ func (g *GMCPMudletModule) sendDiscordStatus(userId int) {
 		PartyMax      int    `json:"partymax,omitempty"`
 	}{
 		Details:       detailsStr,
-		State:         g.config.DiscordState,
+		State:         loadConfigString(g.plug, "discord_state"),
 		Game:          configs.GetServerConfig().MudName.String(),
-		LargeImageKey: g.config.DiscordLargeImageKey,
-		SmallImageKey: g.config.DiscordSmallImageKey,
+		LargeImageKey: loadConfigString(g.plug, "discord_large_image_key"),
+		SmallImageKey: loadConfigString(g.plug, "discord_small_image_key"),
 		StartTime:     user.GetConnectTime().Unix(),
 	}
 
@@ -361,7 +314,7 @@ func (g *GMCPMudletModule) sendMudletMapConfig(userId int) {
 	}
 
 	mapConfig := map[string]string{
-		"url": g.config.MapURL,
+		"url": loadConfigString(g.plug, "map_url"),
 	}
 
 	sendGMCP(userId, "Client.Map", mapConfig)
@@ -378,8 +331,8 @@ func (g *GMCPMudletModule) sendMudletUIInstall(userId int) {
 		Version string `json:"version"`
 		URL     string `json:"url"`
 	}{
-		Version: g.config.UIVersion,
-		URL:     g.config.UIURL,
+		Version: loadConfigString(g.plug, "ui_version"),
+		URL:     loadConfigString(g.plug, "ui_url"),
 	}
 
 	sendGMCP(userId, "Client.GUI", payload)
@@ -429,8 +382,8 @@ func (g *GMCPMudletModule) sendMudletConfig(userId int) {
 		Version string `json:"version"`
 		URL     string `json:"url"`
 	}{
-		Version: g.config.MapperVersion,
-		URL:     g.config.MapperURL,
+		Version: loadConfigString(g.plug, "mapper_version"),
+		URL:     loadConfigString(g.plug, "mapper_url"),
 	}
 	sendGMCP(userId, "Client.GUI", payload)
 


### PR DESCRIPTION
## Summary
  - Fixed GMCP module configuration loading issues preventing Discord Rich Presence and  Mudlet mapper settings from being read correctly
  - Implemented YAML structure preservation to maintain user's config file formatting and comments
  - Resolved type conversion issues with numeric Discord application IDs

## Problem
The GMCP module uses a multi-plugin architecture (gmcp, gmcp.Room, gmcp.Mudlet, etc.) but shares a single configuration file. The plugin system was designed with a one-plugin-one-config assumption, causing the gmcp.Mudlet module to look for configuration under `Modules.gmcp_Mudlet.*` while the config was actually loaded under `Modules.gmcp.*`. This prevented users from customizing Discord Rich Presence settings and Mudlet mapper URLs.

Additionally, when users made in-game configuration changes, the YAML file would be completely reorganized, losing comments, custom ordering, and formatting. When you have a finely crafted custom config file, this would be annoying.

## Solution
1. **Fixed namespace resolution**: Modified `loadConfigString()` in gmcp.Mudlet.go to read from the correct `Modules.gmcp` namespace where the configuration is actually loaded
2. **Added type conversion**: Handle both string and numeric values for Discord application IDs (fixes 18-digit IDs being returned as empty strings)
3. **Implemented YAML v3 structure preservation**: Added functions to maintain file structure, comments, and key ordering when saving configuration changes

## Changes
  - Modified `modules/gmcp/gmcp.Mudlet.go` to fix config loading
  - Added YAML v3 support in `internal/configs/configs.go` for structure preservation
  - Updated `go.mod` to include yaml.v3 as direct dependency
  - Cleaned up whitespace in `mapper.go` and `rooms.go` (auto-formatting)