### PR TITLE
Fix: CI Discord notification workflow

### DIFF
--- a/.github/actions/discord-webhook/action.yml
+++ b/.github/actions/discord-webhook/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: tsickert/discord-webhook@v7.1.0
+    - uses: tsickert/discord-webhook@v7.0.0
       with:
         webhook-url: ${{ inputs.webhook-url }}
         embed-title: ${{ inputs.pr-title }}

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -16,12 +16,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Resolve Discord webhook URL
         id: webhook
-        env:
-          REPO_DISCORD_WEBHOOK_URL: ${{ vars.DISCORD_WEBHOOK_URL }}
         run: |
           webhook_url='${{ secrets.DISCORD_WEBHOOK_URL }}'
           if [ -z "$webhook_url" ]; then
-            webhook_url="${DISCORD_WEBHOOK_URL:-${REPO_DISCORD_WEBHOOK_URL:-}}"
+            webhook_url="${DISCORD_WEBHOOK_URL:-}"
           fi
           echo "url=$webhook_url" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,6 +1,7 @@
+---
 name: Notify Discord
 
-on:
+"on":
   pull_request:
     types:
       - opened
@@ -10,33 +11,31 @@ permissions:
 
 jobs:
   notify-discord:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Get PR Metadata
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6
-        id: pr_meta
-        with:
-          script: |
-            core.setOutput('title', context.payload.pull_request.title || '')
-            core.setOutput('body', context.payload.pull_request.body || '')
-            core.setOutput('url', context.payload.pull_request.html_url || '')
+      - name: Resolve Discord webhook URL
+        id: webhook
+        env:
+          REPO_DISCORD_WEBHOOK_URL: ${{ vars.DISCORD_WEBHOOK_URL }}
+        run: |
+          webhook_url='${{ secrets.DISCORD_WEBHOOK_URL }}'
+          if [ -z "$webhook_url" ]; then
+            webhook_url="${DISCORD_WEBHOOK_URL:-${REPO_DISCORD_WEBHOOK_URL:-}}"
+          fi
+          echo "url=$webhook_url" >> "$GITHUB_OUTPUT"
 
-      - name: Get Release Metadata
-        if: github.event_name == 'release'
-        uses: actions/github-script@v6
-        id: release_meta
-        with:
-          script: |
-            core.setOutput('title', context.payload.release.name || context.payload.release.tag_name || '')
-            core.setOutput('body', context.payload.release.body || '')
-            core.setOutput('url', context.payload.release.html_url || '')
+      - name: Skip when webhook is not configured
+        if: ${{ steps.webhook.outputs.url == '' }}
+        run: >
+          echo "DISCORD_WEBHOOK_URL is not configured;
+          skipping Discord notification."
 
       - name: Send Discord Message
+        if: ${{ steps.webhook.outputs.url != '' }}
         uses: ./.github/actions/discord-webhook
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          pr-title: ${{ steps.pr_meta.outputs.title }}${{ steps.release_meta.outputs.title }}
-          pr-body: ${{ steps.pr_meta.outputs.body }}${{ steps.release_meta.outputs.body }}
-          pr-url: ${{ steps.pr_meta.outputs.url }}${{ steps.release_meta.outputs.url }}
+          webhook-url: ${{ steps.webhook.outputs.url }}
+          pr-title: ${{ github.event.pull_request.title }}
+          pr-body: ${{ github.event.pull_request.body }}
+          pr-url: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

- Fix the Discord notification workflow for PR-open events.
- Resolve `DISCORD_WEBHOOK_URL` from `secrets.DISCORD_WEBHOOK_URL` first
  - Fall back only to a true injected `DISCORD_WEBHOOK_URL` environment variable if present.
- Skip cleanly when no webhook is configured instead of failing (for forks of this project).

## What Broke

- The composite action referenced `tsickert/discord-webhook@v7.1.0`, which is not a published tag.
- That caused the workflow to fail before it could send any Discord message.
- The workflow also needed a safe fallback path for environments that inject `DISCORD_WEBHOOK_URL` directly, while avoiding less secure non-secret repository variables.

## Motivation

- Restore the intended PR notification behavior without expanding the workflow scope.
- Make the workflow tolerate missing webhook configuration and exit successfully when Discord notifications are not set up.
- Support the intended secret-or-env configuration model while keeping secrets preferred and avoiding a GitHub `vars` fallback for a sensitive webhook URL.
- Remove dead complexity from the workflow so the notification path is easier to understand and maintain.

## Validation

- `actionlint .github/workflows/discord-notify.yml`
- `yamllint .github/workflows/discord-notify.yml .github/actions/discord-webhook/action.yml`
- `act` run with a secret-backed webhook
- `act` run with an env-backed webhook
- `act` run with no webhook configured
