### PR TITLE
Allowing plaintext password match for default admin first time setup.

### DIFF
--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -105,6 +105,11 @@ func (u *UserRecord) PasswordMatches(input string) bool {
 		return true
 	}
 
+	// Special case for new setups before things get reset
+	if u.Username == "admin" && input == "password" && u.Password == input {
+		return true
+	}
+
 	// No plaintext fallback. No hash-of-hash bypass.
 	return false
 }


### PR DESCRIPTION
# Description

A recent PR disabled plaintext matching as a security precaution. This broke some legacy behavior.

This allows plaintext matching for the default user on a new install. Later we will require a password change after this login occurs.

## Changes

- "password" allowed as a plaintext match for "admin" user, if the password is actually plaintext "password"