### PR TITLE
[CI] Fix: webclient JavaScript lint

### DIFF
--- a/_datafiles/html/public/static/js/triggers.js
+++ b/_datafiles/html/public/static/js/triggers.js
@@ -1,4 +1,4 @@
-
+/* jshint evil: true */
 const Triggers = (() => {
 
     const STORAGE_KEY = 'triggers';

--- a/_datafiles/html/public/static/js/webclient-core.js
+++ b/_datafiles/html/public/static/js/webclient-core.js
@@ -1,4 +1,4 @@
-/* global MP3Player, WinBox */
+/* global MP3Player, Triggers, WinBox */
 
 /**
  * webclient-core.js
@@ -1767,7 +1767,7 @@ const Client = (() => {
     }
 
     function GetGMCP(path) {
-        return getByPath(Client.GMCPStructs, path)
+        return getByPath(Client.GMCPStructs, path);
     }
 
     // -----------------------------------------------------------------------

--- a/_datafiles/html/public/static/js/windows/window-debug-log.js
+++ b/_datafiles/html/public/static/js/windows/window-debug-log.js
@@ -1,3 +1,4 @@
+/* global Client, VirtualWindow, VirtualWindows, injectStyles */
 /**
  * window-debug-log.js
  *

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -1,4 +1,4 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
+/* global Client, ResizeObserver, VirtualWindow, VirtualWindows, injectStyles */
 
 /**
  * window-map.js


### PR DESCRIPTION
# Description

## Why
- Fixes the upstream `lint` failure from GoMudEngine/GoMud run `24554839212`, job `71788680015`.
- The failing build reported 9 JSHint errors in the webclient browser modules.
- The failures are lint-only issues, not behavior changes.

## Changes
- Allow intentional `Function` constructor use in `triggers.js`.
- Declare browser globals used by modular webclient files.
- Add the missing semicolon in `webclient-core.js`.

## Validation
- `make js-lint`
- `make validate`
- `make test`
