### PR TITLE
Add reverse proxy IP header support for web server logging

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -384,9 +384,9 @@ Network:
   #   ports by separating them with commas. For example, [33333, 33334, 33335]
   TelnetPort: [33333, 44444]
   # - SecureTelnetPort -
-  #   The port the server listens on for secure telnet connections. Listen on multiple
-  #   ports by separating them with commas. For example, [33334, 33335]
-  #   Set to [0] to disable secure telnet.
+  #   Localhost-only ports for secure telnet connections (e.g., TLS proxy forwarding).
+  #   Like LocalPort but shown on website. Multiple ports supported: [33334, 33335]
+  #   Set to [0] to disable.
   SecureTelnetPort: [0]
   # - LocalPort -
   #   A port that can only be accessed via localhost, but will not limit based on connection count

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -390,11 +390,12 @@ Network:
   #   Set to [0] to disable display.
   SecureTelnetPort: [0]
   # - SecureTelnetLocalPort -
-  #   Internal port where TLS proxy forwards secure connections (localhost only).
-  #   Game server binds to this port to receive forwarded TLS connections.
-  #   Example: 9998 if stunnel4 forwards to localhost:9998
-  #   Set to 0 to disable.
-  SecureTelnetLocalPort: 0
+  #   Internal ports where TLS proxy forwards secure connections (localhost only).
+  #   Game server binds to these ports to receive forwarded TLS connections.
+  #   Example: [9998] if stunnel4 forwards to localhost:9998
+  #   Multiple ports supported: [9998, 9997] for multiple TLS proxies
+  #   Set to [0] to disable.
+  SecureTelnetLocalPort: [0]
   # - LocalPort -
   #   A port that can only be accessed via localhost, but will not limit based on connection count
   LocalPort: 9999

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -383,6 +383,11 @@ Network:
   #   The port the server listens on for telnet connections. Listen on multiple
   #   ports by separating them with commas. For example, [33333, 33334, 33335]
   TelnetPort: [33333, 44444]
+  # - SecureTelnetPort -
+  #   The port the server listens on for secure telnet connections. Listen on multiple
+  #   ports by separating them with commas. For example, [33334, 33335]
+  #   Set to [0] to disable secure telnet.
+  SecureTelnetPort: [0]
   # - LocalPort -
   #   A port that can only be accessed via localhost, but will not limit based on connection count
   LocalPort: 9999

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -384,10 +384,17 @@ Network:
   #   ports by separating them with commas. For example, [33333, 33334, 33335]
   TelnetPort: [33333, 44444]
   # - SecureTelnetPort -
-  #   Localhost-only ports for secure telnet connections (e.g., TLS proxy forwarding).
-  #   Like LocalPort but shown on website. Multiple ports supported: [33334, 33335]
-  #   Set to [0] to disable.
+  #   Display-only: External ports where users connect via TLS proxy (e.g., stunnel4).
+  #   These ports are shown on the website but NOT bound by the game server.
+  #   Example: [33334] if stunnel4 listens on port 33334
+  #   Set to [0] to disable display.
   SecureTelnetPort: [0]
+  # - SecureTelnetLocalPort -
+  #   Internal port where TLS proxy forwards secure connections (localhost only).
+  #   Game server binds to this port to receive forwarded TLS connections.
+  #   Example: 9998 if stunnel4 forwards to localhost:9998
+  #   Set to 0 to disable.
+  SecureTelnetLocalPort: 0
   # - LocalPort -
   #   A port that can only be accessed via localhost, but will not limit based on connection count
   LocalPort: 9999

--- a/_datafiles/html/public/index.html
+++ b/_datafiles/html/public/index.html
@@ -1,13 +1,40 @@
 {{template "header" .}}
 
