### PR TITLE
Persistent full world "visited room" tracking

### DIFF
--- a/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
+++ b/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
@@ -93,6 +93,8 @@ ActorObjects are the basic object that represents Users and NPCs
   - [ActorObject.TimerExpired(name string) bool](#actorobjecttimerexpiredname-string-bool)
   - [ActorObject.TimerExists(name string) bool](#actorobjecttimerexistsname-string-bool)
   - [ActorObject.AddEventLog(category string, message string)](#actorobjectaddeventlogcategory-string-message-string)
+  - [ActorObject.MarkVisitedRoom(roomId1 int [, roomId2, ...])](#actorobjectmarkvisitedroomroomid1-int--roomid2-)
+  - [ActorObject.MarkVisitedZone(zoneName string)](#actorobjectmarkvisitedzonezoneename-string)
 
 
 
@@ -639,3 +641,29 @@ Adds a line to the users Event Log (`history`)
 | --- | --- |
 | category | A short single word category  |
 | message | A single line describing the event |
+
+## [ActorObject.MarkVisitedRoom(roomId1 int [, roomId2, ...])](/internal/scripting/actor_func.go)
+Marks one or more rooms as visited for this actor. Only applies to user actors; mobs do not track room visits. Each room is recorded under the zone it belongs to.
+
+_Note: Non-positive room IDs are silently ignored._
+
+|  Argument | Explanation |
+| --- | --- |
+| roomId1, roomId2, ... | One or more room IDs to mark as visited |
+
+**Example:**
+```javascript
+user.MarkVisitedRoom(101, 102, 103);
+```
+
+## [ActorObject.MarkVisitedZone(zoneName string)](/internal/scripting/actor_func.go)
+Marks every room in the named zone as visited for this actor. Only applies to user actors; mobs do not track room visits. Accepts partial zone name matches.
+
+|  Argument | Explanation |
+| --- | --- |
+| zoneName | The zone name (or partial name) to mark all rooms visited in |
+
+**Example:**
+```javascript
+user.MarkVisitedZone("frostfang");
+```

--- a/_datafiles/guides/building/scripting/FUNCTIONS_PARTY.md
+++ b/_datafiles/guides/building/scripting/FUNCTIONS_PARTY.md
@@ -26,6 +26,8 @@ PartyObjects represent collections of actors (users and NPCs) that are grouped t
   - [PartyObject.GiveExtraLife()](#partyobjectgiveextralife)
   - [PartyObject.GrantXP(xpAmt int, reason string)](#partyobjectgrantxpxpamt-int-reason-string)
   - [PartyObject.TimerSet(name string, period string)](#partyobjecttimersetname-string-period-string)
+  - [PartyObject.MarkVisitedRoom(roomId1 int [, roomId2, ...])](#partyobjectmarkvisitedroomroomid1-int--roomid2-)
+  - [PartyObject.MarkVisitedZone(zoneName string)](#partyobjectmarkvisitedzonezoneename-string)
 
 
 
@@ -196,3 +198,27 @@ Starts a new Round timer for all party members.
 | --- | --- |
 | name | A string identifier. Reusing names will overwrite previously assigned names |
 | period | How long until the timer expires. `1 real hour`, `1 hour`, etc |
+
+## [PartyObject.MarkVisitedRoom(roomId1 int [, roomId2, ...])](/internal/scripting/party_func.go)
+Marks one or more rooms as visited for all user members of the party. Mobs in the party are unaffected.
+
+|  Argument | Explanation |
+| --- | --- |
+| roomId1, roomId2, ... | One or more room IDs to mark as visited |
+
+**Example:**
+```javascript
+user.GetParty().MarkVisitedRoom(101, 102, 103);
+```
+
+## [PartyObject.MarkVisitedZone(zoneName string)](/internal/scripting/party_func.go)
+Marks every room in the named zone as visited for all user members of the party. Mobs in the party are unaffected. Accepts partial zone name matches.
+
+|  Argument | Explanation |
+| --- | --- |
+| zoneName | The zone name (or partial name) to mark all rooms visited in |
+
+**Example:**
+```javascript
+user.GetParty().MarkVisitedZone("frostfang");
+```

--- a/_datafiles/world/default/keywords.yaml
+++ b/_datafiles/world/default/keywords.yaml
@@ -68,6 +68,7 @@ help:
       - races
       - who
       - history
+      - visited
     items:
       - drop
       - drink
@@ -125,6 +126,7 @@ help:
       - buff
       - build
       - command
+      - copyover
       - deafen
       - item
       - grant
@@ -145,6 +147,7 @@ help:
       - syslogs
       - zap
       - zone
+      - visit
 # Aliases for keywords when typing: help <keyword>
 # Key is the target keyword, value is the list of aliases
 help-aliases:

--- a/_datafiles/world/default/templates/admincommands/help/command.visit.template
+++ b/_datafiles/world/default/templates/admincommands/help/command.visit.template
@@ -1,0 +1,24 @@
+The <ansi fg="command">visit</ansi> command manages room visit tracking for players:
+
+<ansi fg="command">visit list</ansi>
+  List visit progress across all zones for yourself.
+
+<ansi fg="command">visit list [username]</ansi>
+  List visit progress across all zones for the specified user.
+
+<ansi fg="command">visit set [zonename|all]</ansi>
+  Mark all rooms in the specified zone as visited for yourself.
+  Use <ansi fg="command">all</ansi> to mark every zone.
+
+<ansi fg="command">visit set [zonename|all] [username]</ansi>
+  Mark all rooms in the specified zone as visited for the target user.
+
+<ansi fg="command">visit unset [zonename|all]</ansi>
+  Reset all rooms in the specified zone to unvisited for yourself.
+  Use <ansi fg="command">all</ansi> to reset every zone.
+
+<ansi fg="command">visit unset [zonename|all] [username]</ansi>
+  Reset all rooms in the specified zone to unvisited for the target user.
+
+Zone names support partial matching. The username can be an online character
+name or an offline account username.

--- a/_datafiles/world/default/templates/character/visited.template
+++ b/_datafiles/world/default/templates/character/visited.template
@@ -1,0 +1,4 @@
+ ┌─ <ansi fg="black-bold">.:</ansi><ansi fg="20">Zones Discovered</ansi> ─────────────────────────────────────────────────────┐
+ {{ $nlLen := sub (len .Records) 1 }}{{ range $idx, $zInfo := .Records }}  <ansi fg="yellow-bold">{{ padRight 30 $zInfo.Name }}</ansi> <ansi fg="green">{{ $zInfo.BarFull }}</ansi><ansi fg="black-bold">{{ $zInfo.BarEmpty }}</ansi> <ansi fg="cyan-bold">{{ padRight 4 $zInfo.Completion }}</ansi>{{ if lt $idx $nlLen }}{{ end }}
+ {{ end -}}
+ └──────────────────────────────────────────────────────────────────────────┘

--- a/_datafiles/world/default/templates/help/visited.md
+++ b/_datafiles/world/default/templates/help/visited.md
@@ -1,0 +1,7 @@
+# Help for ~visited~
+
+The ~visited~ command shows all zones you have explored, along with the percentage of rooms visited in each.
+
+## Usage:
+
+  ~visited~

--- a/_datafiles/world/default/templates/maps/map.template
+++ b/_datafiles/world/default/templates/maps/map.template
@@ -3,7 +3,7 @@
 {{- $leftBorder := .LeftBorder -}}
 {{- $midBorder := .MidBorder -}}
 {{- $rightBorder := .RightBorder -}}
-<ansi fg="black-bold">{{ $leftBorder.Top }}</ansi><ansi fg="black-bold">  .:</ansi><ansi fg="20">{{ printf ( printf "%%-%ds" ( sub $mapWidth 4 ) ) .Title }}</ansi><ansi fg="black-bold">{{ $rightBorder.Top }}</ansi>
+<ansi fg="black-bold">{{ $leftBorder.Top }}</ansi><ansi fg="black-bold">  .:</ansi><ansi fg="20">{{ printf ( printf "%%-%ds" ( sub $mapWidth 4 ) ) ( printf "%s (%d%%)" .Title .ZoneCompletePct ) }}</ansi><ansi fg="black-bold">{{ $rightBorder.Top }}</ansi>
 <ansi fg="black-bold">{{ index $leftBorder.Mid 0 }}{{ padRightX "" $midBorder.Top $mapWidth }}{{ index $rightBorder.Mid 0 }}</ansi>
 {{ range $index, $line := .DisplayLines }}
 {{- $mod := mod $index 2 -}}

--- a/_datafiles/world/default/users/1.yaml
+++ b/_datafiles/world/default/users/1.yaml
@@ -17,9 +17,9 @@ character:
     other adventurers, granting them strength, wisdom, or fortune beyond their wildest
     dreams. Conversely, he can also mete out justice to those who would seek to disrupt
     the balance of the world, swiftly and decisively.
-  roomid: 487
+  roomid: 1
   roomidonreset: 0
-  zone: Frostfang Slums
+  zone: Frostfang
   raceid: 2
   stats:
     strength:
@@ -64,15 +64,15 @@ character:
     list:
     - buffid: 28
       permabuff: true
-      roundcounter: 22
+      roundcounter: 9
       triggersleft: 1000000000
     - buffid: 29
       permabuff: true
-      roundcounter: 15
+      roundcounter: 32
       triggersleft: 1000000000
     - buffid: 39
       permabuff: true
-      roundcounter: 4
+      roundcounter: 6
       triggersleft: 1000000000
   equipment:
     weapon:
@@ -147,6 +147,23 @@ character:
     - itemid: 30002
       uses: 1
   created: 2024-10-31T13:28:45.391415-07:00
+  zonesvisited:
+    Frostfang:
+      "0": "0xFFFFFFFEFFFFFFFE"
+      "1": "0x00000000000017FF"
+      "2": "0x000000C000000000"
+      "4": "0x0002EFFFFFDFFFFC"
+      "6": "0x0003000000000000"
+      "9": "0x0000000800000000"
+      "10": "0x0000000000000004"
+      "11": "0x0000000018000000"
+      "12": "0x2DFFFFF8FFBFFF00"
+      "13": "0x0000800000000000"
+      "15": "0x00000C0000000000"
+    Frostfang Slums:
+      "6": "0x0080000000000000"
+    Whispering Wastes:
+      "2": "0x00000F0000000000"
 itemstorage:
   items:
   - itemid: 20011

--- a/_datafiles/world/empty/keywords.yaml
+++ b/_datafiles/world/empty/keywords.yaml
@@ -68,6 +68,7 @@ help:
       - races
       - who
       - history
+      - visited
     items:
       - drop
       - drink
@@ -125,6 +126,7 @@ help:
       - buff
       - build
       - command
+      - copyover
       - deafen
       - item
       - grant
@@ -145,6 +147,7 @@ help:
       - syslogs
       - zap
       - zone
+      - visit
 # Aliases for keywords when typing: help <keyword>
 # Key is the target keyword, value is the list of aliases
 help-aliases:

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -88,6 +88,7 @@ type Character struct {
 	Pet              pets.Pet                       `yaml:"pet,omitempty"`           // Do they have a pet?
 	Created          time.Time                      `yaml:"created"`                 // When this character was created
 	Timers           map[string]gametime.RoundTimer `yaml:"timers,omitempty"`        // any special timers added to this character
+	ZonesVisited     map[string]RoomBitset          `yaml:"zonesvisited,omitempty"`  // permanent record of every room visited, keyed by zone name
 	roomHistory      []int                          // A stack FILO of the last X rooms the character has been in
 	PlayerDamage     map[int]int                    `yaml:"-"` // key = who, value = how much
 	LastPlayerDamage uint64                         `yaml:"-"` // last round a player damaged this character
@@ -982,6 +983,70 @@ func (c *Character) RememberRoom(roomId int) {
 		c.roomHistory = c.roomHistory[len(c.roomHistory)-(mapHistory-1):]
 	}
 	c.roomHistory = append(c.roomHistory, roomId)
+}
+
+// MarkVisitedRoom permanently records that this character has visited roomId
+// in the given zone. Safe to call every time a player enters a room.
+// Returns true only if this specific call completed the zone (i.e. every room
+// in validRoomIds is now visited). Returns false if the room was already
+// visited, if validRoomIds is empty, or if the zone is still incomplete.
+func (c *Character) MarkVisitedRoom(roomId int, zone string, validRoomIds map[int]struct{}) bool {
+	if c.ZonesVisited == nil {
+		c.ZonesVisited = make(map[string]RoomBitset)
+	}
+	if _, ok := c.ZonesVisited[zone]; !ok {
+		c.ZonesVisited[zone] = make(RoomBitset)
+	}
+
+	// If the bit was already set this call cannot be the completing visit.
+	if c.ZonesVisited[zone].Has(roomId) {
+		return false
+	}
+
+	c.ZonesVisited[zone].Set(roomId)
+
+	if len(validRoomIds) == 0 {
+		return false
+	}
+
+	return c.ZonesVisited[zone].IsComplete(validRoomIds)
+}
+
+// HasVisitedRoom reports whether this character has ever visited roomId in zone.
+func (c *Character) HasVisitedRoom(roomId int, zone string) bool {
+	if c.ZonesVisited == nil {
+		return false
+	}
+	bs, ok := c.ZonesVisited[zone]
+	if !ok {
+		return false
+	}
+	return bs.Has(roomId)
+}
+
+// ZoneVisitProgress returns how many rooms the character has visited in zone
+// and the total number of rooms in that zone, allowing callers to compute a
+// completion percentage. validRoomIds should come from ZoneConfig.RoomIds.
+func (c *Character) ZoneVisitProgress(zone string, validRoomIds map[int]struct{}) (visited int, total int) {
+	total = len(validRoomIds)
+	if c.ZonesVisited == nil {
+		return 0, total
+	}
+	bs, ok := c.ZonesVisited[zone]
+	if !ok {
+		return 0, total
+	}
+	return bs.CountIn(validRoomIds), total
+}
+
+// ZoneVisitPercent returns the percentage (0–100) of rooms in zone that the
+// character has visited. Returns 0 when the zone has no rooms.
+func (c *Character) ZoneVisitPercent(zone string, validRoomIds map[int]struct{}) int {
+	visited, total := c.ZoneVisitProgress(zone, validRoomIds)
+	if total == 0 {
+		return 0
+	}
+	return int(float64(visited) / float64(total) * 100)
 }
 
 func (c *Character) IsQuestDone(questToken string) bool {

--- a/internal/characters/context.md
+++ b/internal/characters/context.md
@@ -12,6 +12,13 @@ The `internal/characters` package is the core character system for GoMud, handli
 - **Experience and leveling**: Level progression and TNL (To Next Level) calculations
 - **Persistence**: Character data serialization/deserialization
 
+### Room Visit Tracking (`roombitset.go`)
+- **RoomBitset**: Chunked bitset type (`map[uint16]uint64`) for memory-efficient permanent room visit tracking
+- **Block-based storage**: Each map key is `roomId/64`; each value is a `uint64` bitmask covering that 64-room window
+- **Zone-sharded on Character**: `ZonesVisited map[string]RoomBitset` persisted to YAML under `zonesvisited`
+- **Human-readable serialization**: Blocks serialize as hex strings (e.g. `"0x000000000000003F"`) for debuggable save files
+- **Pruning**: `RoomBitset.Prune(validRoomIds)` clears bits for deleted rooms and removes empty blocks
+
 ### Character Statistics System
 - **Six core stats**: Strength, Speed, Smarts, Vitality, Mysticism, Perception
 - **Stat scaling**: Stats over 100 use `SQRT(overage)*2` formula for diminishing returns
@@ -46,7 +53,8 @@ The `internal/characters` package is the core character system for GoMud, handli
 - YAML-based character data storage
 - Automatic saving with configurable intervals
 - Character creation timestamps and history tracking
-- Room history for movement tracking
+- Short-term room history for map rendering (`roomHistory`, capped by memory capacity)
+- Permanent room visit tracking via `ZonesVisited` (chunked bitset, persisted to YAML)
 
 ### Dynamic Stat System
 - Base stats from race definitions
@@ -91,6 +99,8 @@ The `internal/characters` package is the core character system for GoMud, handli
 - Equipment management through worn item slots
 - State management through adjectives and flags
 - Combat integration through aggro and damage tracking
+- Room visit tracking via `MarkVisitedRoom(roomId, zone)` and queried with `HasVisitedRoom(roomId, zone)`
+- Zone exploration progress via `ZoneVisitProgress(zone, validRoomIds)` returning `(visited, total int)`
 
 ## Testing
 Comprehensive test coverage in `*_test.go` files covering:
@@ -101,5 +111,8 @@ Comprehensive test coverage in `*_test.go` files covering:
 - Shop mechanics and restocking
 - Kill/death tracking
 - Cooldown management
+- `RoomBitset` set/has/count/prune operations
+- `RoomBitset` YAML round-trip serialization
+- `MarkVisitedRoom`, `HasVisitedRoom`, and `ZoneVisitProgress` integration
 
 This package serves as the foundation for all character-related functionality in GoMud, providing a rich and flexible character model that supports both player and NPC needs.

--- a/internal/characters/roombitset.go
+++ b/internal/characters/roombitset.go
@@ -1,0 +1,149 @@
+package characters
+
+import (
+	"fmt"
+	"math/bits"
+	"strconv"
+
+	"gopkg.in/yaml.v2"
+)
+
+// RoomBitset is a memory-efficient set of visited room IDs using a chunked
+// bitset. The map key is roomId/64 (the block index) and the value is a uint64
+// where bit (roomId%64) represents that room. Blocks are only allocated for
+// room ID ranges that have been visited, so sparse zones cost nothing for
+// unvisited regions.
+//
+// YAML serialization uses hex strings ("0x...") so the data is human-readable
+// in character save files.
+type RoomBitset map[uint16]uint64
+
+// Set marks a room as visited. Room IDs must be positive; non-positive IDs
+// are silently ignored because they represent special sentinel values (e.g.
+// -1 for the character-creation room, 0 for StartRoomIdAlias) that are
+// always considered visited.
+func (rb RoomBitset) Set(roomId int) {
+	if roomId < 1 {
+		return
+	}
+	block := uint16(roomId / 64)
+	bit := uint64(1) << (roomId % 64)
+	rb[block] |= bit
+}
+
+// Has reports whether a room has been visited. Non-positive room IDs always
+// return true because they are sentinel values that are considered visited
+// by definition.
+func (rb RoomBitset) Has(roomId int) bool {
+	if roomId < 1 {
+		return true
+	}
+	block := uint16(roomId / 64)
+	bit := uint64(1) << (roomId % 64)
+	return rb[block]&bit != 0
+}
+
+// Count returns the total number of visited rooms across all blocks.
+func (rb RoomBitset) Count() int {
+	total := 0
+	for _, word := range rb {
+		total += bits.OnesCount64(word)
+	}
+	return total
+}
+
+// CountIn returns how many rooms from the provided set have been visited.
+func (rb RoomBitset) CountIn(roomIds map[int]struct{}) int {
+	count := 0
+	for roomId := range roomIds {
+		if rb.Has(roomId) {
+			count++
+		}
+	}
+	return count
+}
+
+// IsComplete reports whether every room in the provided set has been visited.
+func (rb RoomBitset) IsComplete(roomIds map[int]struct{}) bool {
+	return rb.CountIn(roomIds) == len(roomIds)
+}
+
+// Prune clears any bits that do not correspond to a live room in validRoomIds,
+// then removes blocks that become empty. This handles the case where rooms are
+// deleted from a zone after a player has already visited them.
+func (rb RoomBitset) Prune(validRoomIds map[int]struct{}) {
+	// Build a valid-bits mask per block from the live room set.
+	validMasks := make(map[uint16]uint64, len(validRoomIds)/32+1)
+	for roomId := range validRoomIds {
+		block := uint16(roomId / 64)
+		bit := uint64(1) << (roomId % 64)
+		validMasks[block] |= bit
+	}
+
+	for block, word := range rb {
+		masked := word & validMasks[block]
+		if masked == 0 {
+			delete(rb, block)
+		} else {
+			rb[block] = masked
+		}
+	}
+}
+
+// ToSet expands the bitset into a map[int]struct{} of all visited room IDs.
+func (rb RoomBitset) ToSet() map[int]struct{} {
+	out := make(map[int]struct{}, rb.Count())
+	for block, word := range rb {
+		base := int(block) * 64
+		for bit := 0; bit < 64; bit++ {
+			if word&(uint64(1)<<bit) != 0 {
+				out[base+bit] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+// MarshalYAML serialises the bitset as a map of block-index to hex string so
+// that character save files remain human-readable.
+//
+// Example output:
+//
+//	0: "0x0000000000000003"
+//	9: "0xFFFFFFFFFFFFFFFF"
+func (rb RoomBitset) MarshalYAML() (interface{}, error) {
+	out := make(map[string]string, len(rb))
+	for block, word := range rb {
+		out[strconv.Itoa(int(block))] = fmt.Sprintf("0x%016X", word)
+	}
+	return out, nil
+}
+
+// UnmarshalYAML deserialises the hex-string map produced by MarshalYAML.
+func (rb *RoomBitset) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	raw := make(map[string]string)
+	if err := unmarshal(&raw); err != nil {
+		// Tolerate an empty / null node.
+		*rb = make(RoomBitset)
+		return nil
+	}
+
+	result := make(RoomBitset, len(raw))
+	for blockStr, hexStr := range raw {
+		block, err := strconv.ParseUint(blockStr, 10, 16)
+		if err != nil {
+			return fmt.Errorf("roombitset: invalid block key %q: %w", blockStr, err)
+		}
+		word, err := strconv.ParseUint(hexStr, 0, 64)
+		if err != nil {
+			return fmt.Errorf("roombitset: invalid word value %q: %w", hexStr, err)
+		}
+		result[uint16(block)] = word
+	}
+	*rb = result
+	return nil
+}
+
+// Ensure RoomBitset satisfies the yaml interfaces at compile time.
+var _ yaml.Marshaler = RoomBitset{}
+var _ yaml.Unmarshaler = (*RoomBitset)(nil)

--- a/internal/characters/roombitset_test.go
+++ b/internal/characters/roombitset_test.go
@@ -1,0 +1,303 @@
+package characters
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestRoomBitset_SetAndHas(t *testing.T) {
+	rb := make(RoomBitset)
+
+	// Non-positive IDs are sentinel values and are always considered visited.
+	assert.True(t, rb.Has(0))
+	assert.True(t, rb.Has(-1))
+	assert.False(t, rb.Has(63))
+	assert.False(t, rb.Has(64))
+	assert.False(t, rb.Has(512))
+
+	rb.Set(0)  // sentinel — must be ignored (no-op)
+	rb.Set(-1) // sentinel — must be ignored (no-op)
+	rb.Set(63)
+	rb.Set(64)
+	rb.Set(512)
+
+	assert.True(t, rb.Has(0))  // true — sentinel
+	assert.True(t, rb.Has(-1)) // true — sentinel
+	assert.True(t, rb.Has(63))
+	assert.True(t, rb.Has(64))
+	assert.True(t, rb.Has(512))
+
+	// Neighbours should remain unset.
+	assert.False(t, rb.Has(1))
+	assert.False(t, rb.Has(62))
+	assert.False(t, rb.Has(65))
+	assert.False(t, rb.Has(511))
+	assert.False(t, rb.Has(513))
+}
+
+func TestRoomBitset_Count(t *testing.T) {
+	rb := make(RoomBitset)
+	assert.Equal(t, 0, rb.Count())
+
+	rb.Set(1)
+	rb.Set(64)
+	rb.Set(128)
+	assert.Equal(t, 3, rb.Count())
+
+	// Setting the same room twice should not change the count.
+	rb.Set(1)
+	assert.Equal(t, 3, rb.Count())
+}
+
+func TestRoomBitset_CountIn(t *testing.T) {
+	rb := make(RoomBitset)
+	rb.Set(1)
+	rb.Set(2)
+	rb.Set(300)
+
+	valid := map[int]struct{}{
+		1:   {},
+		2:   {},
+		3:   {},
+		300: {},
+	}
+
+	assert.Equal(t, 3, rb.CountIn(valid))
+}
+
+func TestRoomBitset_IsComplete(t *testing.T) {
+	rb := make(RoomBitset)
+
+	zone := map[int]struct{}{
+		10: {},
+		11: {},
+		12: {},
+	}
+
+	assert.False(t, rb.IsComplete(zone))
+
+	rb.Set(10)
+	rb.Set(11)
+	assert.False(t, rb.IsComplete(zone))
+
+	rb.Set(12)
+	assert.True(t, rb.IsComplete(zone))
+}
+
+func TestRoomBitset_Prune(t *testing.T) {
+	rb := make(RoomBitset)
+	rb.Set(10)
+	rb.Set(11)
+	rb.Set(500) // will be pruned — not in valid set
+
+	valid := map[int]struct{}{
+		10: {},
+		11: {},
+	}
+
+	rb.Prune(valid)
+
+	assert.True(t, rb.Has(10))
+	assert.True(t, rb.Has(11))
+	assert.False(t, rb.Has(500))
+	assert.Equal(t, 2, rb.Count())
+}
+
+func TestRoomBitset_Prune_EmptyBlockRemoved(t *testing.T) {
+	rb := make(RoomBitset)
+	rb.Set(640) // block 10
+	rb.Set(641) // block 10
+
+	// Valid set contains no rooms in block 10.
+	valid := map[int]struct{}{
+		1: {},
+	}
+
+	rb.Prune(valid)
+
+	// Block 10 should be gone entirely.
+	_, exists := rb[10]
+	assert.False(t, exists)
+}
+
+func TestRoomBitset_YAMLRoundTrip(t *testing.T) {
+	original := make(RoomBitset)
+	original.Set(1)
+	original.Set(63)
+	original.Set(64)
+	original.Set(300)
+	original.Set(878)
+
+	data, err := yaml.Marshal(original)
+	require.NoError(t, err)
+
+	// Verify the output is human-readable hex, not a binary blob.
+	assert.Contains(t, string(data), "0x")
+
+	var restored RoomBitset
+	err = yaml.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	assert.True(t, restored.Has(1))
+	assert.True(t, restored.Has(63))
+	assert.True(t, restored.Has(64))
+	assert.True(t, restored.Has(300))
+	assert.True(t, restored.Has(878))
+	assert.False(t, restored.Has(2))
+	assert.False(t, restored.Has(65))
+	assert.Equal(t, original.Count(), restored.Count())
+}
+
+func TestRoomBitset_UnmarshalYAML_EmptyNode(t *testing.T) {
+	var rb RoomBitset
+	err := yaml.Unmarshal([]byte("null\n"), &rb)
+	require.NoError(t, err)
+	// A null node decodes to an empty map, which is valid and usable.
+	assert.Equal(t, 0, rb.Count())
+}
+
+func TestMarkVisitedRoom_ZoneCompletion(t *testing.T) {
+	c := New()
+
+	zone := map[int]struct{}{
+		1: {},
+		2: {},
+		3: {},
+	}
+
+	// Non-completing visits return false.
+	assert.False(t, c.MarkVisitedRoom(1, "testzone", zone))
+	assert.False(t, c.MarkVisitedRoom(2, "testzone", zone))
+
+	// Visiting an already-visited room is never the completing visit.
+	assert.False(t, c.MarkVisitedRoom(1, "testzone", zone))
+
+	// The last unvisited room completes the zone.
+	assert.True(t, c.MarkVisitedRoom(3, "testzone", zone))
+
+	// Revisiting after completion still returns false.
+	assert.False(t, c.MarkVisitedRoom(3, "testzone", zone))
+
+	// Nil validRoomIds never signals completion.
+	c2 := New()
+	assert.False(t, c2.MarkVisitedRoom(1, "testzone", nil))
+}
+
+func TestRoomBitset_CharacterIntegration(t *testing.T) {
+	c := New()
+
+	assert.False(t, c.HasVisitedRoom(1, "frostfang"))
+
+	c.MarkVisitedRoom(1, "frostfang", nil)
+	c.MarkVisitedRoom(64, "frostfang", nil)
+	c.MarkVisitedRoom(300, "dark_forest", nil)
+
+	assert.True(t, c.HasVisitedRoom(1, "frostfang"))
+	assert.True(t, c.HasVisitedRoom(64, "frostfang"))
+	assert.False(t, c.HasVisitedRoom(2, "frostfang"))
+	assert.True(t, c.HasVisitedRoom(300, "dark_forest"))
+	assert.False(t, c.HasVisitedRoom(1, "dark_forest"))
+}
+
+func TestRoomBitset_ZoneVisitProgress(t *testing.T) {
+	c := New()
+
+	zone := map[int]struct{}{
+		1: {},
+		2: {},
+		3: {},
+		4: {},
+	}
+
+	visited, total := c.ZoneVisitProgress("frostfang", zone)
+	assert.Equal(t, 0, visited)
+	assert.Equal(t, 4, total)
+
+	c.MarkVisitedRoom(1, "frostfang", nil)
+	c.MarkVisitedRoom(3, "frostfang", nil)
+
+	visited, total = c.ZoneVisitProgress("frostfang", zone)
+	assert.Equal(t, 2, visited)
+	assert.Equal(t, 4, total)
+}
+
+func TestCharacter_ZoneVisitPercent(t *testing.T) {
+	tests := []struct {
+		name         string
+		visitedRooms []int
+		zone         map[int]struct{}
+		want         int
+	}{
+		{
+			name:         "none visited",
+			visitedRooms: []int{},
+			zone:         map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}},
+			want:         0,
+		},
+		{
+			name:         "half visited",
+			visitedRooms: []int{1, 2},
+			zone:         map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}},
+			want:         50,
+		},
+		{
+			name:         "all visited",
+			visitedRooms: []int{1, 2, 3, 4},
+			zone:         map[int]struct{}{1: {}, 2: {}, 3: {}, 4: {}},
+			want:         100,
+		},
+		{
+			name:         "empty zone",
+			visitedRooms: []int{},
+			zone:         map[int]struct{}{},
+			want:         0,
+		},
+		{
+			name:         "one of three visited",
+			visitedRooms: []int{1},
+			zone:         map[int]struct{}{1: {}, 2: {}, 3: {}},
+			want:         33,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New()
+			for _, roomId := range tt.visitedRooms {
+				c.MarkVisitedRoom(roomId, "testzone", nil)
+			}
+			got := c.ZoneVisitPercent("testzone", tt.zone)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRoomBitset_CharacterYAMLRoundTrip(t *testing.T) {
+	c := New()
+	c.Name = "Tester"
+	c.MarkVisitedRoom(1, "frostfang", nil)
+	c.MarkVisitedRoom(300, "dark_forest", nil)
+
+	data, err := yaml.Marshal(c)
+	require.NoError(t, err)
+
+	// The zonesvisited key must appear in the output.
+	assert.Contains(t, string(data), "zonesvisited")
+
+	var c2 Character
+	err = yaml.Unmarshal(data, &c2)
+	require.NoError(t, err)
+
+	assert.True(t, c2.HasVisitedRoom(1, "frostfang"))
+	assert.True(t, c2.HasVisitedRoom(300, "dark_forest"))
+	assert.False(t, c2.HasVisitedRoom(2, "frostfang"))
+
+	// Verify no extra bytes were introduced (idempotent marshal).
+	data2, err := yaml.Marshal(&c2)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(data, data2))
+}

--- a/internal/mapper/mapper.config.go
+++ b/internal/mapper/mapper.config.go
@@ -6,6 +6,7 @@ type Config struct {
 	Height          int                    // Height of final map render
 	UserId          int                    // Optional userId to intelligently render some data
 	symbolOverrides map[int]SymbolOverride // Force symbols/legends for a specific room
+	visitedRooms    map[int]struct{}       // If set, only visited rooms are rendered
 }
 
 type SymbolOverride struct {
@@ -19,4 +20,16 @@ func (c *Config) OverrideSymbol(roomId int, symbol rune, legend string) {
 	}
 
 	c.symbolOverrides[roomId] = SymbolOverride{symbol, legend}
+}
+
+func (c *Config) SetVisitedRooms(visitedRooms map[int]struct{}) {
+	c.visitedRooms = visitedRooms
+}
+
+func (c *Config) HasVisited(roomId int) bool {
+	if c.visitedRooms == nil {
+		return true
+	}
+	_, ok := c.visitedRooms[roomId]
+	return ok
 }

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -560,6 +560,10 @@ func (r *mapper) GetLimitedMap(centerRoomId int, c Config) mapRender {
 			continue
 		}
 
+		if !c.HasVisited(node.RoomId) {
+			continue
+		}
+
 		symbol = node.Symbol
 		legend = node.Legend
 
@@ -616,7 +620,8 @@ func (r *mapper) GetLimitedMap(centerRoomId int, c Config) mapRender {
 				}
 
 				if c.UserId >= 0 {
-					if !targetRoom.HasVisited(c.UserId, rooms.VisitorUser) {
+					user := users.GetByUserId(c.UserId)
+					if user == nil || !user.Character.HasVisitedRoom(exitInfo.RoomId, targetRoom.Zone) {
 						continue
 					}
 				}

--- a/internal/rooms/roomdetails.go
+++ b/internal/rooms/roomdetails.go
@@ -305,10 +305,10 @@ func GetDetails(r *Room, user *users.UserRecord, tinymap ...[]string) RoomTempla
 
 	for exitStr, exitInfo := range r.Exits {
 
-		// If it's a secret room we need to make sure the player has recently been there before including it in the exits
+		// If it's a secret room we need to make sure the player has been there before including it in the exits
 		if exitInfo.Secret {
 			if targetRm := LoadRoom(exitInfo.RoomId); targetRm != nil {
-				if targetRm.HasVisited(user.UserId, VisitorUser) {
+				if user.Character.HasVisitedRoom(exitInfo.RoomId, targetRm.Zone) {
 					details.VisibleExits[exitStr] = exitInfo
 				}
 			}

--- a/internal/rooms/roommanager.go
+++ b/internal/rooms/roommanager.go
@@ -363,6 +363,11 @@ func MoveToRoom(userId int, toRoomId int, isSpawn ...bool) error {
 	user.Character.RoomId = newRoom.RoomId
 	user.Character.Zone = newRoom.Zone
 	user.Character.RememberRoom(newRoom.RoomId) // Mark this room as remembered.
+	if zCfg := GetZoneConfig(newRoom.Zone); zCfg != nil {
+		user.Character.MarkVisitedRoom(newRoom.RoomId, newRoom.Zone, zCfg.RoomIds) // Permanently record the visit.
+	} else {
+		user.Character.MarkVisitedRoom(newRoom.RoomId, newRoom.Zone, nil) // Permanently record the visit.
+	}
 
 	playerCt := newRoom.AddPlayer(userId)
 	roomManager.roomsWithUsers[newRoom.RoomId] = playerCt

--- a/internal/scripting/actor_func.go
+++ b/internal/scripting/actor_func.go
@@ -381,6 +381,47 @@ func (a ScriptActor) AddEventLog(category string, message string) {
 	}
 }
 
+// MarkVisitedRoom marks one or more rooms as visited for this actor.
+// Only applies to user actors; mobs do not track room visits.
+// Each roomId argument is recorded under the zone that room belongs to.
+func (a ScriptActor) MarkVisitedRoom(roomIds ...int) {
+	if a.userRecord == nil {
+		return
+	}
+	for _, roomId := range roomIds {
+		room := rooms.LoadRoom(roomId)
+		if room == nil {
+			continue
+		}
+		zCfg := rooms.GetZoneConfig(room.Zone)
+		var validRoomIds map[int]struct{}
+		if zCfg != nil {
+			validRoomIds = zCfg.RoomIds
+		}
+		a.characterRecord.MarkVisitedRoom(roomId, room.Zone, validRoomIds)
+	}
+}
+
+// MarkVisitedZone marks every room in the named zone as visited for this actor.
+// Only applies to user actors; mobs do not track room visits.
+// Uses FindZoneName for partial/best-match zone name resolution.
+func (a ScriptActor) MarkVisitedZone(zoneName string) {
+	if a.userRecord == nil {
+		return
+	}
+	resolvedZone := rooms.FindZoneName(zoneName)
+	if resolvedZone == `` {
+		return
+	}
+	zCfg := rooms.GetZoneConfig(resolvedZone)
+	if zCfg == nil {
+		return
+	}
+	for roomId := range zCfg.RoomIds {
+		a.characterRecord.MarkVisitedRoom(roomId, resolvedZone, nil)
+	}
+}
+
 func (a ScriptActor) GiveItem(itm any) {
 
 	var sItem *ScriptItem

--- a/internal/scripting/party_func.go
+++ b/internal/scripting/party_func.go
@@ -238,3 +238,15 @@ func (p ScriptParty) TimerSet(name string, period string) {
 		a.TimerSet(name, period)
 	})
 }
+
+func (p ScriptParty) MarkVisitedRoom(roomIds ...int) {
+	p.each(func(a ScriptActor) {
+		a.MarkVisitedRoom(roomIds...)
+	})
+}
+
+func (p ScriptParty) MarkVisitedZone(zoneName string) {
+	p.each(func(a ScriptActor) {
+		a.MarkVisitedZone(zoneName)
+	})
+}

--- a/internal/usercommands/admin.visit.go
+++ b/internal/usercommands/admin.visit.go
@@ -1,0 +1,182 @@
+package usercommands
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/templates"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+/*
+* Role Permissions:
+* visit 				(All)
+ */
+func Visit(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+
+	args := util.SplitButRespectQuotes(rest)
+
+	if len(args) == 0 {
+		infoOutput, _ := templates.Process("admincommands/help/command.visit", nil, user.UserId)
+		user.SendText(infoOutput)
+		return true, nil
+	}
+
+	subCmd := strings.ToLower(args[0])
+	args = args[1:]
+
+	switch subCmd {
+	case "list":
+		return visit_List(args, user)
+	case "set":
+		return visit_SetUnset(args, user, true)
+	case "unset":
+		return visit_SetUnset(args, user, false)
+	default:
+		infoOutput, _ := templates.Process("admincommands/help/command.visit", nil, user.UserId)
+		user.SendText(infoOutput)
+	}
+
+	return true, nil
+}
+
+func visit_resolveTarget(args []string, invoker *users.UserRecord) (*users.UserRecord, bool, error) {
+	if len(args) == 0 {
+		return invoker, false, nil
+	}
+
+	username := args[0]
+
+	if online := users.GetByCharacterName(username); online != nil {
+		return online, false, nil
+	}
+
+	return nil, false, fmt.Errorf(`user "%s" not found`, username)
+}
+
+func visit_List(args []string, user *users.UserRecord) (bool, error) {
+
+	targetUser, isOffline, err := visit_resolveTarget(args, user)
+	if err != nil {
+		user.SendText(err.Error())
+		return true, nil
+	}
+
+	allZoneNames := rooms.GetAllZoneNames()
+	sort.Strings(allZoneNames)
+
+	headers := []string{"Zone", "Visited", "Unvisited", "% Complete"}
+	rows := [][]string{}
+
+	for _, zoneName := range allZoneNames {
+		zCfg := rooms.GetZoneConfig(zoneName)
+		if zCfg == nil {
+			continue
+		}
+
+		visited, total := targetUser.Character.ZoneVisitProgress(zoneName, zCfg.RoomIds)
+		unvisited := total - visited
+
+		pct := 0
+		if total > 0 {
+			pct = (visited * 100) / total
+		}
+
+		rows = append(rows, []string{
+			zoneName,
+			fmt.Sprintf(`%d`, visited),
+			fmt.Sprintf(`%d`, unvisited),
+			fmt.Sprintf(`%d%%`, pct),
+		})
+	}
+
+	title := fmt.Sprintf(`Visit Progress for %s`, targetUser.Character.Name)
+	if isOffline {
+		title += ` (offline)`
+	}
+
+	tableData := templates.GetTable(title, headers, rows)
+	tplTxt, _ := templates.Process("tables/generic", tableData, user.UserId)
+	user.SendText(tplTxt)
+
+	return true, nil
+}
+
+func visit_SetUnset(args []string, user *users.UserRecord, markVisited bool) (bool, error) {
+
+	if len(args) == 0 {
+		infoOutput, _ := templates.Process("admincommands/help/command.visit", nil, user.UserId)
+		user.SendText(infoOutput)
+		return true, nil
+	}
+
+	zonePart := args[0]
+	userArgs := args[1:]
+
+	targetUser, isOffline, err := visit_resolveTarget(userArgs, user)
+	if err != nil {
+		user.SendText(err.Error())
+		return true, nil
+	}
+
+	action := "marked visited"
+	if !markVisited {
+		action = "reset to unvisited"
+	}
+
+	if strings.ToLower(zonePart) == "all" {
+		allZoneNames := rooms.GetAllZoneNames()
+		for _, zoneName := range allZoneNames {
+			visit_applyZone(targetUser, zoneName, markVisited)
+		}
+
+		if isOffline {
+			users.SaveUser(*targetUser)
+		}
+
+		user.SendText(fmt.Sprintf(`All zones %s for <ansi fg="username">%s</ansi>.`, action, targetUser.Character.Name))
+		return true, nil
+	}
+
+	allZoneNames := rooms.GetAllZoneNames()
+	exactZone, closeZone := util.FindMatchIn(zonePart, allZoneNames...)
+	resolvedZone := exactZone
+	if resolvedZone == `` {
+		resolvedZone = closeZone
+	}
+	if resolvedZone == `` {
+		user.SendText(fmt.Sprintf(`Zone "%s" not found.`, zonePart))
+		return true, nil
+	}
+
+	visit_applyZone(targetUser, resolvedZone, markVisited)
+
+	if isOffline {
+		users.SaveUser(*targetUser)
+	}
+
+	user.SendText(fmt.Sprintf(`Zone <ansi fg="yellow">%s</ansi> %s for <ansi fg="username">%s</ansi>.`, resolvedZone, action, targetUser.Character.Name))
+
+	return true, nil
+}
+
+func visit_applyZone(targetUser *users.UserRecord, zoneName string, markVisited bool) {
+	zCfg := rooms.GetZoneConfig(zoneName)
+	if zCfg == nil {
+		return
+	}
+
+	if markVisited {
+		for roomId := range zCfg.RoomIds {
+			targetUser.Character.MarkVisitedRoom(roomId, zoneName, nil)
+		}
+	} else {
+		if targetUser.Character.ZonesVisited != nil {
+			delete(targetUser.Character.ZonesVisited, zoneName)
+		}
+	}
+}

--- a/internal/usercommands/skill.map.go
+++ b/internal/usercommands/skill.map.go
@@ -143,6 +143,17 @@ func Map(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		}
 	}
 
+	if skillLevel <= 4 {
+		visited := make(map[int]struct{})
+		for _, bs := range user.Character.ZonesVisited {
+			for roomId := range bs.ToSet() {
+				visited[roomId] = struct{}{}
+			}
+		}
+		visited[user.Character.RoomId] = struct{}{}
+		c.SetVisitedRooms(visited)
+	}
+
 	if p := parties.Get(user.UserId); p != nil {
 		for _, uid := range p.GetMembers() {
 			if tmpUser := users.GetByUserId(uid); tmpUser != nil {
@@ -182,13 +193,19 @@ func Map(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		}
 	}
 
+	zoneCompletePct := 0
+	if zCfg := rooms.GetZoneConfig(zone); zCfg != nil {
+		zoneCompletePct = user.Character.ZoneVisitPercent(zone, zCfg.RoomIds)
+	}
+
 	mapData := map[string]any{
-		"Title":        room.Zone,
-		"DisplayLines": displayLines,
-		"Height":       len(displayLines),
-		"Width":        width,
-		"Legend":       legend,
-		"LegendWidth":  width,
+		"Title":           room.Zone,
+		"ZoneCompletePct": zoneCompletePct,
+		"DisplayLines":    displayLines,
+		"Height":          len(displayLines),
+		"Width":           width,
+		"Legend":          legend,
+		"LegendWidth":     width,
 		"LeftBorder": map[string]any{
 			"Top":    ".-=~=-.",
 			"Mid":    []string{"( _ __)", "(__  _)"},

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -166,6 +166,8 @@ var (
 		`dual-wield`:  {DualWield, true, false},
 		`whisper`:     {Whisper, true, false},
 		`who`:         {Who, true, false},
+		`visit`:       {Visit, true, true}, // Admin only
+		`visited`:     {Visited, true, false},
 		`zap`:         {Zap, true, true},   // Admin only
 		`zone`:        {Zone, false, true}, // Admin only
 		// Special command only used upon creating a new account

--- a/internal/usercommands/visited.go
+++ b/internal/usercommands/visited.go
@@ -1,0 +1,67 @@
+package usercommands
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/templates"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+func Visited(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+
+	type ZoneRecord struct {
+		Name       string
+		Completion string
+		BarFull    string
+		BarEmpty   string
+	}
+
+	type VisitedInfo struct {
+		ZonesTotal   int
+		ZonesVisited int
+		Records      []ZoneRecord
+	}
+
+	allZoneNames := rooms.GetAllZoneNames()
+	sort.Strings(allZoneNames)
+
+	records := []ZoneRecord{}
+
+	for _, zoneName := range allZoneNames {
+		zCfg := rooms.GetZoneConfig(zoneName)
+		if zCfg == nil {
+			continue
+		}
+
+		visited, total := user.Character.ZoneVisitProgress(zoneName, zCfg.RoomIds)
+		if visited == 0 {
+			continue
+		}
+
+		pct := int(math.Floor(float64(visited) / float64(total) * 100))
+		barFull, barEmpty := util.ProgressBar(float64(visited)/float64(total), 35)
+
+		records = append(records, ZoneRecord{
+			Name:       zoneName,
+			Completion: fmt.Sprintf(`%d%%`, pct),
+			BarFull:    barFull,
+			BarEmpty:   barEmpty,
+		})
+	}
+
+	info := VisitedInfo{
+		ZonesTotal:   len(allZoneNames),
+		ZonesVisited: len(records),
+		Records:      records,
+	}
+
+	tplTxt, _ := templates.Process("character/visited", info, user.UserId)
+	user.SendText(tplTxt)
+
+	return true, nil
+}

--- a/internal/users/context.md
+++ b/internal/users/context.md
@@ -472,10 +472,13 @@ type OnlineInfo struct {
 ### Character System Integration
 ```go
 // Users have associated characters
-- user.Character                    // Full character data
-- user.Character.Name              // Character name
-- user.Character.Level             // Character progression
-- user.Character.RoomId            // Current location
+- user.Character                                          // Full character data
+- user.Character.Name                                    // Character name
+- user.Character.Level                                   // Character progression
+- user.Character.RoomId                                  // Current location
+- user.Character.HasVisitedRoom(roomId, zone)            // Permanent room visit check
+- user.Character.MarkVisitedRoom(roomId, zone)           // Record a room visit
+- user.Character.ZoneVisitProgress(zone, validRoomIds)   // Visited/total count for a zone
 ```
 
 ### Connection System Integration

--- a/modules/gmcp/gmcp.Room.go
+++ b/modules/gmcp/gmcp.Room.go
@@ -373,7 +373,7 @@ func (g *GMCPRoomModule) GetRoomNode(user *users.UserRecord, gmcpModule string) 
 
 			if exitInfo.Secret {
 				if exitRoom := rooms.LoadRoom(exitInfo.RoomId); exitRoom != nil {
-					if !exitRoom.HasVisited(user.UserId, rooms.VisitorUser) {
+					if !user.Character.HasVisitedRoom(exitInfo.RoomId, exitRoom.Zone) {
 						continue
 					}
 				}


### PR DESCRIPTION
# Description

This adds tracking of all rooms in all zones for users. The exception is negative number rooms (should only be special case anyways) which will always be considered "visited".

This also adds an admin command `visit` to toggle zones as visited for users, and `visited`, a user command to see what they have visited.

Issue: https://github.com/GoMudEngine/GoMud/issues/215

## Changes

- Rooms visited tracked via a sharded bitset
- `visit` admin command
- `visited` user command
- `map` command now only shows rooms that have been visited
- `map` command shows % of the current zone that has been explored.
- New scripting functions for Actors and Parties: `MarkVisitedZone()` and `MarkVisitedRoom()`

## Examples

<img width="720" height="128" alt="image" src="https://github.com/user-attachments/assets/0e77aa3d-b7b0-4f62-9fe3-1e57580d0c87" />

<img width="720" height="517" alt="image" src="https://github.com/user-attachments/assets/9cce570a-56d1-423a-a00e-262f8a09b5e2" />

<img width="361" height="320" alt="image" src="https://github.com/user-attachments/assets/dc947d15-d796-43fb-a230-19a3906eefbe" />

