### PR TITLE
Centralize MUD branding configuration

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -34,6 +34,24 @@ Server:
   #   Display name of the MUD.
   #   This will be used a few places by default (such as the web pages).
   MudName: "GoMud"
+  # - Tagline -
+  #   Short tagline displayed on the login splash screen.
+  Tagline: "an open source MUD Library written in Go"
+  # - Description -
+  #   Longer description used on the about page.
+  Description: "GoMud is an open source MUD (Multi-user Dungeon) game world and library."
+  # - URL -
+  #   Project or server URL shown to players.
+  URL: "github.com/GoMudEngine/GoMud"
+  # - DiscordURL -
+  #   Community Discord invite link.
+  DiscordURL: "discord.gg/cjukKvQWyy"
+  # - AdminName -
+  #   Server operator name (optional, shown on about page if set).
+  AdminName: ""
+  # - AdminEmail -
+  #   Contact email (optional, shown on about page if set).
+  AdminEmail: ""
   # - Seed -
   #   The seed used for certain types of content generation
   #   To prevent certain secrets or content from being spoiled, you can set this

--- a/_datafiles/world/default/templates/help/about.template
+++ b/_datafiles/world/default/templates/help/about.template
@@ -1,12 +1,12 @@
-<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">About </ansi><ansi fg="command">GoMud</ansi>
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">About </ansi><ansi fg="command">{{ branding "MudName" }}</ansi>
 
-<ansi fg="command">GoMud</ansi> is an open source <ansi fg="229">MUD</ansi> (Multi-user Dungeon) game world and library.
+{{ branding "Description" }}
 
-The <ansi fg="command">GoMud</ansi> engine ships with a default world to play in, but can be overwritten
+The <ansi fg="command">{{ branding "MudName" }}</ansi> engine ships with a default world to play in, but can be overwritten
 or modified to build your own world using built-in tools.
 
-<ansi fg="black-bold">Join the <ansi fg="command">GoMud</ansi> Discord Server:</ansi>   <ansi fg="51">discord.gg/cjukKvQWyy</ansi>
-<ansi fg="black-bold">Find out more (or get the code):</ansi> <ansi fg="51">github.com/GoMudEngine/GoMud</ansi>
+<ansi fg="black-bold">Join the <ansi fg="command">{{ branding "MudName" }}</ansi> Discord Server:</ansi>   <ansi fg="51">{{ branding "DiscordURL" }}</ansi>
+<ansi fg="black-bold">Find out more (or get the code):</ansi> <ansi fg="51">{{ branding "URL" }}</ansi>
 
 <ansi fg="6">  .--.      .-'.      .--.      .--.      .--.      .--.      .`-.      .--.
 <ansi fg="187">:::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187"></ansi>

--- a/_datafiles/world/default/templates/login/connect-splash.template
+++ b/_datafiles/world/default/templates/login/connect-splash.template
@@ -18,9 +18,9 @@
                                           <ansi fg="252">-===============</ansi><ansi fg="214">|</ansi><ansi fg="94">xxx</ansi><ansi fg="214">(}</ansi>
                                                           <ansi fg="214">O</ansi></ansi>
 
-<ansi fg="black-bold">.:</ansi> Welcome to <ansi fg="45">GoMud</ansi>, an open source MUD Library written in <ansi fg="45">Go</ansi>.
+<ansi fg="black-bold">.:</ansi> Welcome to <ansi fg="45">{{ branding "MudName" }}</ansi>, {{ branding "Tagline" }}.
 
                                             <ansi fg="black-bold">Find out more (or get the code) at:
-                                                        <ansi fg="51">github.com/GoMudEngine/GoMud</ansi></ansi>
+                                                        <ansi fg="51">{{ branding "URL" }}</ansi></ansi>
 
 <ansi fg="black-bold">{{ repeat "=" 80 }}</ansi>

--- a/_datafiles/world/empty/templates/help/about.template
+++ b/_datafiles/world/empty/templates/help/about.template
@@ -1,12 +1,12 @@
-<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">About </ansi><ansi fg="command">GoMud</ansi>
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">About </ansi><ansi fg="command">{{ branding "MudName" }}</ansi>
 
-<ansi fg="command">GoMud</ansi> is an open source <ansi fg="229">MUD</ansi> (Multi-user Dungeon) game world and library.
+{{ branding "Description" }}
 
-The <ansi fg="command">GoMud</ansi> engine ships with a default world to play in, but can be overwritten
+The <ansi fg="command">{{ branding "MudName" }}</ansi> engine ships with a default world to play in, but can be overwritten
 or modified to build your own world using built-in tools.
 