-  <div class="play-button">
-    <a href="/webclient">
-      <img src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/images/btn_play.png" alt="Play" />
-    </a>
+<div class="play-button">
+  <a href="/webclient">
+    <img
+      src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/images/btn_play.png"
+      alt="Play"
+    />
+  </a>
+</div>
+<p>&nbsp;</p>
+<div style="text-align: center;">
+  <div class="underlay" style="width: auto; display: inline-block; padding-left: 20px; padding-right: 20px;">
+    <div style="display: table; margin: 0 auto">
+    <div style="display: table-row">
+      <h3 style="display: table-cell; text-align: right; padding-right: 0.5em">
+        Telnet Port{{ if gt (len .CONFIG.Network.TelnetPort) 1 }}s{{end}}
+      </h3>
+      <h3 style="display: table-cell; text-align: left">
+        : {{ join .CONFIG.Network.TelnetPort ", " }}
+      </h3>
+    </div>
+    {{ if and .CONFIG.Network.SecureTelnetPort (ne (index
+    .CONFIG.Network.SecureTelnetPort 0) "0") }}
+    <br />
+    <div style="display: table-row">
+      <h3 style="display: table-cell; text-align: right; padding-right: 0.5em">
+        Secure Telnet Port{{ if gt (len .CONFIG.Network.SecureTelnetPort) 1
+        }}s{{end}}
+      </h3>
+      <h3 style="display: table-cell; text-align: left">
+        : {{ join .CONFIG.Network.SecureTelnetPort ", " }}
+      </h3>
+    </div>
+    {{ end }}
   </div>
-  <p>&nbsp;</p>
-  <div class="underlay">
-    <h3>Telnet Port{{ if gt (len .CONFIG.Network.TelnetPort) 1 }}s{{end}}: {{ join .CONFIG.Network.TelnetPort ", " }}</h3>
   </div>
+</div>
 
 {{template "footer" .}}

--- a/_datafiles/html/public/online.html
+++ b/_datafiles/html/public/online.html
@@ -12,6 +12,7 @@
                 <th>Alignment</th>
                 <th>Profession</th>
                 <th>Time Online</th>
+                <th>Connection</th>
                 <th>Role</th>
             </tr>
             {{range $index, $uInfo := .STATS.OnlineUsers}}
@@ -22,6 +23,7 @@
                 <td align="center">{{ $uInfo.Alignment }}</td>
                 <td align="center">{{ $uInfo.Profession }}</td>
                 <td align="center">{{ $uInfo.OnlineTimeStr }}{{ if $uInfo.IsAFK }} (AFK){{end}}</td>
