### PR TITLE
Plaintext paswords require a pw change

### DIFF
--- a/internal/hooks/PlayerSpawn_HandleJoin.go
+++ b/internal/hooks/PlayerSpawn_HandleJoin.go
@@ -65,19 +65,24 @@ func HandleJoin(e events.Event) events.ListenerReturn {
 	}
 
 	// TODO HERE
-	loginCmds := configs.GetConfig().Server.OnLoginCommands
-	if len(loginCmds) > 0 {
+	if user.HasPlaintextPassword() {
+		user.SendText(`<ansi fg="alert-5">You must change your password before doing anything else.</ansi>`)
+		user.SendText(`<ansi fg="yellow">Type <ansi fg="yellow-bold">password</ansi> to set a new password.</ansi>`)
+	} else {
+		loginCmds := configs.GetConfig().Server.OnLoginCommands
+		if len(loginCmds) > 0 {
 
-		for _, cmd := range loginCmds {
+			for _, cmd := range loginCmds {
 
-			events.AddToQueue(events.Input{
-				UserId:    evt.UserId,
-				InputText: cmd,
-				ReadyTurn: 0, // No delay between execution of commands
-			})
+				events.AddToQueue(events.Input{
+					UserId:    evt.UserId,
+					InputText: cmd,
+					ReadyTurn: 0, // No delay between execution of commands
+				})
+
+			}
 
 		}
-
 	}
 
 	if room != nil {

--- a/internal/usercommands/password.go
+++ b/internal/usercommands/password.go
@@ -11,18 +11,20 @@ func Password(rest string, user *users.UserRecord, room *rooms.Room, flags event
 	// Get if already exists, otherwise create new
 	cmdPrompt, _ := user.StartPrompt(`password`, rest)
 
-	question := cmdPrompt.Ask(`What is your current password?`, []string{})
-	if !question.Done {
-		return true, nil
+	if !user.HasPlaintextPassword() {
+		question := cmdPrompt.Ask(`What is your current password?`, []string{})
+		if !question.Done {
+			return true, nil
+		}
+
+		if !user.PasswordMatches(question.Response) {
+			user.SendText(`<ansi fg="alert-5">Sorry, your password was incorrect.</ansi>`)
+			user.ClearPrompt()
+			return true, nil
+		}
 	}
 
-	if !user.PasswordMatches(question.Response) {
-		user.SendText(`<ansi fg="alert-5">Sorry, your password was incorrect.</ansi>`)
-		user.ClearPrompt()
-		return true, nil
-	}
-
-	question = cmdPrompt.Ask(`What new password would you like?`, []string{})
+	question := cmdPrompt.Ask(`What new password would you like?`, []string{})
 	if !question.Done {
 		return true, nil
 	}

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -352,6 +352,12 @@ func TryCommand(cmd string, rest string, userId int, flags events.EventFlag) (bo
 		}
 	}
 
+	if user.HasPlaintextPassword() && cmd != `password` {
+		user.SendText(`<ansi fg="alert-5">You must change your password before doing anything else.</ansi>`)
+		user.SendText(`<ansi fg="yellow">Type <ansi fg="yellow-bold">password</ansi> to set a new password.</ansi>`)
+		return true, nil
+	}
+
 	if cmdInfo, ok := userCommands[cmd]; ok {
 
 		if !cmdInfo.AllowedWhenDowned {

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -89,6 +89,18 @@ func (u *UserRecord) ClientSettings() connections.ClientSettings {
 	return connections.GetClientSettings(u.connectionId)
 }
 
+func (u *UserRecord) HasPlaintextPassword() bool {
+	// bcrypt check
+	if strings.HasPrefix(u.Password, "$2a$") || strings.HasPrefix(u.Password, "$2b$") {
+		return false
+	}
+	// SHA256 check
+	if len(u.Password) == 64 {
+		return false
+	}
+	return true
+}
+
 func (u *UserRecord) PasswordMatches(input string) bool {
 
 	// Try bcrypt first (new format).
@@ -106,7 +118,7 @@ func (u *UserRecord) PasswordMatches(input string) bool {
 	}
 
 	// Special case for new setups before things get reset
-	if u.Username == "admin" && input == "password" && u.Password == input {
+	if u.HasPlaintextPassword() && u.Password == input {
 		return true
 	}
 


### PR DESCRIPTION
# Description

If a user record is set to a plaintext password, they will be required to change it before they can do anything else.

This is specifically applicable to the default admin login, but in case user files are manually edited to change the password in the future.

## Changes

- Disallow any commands other than `password` if they have a plaintext password
- Suppress "on login commands" if plaintext password
- Remove previous temporary measure allowing only admin to have a plaintext password