-<ansi fg="black-bold">Join the <ansi fg="command">GoMud</ansi> Discord Server:</ansi>   <ansi fg="51">discord.gg/cjukKvQWyy</ansi>
-<ansi fg="black-bold">Find out more (or get the code):</ansi> <ansi fg="51">github.com/GoMudEngine/GoMud</ansi>
+<ansi fg="black-bold">Join the <ansi fg="command">{{ branding "MudName" }}</ansi> Discord Server:</ansi>   <ansi fg="51">{{ branding "DiscordURL" }}</ansi>
+<ansi fg="black-bold">Find out more (or get the code):</ansi> <ansi fg="51">{{ branding "URL" }}</ansi>
 
 <ansi fg="6">  .--.      .-'.      .--.      .--.      .--.      .--.      .`-.      .--.
 <ansi fg="187">:::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187">::::::::.</ansi>\<ansi fg="187"></ansi>

--- a/_datafiles/world/empty/templates/login/connect-splash.template
+++ b/_datafiles/world/empty/templates/login/connect-splash.template
@@ -18,9 +18,9 @@
                                           <ansi fg="252">-===============</ansi><ansi fg="214">|</ansi><ansi fg="94">xxx</ansi><ansi fg="214">(}</ansi>
                                                           <ansi fg="214">O</ansi></ansi>
 
-<ansi fg="black-bold">.:</ansi> Welcome to <ansi fg="45">GoMud</ansi>, an open source MUD Library written in <ansi fg="45">Go</ansi>.
+<ansi fg="black-bold">.:</ansi> Welcome to <ansi fg="45">{{ branding "MudName" }}</ansi>, {{ branding "Tagline" }}.
 
                                             <ansi fg="black-bold">Find out more (or get the code) at:
-                                                        <ansi fg="51">github.com/GoMudEngine/GoMud</ansi></ansi>
+                                                        <ansi fg="51">{{ branding "URL" }}</ansi></ansi>
 
 <ansi fg="black-bold">{{ repeat "=" 80 }}</ansi>

--- a/internal/configs/config.server.go
+++ b/internal/configs/config.server.go
@@ -2,6 +2,12 @@ package configs
 
 type Server struct {
 	MudName         ConfigString      `yaml:"MudName"`         // Name of the MUD
+	Tagline         ConfigString      `yaml:"Tagline"`         // Short tagline shown on login splash
+	Description     ConfigString      `yaml:"Description"`     // Longer description for about page
+	URL             ConfigString      `yaml:"URL"`             // Project or server URL
+	DiscordURL      ConfigString      `yaml:"DiscordURL"`      // Community Discord invite link
+	AdminName       ConfigString      `yaml:"AdminName"`       // Server operator name (optional)
+	AdminEmail      ConfigString      `yaml:"AdminEmail"`      // Contact email (optional)
 	CurrentVersion  ConfigString      `yaml:"CurrentVersion"`  // Current version this mud has been updated to
 	Seed            ConfigSecret      `yaml:"Seed"`            // Seed that may be used for generating content
 	MaxCPUCores     ConfigInt         `yaml:"MaxCPUCores"`     // How many cores to allow for multi-core operations
@@ -18,6 +24,25 @@ func (s *Server) Validate() {
 	// Ignore Motd
 	// Ignore NextRoomId
 	// Ignore Locked
+
+	if s.Tagline == `` {
+		s.Tagline = `an open source MUD Library written in Go`
+	}
+
+	if s.Description == `` {
+		s.Description = `GoMud is an open source MUD (Multi-user Dungeon) game world and library.`
+	}
+
+	if s.URL == `` {
+		s.URL = `github.com/GoMudEngine/GoMud`
+	}
+
+	if s.DiscordURL == `` {
+		s.DiscordURL = `discord.gg/cjukKvQWyy`
+	}
+
+	// Ignore AdminName
+	// Ignore AdminEmail
 
 	if s.Seed == `` {
 		s.Seed = `Mud` // default

--- a/internal/templates/templatesfunctions.go
+++ b/internal/templates/templatesfunctions.go
@@ -207,6 +207,27 @@ var (
 		},
 		"map": makeMap,
 		"t":   language.T,
+		"branding": func(field string) string {
+			s := configs.GetServerConfig()
+			switch field {
+			case "MudName":
+				return string(s.MudName)
+			case "Tagline":
+				return string(s.Tagline)
+			case "Description":
+				return string(s.Description)
+			case "URL":
+				return string(s.URL)
+			case "DiscordURL":
+				return string(s.DiscordURL)
+			case "AdminName":
+				return string(s.AdminName)
+			case "AdminEmail":
+				return string(s.AdminEmail)
+			default:
+				return ""
+			}
+		},
 	}
 )
 


### PR DESCRIPTION
## Summary

- Add branding fields (`Tagline`, `Description`, `URL`, `DiscordURL`, `AdminName`, `AdminEmail`) to `Server` config section
- Add `{{ branding "Field" }}` template function so templates read from config instead of hardcoding strings
- Update login splash and about templates in both `default` and `empty` worlds to use the new function
- Operators can now rebrand entirely from `config.yaml` without editing templates or recompiling

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go build ./...` compiles cleanly
- [ ] `gofmt -l .` reports no unformatted files
- [ ] Connect via telnet, verify login splash shows branding from config
- [ ] Run `help about`, verify it shows branding from config
- [ ] Change `Server.Tagline` in config.yaml, restart, verify it updates on the splash screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)