### PR TITLE
Fixing discord notifications

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
     steps:
+      - uses: actions/checkout@v4
       - name: Skip when webhook is not configured
         if: ${{ env.DISCORD_WEBHOOK_URL == '' }}
         run: >


### PR DESCRIPTION
# Description

A recent change to github workflows accidentally disabled the slack notifications for PR's. This fixes it.

## Changes

- Added back `actions/checkout@v4`