+                <td align="center">{{ $uInfo.ConnectionType }}</td>
                 <td align="center">{{ $uInfo.Role }}</td>
             </tr>
             {{end}}

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -4,7 +4,7 @@ type Network struct {
 	MaxTelnetConnections  ConfigInt         `yaml:"MaxTelnetConnections"`  // Maximum number of telnet connections to accept
 	TelnetPort            ConfigSliceString `yaml:"TelnetPort"`            // One or more Ports used to accept telnet connections
 	SecureTelnetPort      ConfigSliceString `yaml:"SecureTelnetPort"`      // Display-only: external ports where users connect via TLS
-	SecureTelnetLocalPort ConfigInt         `yaml:"SecureTelnetLocalPort"` // Internal port where TLS proxy forwards to (localhost only)
+	SecureTelnetLocalPort ConfigSliceString `yaml:"SecureTelnetLocalPort"` // Internal ports where TLS proxy forwards to (localhost only)
 	LocalPort             ConfigInt         `yaml:"LocalPort"`             // Port used for admin connections, localhost only
 	HttpPort              ConfigInt         `yaml:"HttpPort"`              // Port used for web requests
 	HttpsPort             ConfigInt         `yaml:"HttpsPort"`             // Port used for web https requests

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -8,12 +8,12 @@ type Network struct {
 	LocalPort             ConfigInt         `yaml:"LocalPort"`             // Port used for admin connections, localhost only
 	HttpPort              ConfigInt         `yaml:"HttpPort"`              // Port used for web requests
 	HttpsPort             ConfigInt         `yaml:"HttpsPort"`             // Port used for web https requests
-	HttpsRedirect        ConfigBool        `yaml:"HttpsRedirect"`        // If true, http traffic will be redirected to https
-	AfkSeconds           ConfigInt         `yaml:"AfkSeconds"`           // How long until a player is marked as afk?
-	MaxIdleSeconds       ConfigInt         `yaml:"MaxIdleSeconds"`       // How many seconds a player can go without a command in game before being kicked.
-	TimeoutMods          ConfigBool        `yaml:"TimeoutMods"`          // Whether to kick admin/mods when idle too long.
-	ZombieSeconds        ConfigInt         `yaml:"ZombieSeconds"`        // How many seconds a player will be a zombie allowing them to reconnect.
-	LogoutRounds         ConfigInt         `yaml:"LogoutRounds"`         // How many rounds of uninterrupted meditation must be completed to log out.
+	HttpsRedirect         ConfigBool        `yaml:"HttpsRedirect"`         // If true, http traffic will be redirected to https
+	AfkSeconds            ConfigInt         `yaml:"AfkSeconds"`            // How long until a player is marked as afk?
+	MaxIdleSeconds        ConfigInt         `yaml:"MaxIdleSeconds"`        // How many seconds a player can go without a command in game before being kicked.
+	TimeoutMods           ConfigBool        `yaml:"TimeoutMods"`           // Whether to kick admin/mods when idle too long.
+	ZombieSeconds         ConfigInt         `yaml:"ZombieSeconds"`         // How many seconds a player will be a zombie allowing them to reconnect.
+	LogoutRounds          ConfigInt         `yaml:"LogoutRounds"`          // How many rounds of uninterrupted meditation must be completed to log out.
 }
 
 func (n *Network) Validate() {

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -3,6 +3,7 @@ package configs
 type Network struct {
 	MaxTelnetConnections ConfigInt         `yaml:"MaxTelnetConnections"` // Maximum number of telnet connections to accept
 	TelnetPort           ConfigSliceString `yaml:"TelnetPort"`           // One or more Ports used to accept telnet connections
+	SecureTelnetPort     ConfigSliceString `yaml:"SecureTelnetPort"`     // One or more Ports used to accept secure telnet connections
 	LocalPort            ConfigInt         `yaml:"LocalPort"`            // Port used for admin connections, localhost only
 	HttpPort             ConfigInt         `yaml:"HttpPort"`             // Port used for web requests
 	HttpsPort            ConfigInt         `yaml:"HttpsPort"`            // Port used for web https requests

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -1,12 +1,13 @@
 package configs
 
 type Network struct {
-	MaxTelnetConnections ConfigInt         `yaml:"MaxTelnetConnections"` // Maximum number of telnet connections to accept
-	TelnetPort           ConfigSliceString `yaml:"TelnetPort"`           // One or more Ports used to accept telnet connections
-	SecureTelnetPort     ConfigSliceString `yaml:"SecureTelnetPort"`     // One or more Ports used to accept secure telnet connections
-	LocalPort            ConfigInt         `yaml:"LocalPort"`            // Port used for admin connections, localhost only
-	HttpPort             ConfigInt         `yaml:"HttpPort"`             // Port used for web requests
-	HttpsPort            ConfigInt         `yaml:"HttpsPort"`            // Port used for web https requests
+	MaxTelnetConnections  ConfigInt         `yaml:"MaxTelnetConnections"`  // Maximum number of telnet connections to accept
+	TelnetPort            ConfigSliceString `yaml:"TelnetPort"`            // One or more Ports used to accept telnet connections
+	SecureTelnetPort      ConfigSliceString `yaml:"SecureTelnetPort"`      // Display-only: external ports where users connect via TLS
+	SecureTelnetLocalPort ConfigInt         `yaml:"SecureTelnetLocalPort"` // Internal port where TLS proxy forwards to (localhost only)
+	LocalPort             ConfigInt         `yaml:"LocalPort"`             // Port used for admin connections, localhost only
+	HttpPort              ConfigInt         `yaml:"HttpPort"`              // Port used for web requests
+	HttpsPort             ConfigInt         `yaml:"HttpsPort"`             // Port used for web https requests
 	HttpsRedirect        ConfigBool        `yaml:"HttpsRedirect"`        // If true, http traffic will be redirected to https
 	AfkSeconds           ConfigInt         `yaml:"AfkSeconds"`           // How long until a player is marked as afk?
 	MaxIdleSeconds       ConfigInt         `yaml:"MaxIdleSeconds"`       // How many seconds a player can go without a command in game before being kicked.

--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -3,6 +3,7 @@ package connections
 import (
 	"errors"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -276,6 +277,32 @@ func (cd *ConnectionDetails) RemoteAddr() net.Addr {
 		return cd.wsConn.RemoteAddr()
 	}
 	return cd.conn.RemoteAddr()
+}
+
+// GetLocalPort returns the local port the connection came in on
+func (cd *ConnectionDetails) GetLocalPort() int {
+	var localAddr net.Addr
+	if cd.wsConn != nil {
+		localAddr = cd.wsConn.LocalAddr()
+	} else if cd.conn != nil {
+		localAddr = cd.conn.LocalAddr()
+	} else {
+		return 0
+	}
+
+	// Extract port from address
+	if tcpAddr, ok := localAddr.(*net.TCPAddr); ok {
+		return tcpAddr.Port
+	}
+
+	// Try parsing as string
+	_, portStr, err := net.SplitHostPort(localAddr.String())
+	if err != nil {
+		return 0
+	}
+
+	port, _ := strconv.Atoi(portStr)
+	return port
 }
 
 // get for uniqueId

--- a/internal/connections/connections.go
+++ b/internal/connections/connections.go
@@ -80,6 +80,17 @@ func IsWebsocket(id ConnectionId) bool {
 	return false
 }
 
+func GetConnectionPort(id ConnectionId) int {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if cd, ok := netConnections[id]; ok {
+		return cd.GetLocalPort()
+	}
+
+	return 0
+}
+
 func GetAllConnectionIds() []ConnectionId {
 
 	lock.Lock()

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -998,15 +998,15 @@ func PreCacheMaps() {
 func validateRoomBiomes() {
 	missingBiomeCount := 0
 	invalidBiomeCount := 0
-	
+
 	for _, roomId := range rooms.GetAllRoomIds() {
 		room := rooms.LoadRoom(roomId)
 		if room == nil {
 			continue
 		}
-		
+
 		originalBiome := room.Biome
-		
+
 		// Check if room has no biome
 		if originalBiome == "" {
 			zoneBiome := rooms.GetZoneBiome(room.Zone)
@@ -1022,7 +1022,7 @@ func validateRoomBiomes() {
 			}
 		}
 	}
-	
+
 	if missingBiomeCount > 0 || invalidBiomeCount > 0 {
 		mudlog.Info("Biome validation complete", "missing", missingBiomeCount, "invalid", invalidBiomeCount)
 	}

--- a/internal/rooms/rooms.go
+++ b/internal/rooms/rooms.go
@@ -2198,7 +2198,6 @@ func (r *Room) Validate() error {
 		}
 	}
 
-
 	// Make sure all items are validated (and have uids)
 	for i := range r.Items {
 		r.Items[i].Validate()

--- a/internal/users/onlineinfo.go
+++ b/internal/users/onlineinfo.go
@@ -1,13 +1,14 @@
 package users
 
 type OnlineInfo struct {
-	Username      string
-	CharacterName string
-	Level         int
-	Alignment     string
-	Profession    string
-	OnlineTime    int64
-	OnlineTimeStr string
-	IsAFK         bool
-	Role          string
+	Username       string
+	CharacterName  string
+	Level          int
+	Alignment      string
+	Profession     string
+	OnlineTime     int64
+	OnlineTimeStr  string
+	IsAFK          bool
+	Role           string
+	ConnectionType string // "Web", "Telnet", or "Secure"
 }

--- a/internal/users/onlineinfo.go
+++ b/internal/users/onlineinfo.go
@@ -10,5 +10,5 @@ type OnlineInfo struct {
 	OnlineTimeStr  string
 	IsAFK          bool
 	Role           string
-	ConnectionType string // "Web", "Telnet", or "Secure"
+	ConnectionType string // "Web", "Telnet", or "TLS"
 }

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -619,6 +620,23 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 		isAfk = true
 	}
 
+	// Determine connection type
+	connectionType := "Telnet"
+	if connections.IsWebsocket(u.connectionId) {
+		connectionType = "Web"
+	} else {
+		// Check if connected through a secure telnet port
+		port := connections.GetConnectionPort(u.connectionId)
+		networkConfig := configs.GetNetworkConfig()
+		for _, securePortStr := range networkConfig.SecureTelnetPort {
+			securePort, _ := strconv.Atoi(securePortStr)
+			if securePort > 0 && port == securePort {
+				connectionType = "Secure"
+				break
+			}
+		}
+	}
+
 	return OnlineInfo{
 		u.Username,
 		u.Character.Name,
@@ -629,6 +647,7 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 		timeStr,
 		isAfk,
 		u.Role,
+		connectionType,
 	}
 }
 

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -628,10 +628,14 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 		// Check if connected through a secure telnet port
 		port := connections.GetConnectionPort(u.connectionId)
 		networkConfig := configs.GetNetworkConfig()
+		
+		// Debug logging
+		mudlog.Debug("Connection type check", "connectionId", u.connectionId, "port", port, "securePorts", networkConfig.SecureTelnetPort)
+		
 		for _, securePortStr := range networkConfig.SecureTelnetPort {
 			securePort, _ := strconv.Atoi(securePortStr)
 			if securePort > 0 && port == securePort {
-				connectionType = "Secure"
+				connectionType = "TLS"
 				break
 			}
 		}

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -625,19 +625,15 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 	if connections.IsWebsocket(u.connectionId) {
 		connectionType = "Web"
 	} else {
-		// Check if connected through a secure telnet port
+		// Check if connected through the secure telnet local port (where TLS proxy forwards)
 		port := connections.GetConnectionPort(u.connectionId)
 		networkConfig := configs.GetNetworkConfig()
 		
 		// Debug logging
-		mudlog.Debug("Connection type check", "connectionId", u.connectionId, "port", port, "securePorts", networkConfig.SecureTelnetPort)
+		mudlog.Debug("Connection type check", "connectionId", u.connectionId, "port", port, "secureLocalPort", networkConfig.SecureTelnetLocalPort)
 		
-		for _, securePortStr := range networkConfig.SecureTelnetPort {
-			securePort, _ := strconv.Atoi(securePortStr)
-			if securePort > 0 && port == securePort {
-				connectionType = "TLS"
-				break
-			}
+		if networkConfig.SecureTelnetLocalPort > 0 && port == int(networkConfig.SecureTelnetLocalPort) {
+			connectionType = "TLS"
 		}
 	}
 

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -625,15 +625,19 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 	if connections.IsWebsocket(u.connectionId) {
 		connectionType = "Web"
 	} else {
-		// Check if connected through the secure telnet local port (where TLS proxy forwards)
+		// Check if connected through a secure telnet local port (where TLS proxy forwards)
 		port := connections.GetConnectionPort(u.connectionId)
 		networkConfig := configs.GetNetworkConfig()
 		
 		// Debug logging
-		mudlog.Debug("Connection type check", "connectionId", u.connectionId, "port", port, "secureLocalPort", networkConfig.SecureTelnetLocalPort)
+		mudlog.Debug("Connection type check", "connectionId", u.connectionId, "port", port, "secureLocalPorts", networkConfig.SecureTelnetLocalPort)
 		
-		if networkConfig.SecureTelnetLocalPort > 0 && port == int(networkConfig.SecureTelnetLocalPort) {
-			connectionType = "TLS"
+		for _, securePortStr := range networkConfig.SecureTelnetLocalPort {
+			securePort, _ := strconv.Atoi(securePortStr)
+			if securePort > 0 && port == securePort {
+				connectionType = "TLS"
+				break
+			}
 		}
 	}
 

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -628,7 +628,7 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 		// Check if connected through a secure telnet local port (where TLS proxy forwards)
 		port := connections.GetConnectionPort(u.connectionId)
 		networkConfig := configs.GetNetworkConfig()
-		
+
 		for _, securePortStr := range networkConfig.SecureTelnetLocalPort {
 			securePort, _ := strconv.Atoi(securePortStr)
 			if securePort > 0 && port == securePort {

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -629,9 +629,6 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 		port := connections.GetConnectionPort(u.connectionId)
 		networkConfig := configs.GetNetworkConfig()
 		
-		// Debug logging
-		mudlog.Debug("Connection type check", "connectionId", u.connectionId, "port", port, "secureLocalPorts", networkConfig.SecureTelnetLocalPort)
-		
 		for _, securePortStr := range networkConfig.SecureTelnetLocalPort {
 			securePort, _ := strconv.Atoi(securePortStr)
 			if securePort > 0 && port == securePort {

--- a/internal/web/stats.go
+++ b/internal/web/stats.go
@@ -7,17 +7,19 @@ import (
 )
 
 type Stats struct {
-	OnlineUsers   []users.OnlineInfo
-	TelnetPorts   []int
-	WebSocketPort int
+	OnlineUsers       []users.OnlineInfo
+	TelnetPorts       []int
+	SecureTelnetPorts []int
+	WebSocketPort     int
 }
 
 var (
 	statsLock   = sync.RWMutex{}
 	serverStats = Stats{
-		WebSocketPort: 0,
-		OnlineUsers:   []users.OnlineInfo{},
-		TelnetPorts:   []int{},
+		WebSocketPort:     0,
+		OnlineUsers:       []users.OnlineInfo{},
+		TelnetPorts:       []int{},
+		SecureTelnetPorts: []int{},
 	}
 )
 
@@ -41,4 +43,5 @@ func (s *Stats) Reset() {
 	s.WebSocketPort = 0
 	s.OnlineUsers = []users.OnlineInfo{}
 	s.TelnetPorts = []int{}
+	s.SecureTelnetPorts = []int{}
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -42,6 +42,47 @@ type WebNav struct {
 	Target string
 }
 
+// getClientIP extracts the real client IP address from the request.
+// It checks for X-Real-IP and X-Forwarded-For headers when the direct
+// connection is from localhost (trusted proxy), otherwise returns the
+// direct connection IP.
+func getClientIP(r *http.Request) string {
+	// Get the direct connection IP
+	remoteAddr := r.RemoteAddr
+
+	// Extract just the IP part (remove port)
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		// If splitting fails, use the whole remoteAddr
+		host = remoteAddr
+	}
+
+	// Only trust proxy headers if the connection is from localhost
+	if host == "127.0.0.1" || host == "::1" || host == "localhost" {
+		// Check X-Real-IP first (higher priority)
+		if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+			return realIP
+		}
+
+		// Check X-Forwarded-For (may contain multiple IPs)
+		if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
+			// X-Forwarded-For can contain comma-separated IPs
+			// The first one is the original client
+			ips := strings.Split(forwardedFor, ",")
+			if len(ips) > 0 {
+				// Trim any whitespace from the IP
+				clientIP := strings.TrimSpace(ips[0])
+				if clientIP != "" {
+					return clientIP
+				}
+			}
+		}
+	}
+
+	// Return the direct connection IP if no proxy headers or not from localhost
+	return host
+}
+
 type WebPlugin interface {
 	NavLinks() map[string]string                                                    // Name=>Path pairs
 	WebRequest(r *http.Request) (html string, templateData map[string]any, ok bool) // Get the first handler of a given request
@@ -106,7 +147,7 @@ func serveTemplate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !pageFound || len(fileBase) > 0 && fileBase[0] == '_' {
-		mudlog.Info("Web", "ip", r.RemoteAddr, "ref", r.Header.Get("Referer"), "file path", fullPath, "file extension", fileExt, "error", "Not found")
+		mudlog.Info("Web", "ip", getClientIP(r), "ref", r.Header.Get("Referer"), "file path", fullPath, "file extension", fileExt, "error", "Not found")
 
 		fullPath = filepath.Join(httpRoot, `404.html`)
 		fInfo, err = os.Stat(fullPath)
@@ -122,7 +163,7 @@ func serveTemplate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Log the request
-	mudlog.Info("Web", "ip", r.RemoteAddr, "ref", r.Header.Get("Referer"), "file path", fullPath, "file extension", fileExt, "file source", source, "size", fmt.Sprintf(`%.2fk`, float64(fSize)/1024))
+	mudlog.Info("Web", "ip", getClientIP(r), "ref", r.Header.Get("Referer"), "file path", fullPath, "file extension", fileExt, "file source", source, "size", fmt.Sprintf(`%.2fk`, float64(fSize)/1024))
 
 	// For non-HTML files, serve them statically.
 	if fileExt != ".html" {

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -47,31 +47,25 @@ type WebNav struct {
 // connection is from localhost (trusted proxy), otherwise returns the
 // direct connection IP.
 func getClientIP(r *http.Request) string {
-	// Get the direct connection IP
 	remoteAddr := r.RemoteAddr
 
-	// Extract just the IP part (remove port)
 	host, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {
-		// If splitting fails, use the whole remoteAddr
 		host = remoteAddr
 	}
 
 	// Only trust proxy headers if the connection is from localhost
-	// Check for various localhost representations
 	if host == "127.0.0.1" || host == "::1" || host == "localhost" {
-		// Check X-Real-IP first (higher priority)
+		// X-Real-IP has higher priority than X-Forwarded-For
 		if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
 			return realIP
 		}
 
-		// Check X-Forwarded-For (may contain multiple IPs)
 		if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
 			// X-Forwarded-For can contain comma-separated IPs
 			// The first one is the original client
 			ips := strings.Split(forwardedFor, ",")
 			if len(ips) > 0 {
-				// Trim any whitespace from the IP
 				clientIP := strings.TrimSpace(ips[0])
 				if clientIP != "" {
 					return clientIP
@@ -80,7 +74,6 @@ func getClientIP(r *http.Request) string {
 		}
 	}
 
-	// Return the direct connection IP if no proxy headers or not from localhost
 	return host
 }
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -59,7 +59,7 @@ func getClientIP(r *http.Request) string {
 
 	// Only trust proxy headers if the connection is from localhost
 	// Check for various localhost representations
-	if host == "127.0.0.1" || host == "::1" || host == "localhost" || host == "0.0.0.0" {
+	if host == "127.0.0.1" || host == "::1" || host == "localhost" {
 		// Check X-Real-IP first (higher priority)
 		if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
 			return realIP

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -58,7 +58,8 @@ func getClientIP(r *http.Request) string {
 	}
 
 	// Only trust proxy headers if the connection is from localhost
-	if host == "127.0.0.1" || host == "::1" || host == "localhost" {
+	// Check for various localhost representations
+	if host == "127.0.0.1" || host == "::1" || host == "localhost" || host == "0.0.0.0" {
 		// Check X-Real-IP first (higher priority)
 		if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
 			return realIP

--- a/main.go
+++ b/main.go
@@ -271,11 +271,13 @@ func main() {
 		TelnetListenOnPort(`127.0.0.1`, int(c.Network.LocalPort), &wg, 0)
 	}
 
-	// Secure telnet local port - where TLS proxy forwards to
-	if c.Network.SecureTelnetLocalPort > 0 {
-		mudlog.Info("Telnet", "stage", "Listening on secure local port (localhost only)", "port", c.Network.SecureTelnetLocalPort)
-		// Same as LocalPort - localhost only, no connection limit
-		TelnetListenOnPort(`127.0.0.1`, int(c.Network.SecureTelnetLocalPort), &wg, 0)
+	// Secure telnet local ports - where TLS proxy forwards to
+	for _, port := range c.Network.SecureTelnetLocalPort {
+		if p, err := strconv.Atoi(port); err == nil && p > 0 {
+			mudlog.Info("Telnet", "stage", "Listening on secure local port (localhost only)", "port", p)
+			// Same as LocalPort - localhost only, no connection limit
+			TelnetListenOnPort(`127.0.0.1`, p, &wg, 0)
+		}
 	}
 
 	go worldManager.InputWorker(workerShutdownChan, &wg)

--- a/main.go
+++ b/main.go
@@ -271,13 +271,11 @@ func main() {
 		TelnetListenOnPort(`127.0.0.1`, int(c.Network.LocalPort), &wg, 0)
 	}
 
-	// Secure telnet ports - same as LocalPort but tracked differently
-	for _, port := range c.Network.SecureTelnetPort {
-		if p, err := strconv.Atoi(port); err == nil && p > 0 {
-			mudlog.Info("Telnet", "stage", "Listening on secure port (localhost only)", "port", p)
-			// Same as LocalPort - localhost only, no connection limit
-			TelnetListenOnPort(`127.0.0.1`, p, &wg, 0)
-		}
+	// Secure telnet local port - where TLS proxy forwards to
+	if c.Network.SecureTelnetLocalPort > 0 {
+		mudlog.Info("Telnet", "stage", "Listening on secure local port (localhost only)", "port", c.Network.SecureTelnetLocalPort)
+		// Same as LocalPort - localhost only, no connection limit
+		TelnetListenOnPort(`127.0.0.1`, int(c.Network.SecureTelnetLocalPort), &wg, 0)
 	}
 
 	go worldManager.InputWorker(workerShutdownChan, &wg)

--- a/main.go
+++ b/main.go
@@ -271,6 +271,15 @@ func main() {
 		TelnetListenOnPort(`127.0.0.1`, int(c.Network.LocalPort), &wg, 0)
 	}
 
+	// Secure telnet ports - same as LocalPort but tracked differently
+	for _, port := range c.Network.SecureTelnetPort {
+		if p, err := strconv.Atoi(port); err == nil && p > 0 {
+			mudlog.Info("Telnet", "stage", "Listening on secure port (localhost only)", "port", p)
+			// Same as LocalPort - localhost only, no connection limit
+			TelnetListenOnPort(`127.0.0.1`, p, &wg, 0)
+		}
+	}
+
 	go worldManager.InputWorker(workerShutdownChan, &wg)
 	go worldManager.MainWorker(workerShutdownChan, &wg)
 

--- a/world.go
+++ b/world.go
@@ -1057,6 +1057,13 @@ func (w *World) UpdateStats() {
 		}
 	}
 
+	for _, t := range c.SecureTelnetPort {
+		p, _ := strconv.Atoi(t)
+		if p > 0 {
+			s.SecureTelnetPorts = append(s.SecureTelnetPorts, p)
+		}
+	}
+
 	s.WebSocketPort = int(c.HttpPort)
 
 	web.UpdateStats(s)


### PR DESCRIPTION
Added:
  - getClientIP helper function to extract real client IPs from proxy headers
  - X-Real-IP header parsing (higher priority)
  - X-Forwarded-For header parsing with comma-separated IP support
  - Security check to only trust headers from localhost connections

Changed:
  - Web request logging to use getClientIP instead of r.RemoteAddr
  - Log output now shows real client IPs when behind trusted reverse proxy