### PR TITLE
[CI] Automate binary builds and prerelease publishing

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -5,6 +5,14 @@
 This downstream fork is the proving ground for release automation changes before they
 are proposed upstream.
 
+Recommended versioning for the next release line:
+
+- Start the next stable release at `v0.10.0`.
+- Use normal stable tags as `v0.10.x`.
+- Use SemVer prerelease tags for downstream validation, not ad hoc `-test` tags.
+- Prefer `v0.10.x-pre.YYYYMMDDHHMMSS` for disposable downstream runs.
+- Prefer `v0.10.x-rc.N` for a release candidate you may want to share or promote.
+
 ### 1. New Feature or Breaking‑Change Release (Minor/Major)
 
 1. **Merge & Verify**
@@ -18,17 +26,17 @@ are proposed upstream.
 
 3. **Create Git Tag**
    ```bash
-   git tag vX.Y.Z
-   git push origin vX.Y.Z
+   git tag v0.10.0
+   git push origin v0.10.0
    ```
    This triggers the `Release` workflow.
 
 4. **Monitor Release**
    - GitHub Actions will:
      - Run `go generate ./...`
-     - Build artifacts with `main.version=vX.Y.Z`
-     - Zip as `go-mud-release-vX.Y.Z.zip`
-     - Publish a GitHub prerelease for `vX.Y.Z`
+     - Build artifacts with `main.version=v0.10.0`
+     - Zip as `go-mud-release-v0.10.0.zip`
+     - Publish a GitHub prerelease for `v0.10.0`
      - Leave the release unmarked as `Latest`
 
 5. **Announce**
@@ -45,9 +53,9 @@ are proposed upstream.
 
 2. **Determine Patch Bump**
    ```bash
-   # if current version is vX.Y.Z:
-   git tag vX.Y.(Z+1)
-   git push origin vX.Y.(Z+1)
+   # for example, after v0.10.0:
+   git tag v0.10.1
+   git push origin v0.10.1
    ```
 
 3. **Tag & Push**
@@ -65,10 +73,16 @@ are proposed upstream.
    - Use this downstream repo to verify any release automation change before opening
      an upstream PR.
 
-2. **Push a disposable test tag**
+2. **Push a disposable prerelease tag**
    ```bash
-   git tag vX.Y.Z-test.1
-   git push origin vX.Y.Z-test.1
+   git tag v0.10.0-pre.20260417014024
+   git push origin v0.10.0-pre.20260417014024
+   ```
+
+   Or, for a numbered candidate:
+   ```bash
+   git tag v0.10.0-rc.1
+   git push origin v0.10.0-rc.1
    ```
 
 3. **Verify the GitHub release**
@@ -94,6 +108,11 @@ are proposed upstream.
 - **Are workflow-created releases stable releases?**
   No - the workflow creates prereleases. A repo owner must manually promote a release
   to `Latest` in GitHub when it is approved.
+
+- **What tag format should we use going forward?**
+  Start the next release line at `v0.10.x`. Use `v0.10.x` for stable releases,
+  `v0.10.x-pre.YYYYMMDDHHMMSS` for disposable downstream validation, and
+  `v0.10.x-rc.N` for numbered release candidates.
 
 - **When should I bump minor vs. patch?**
   - **Minor** for new, backward‑compatible features.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -26,6 +26,10 @@ Recommended versioning for the next release line:
 3. **Merge to `master`**
    - Merging to `master` triggers the `Release` workflow automatically.
 
+   Or, for a manual downstream test without merging:
+   - Run the `Release` workflow with `workflow_dispatch`.
+   - Optionally provide a short `release_label` such as `test`.
+
 4. **Monitor Release**
    - GitHub Actions will:
      - Run `go generate ./...`
@@ -51,9 +55,14 @@ Recommended versioning for the next release line:
 2. **Merges to `master` do publish release binaries**
    - A push to `master` runs the `Release` workflow and publishes a prerelease.
 
-3. **Generated release naming**
+3. **Manual test runs can also publish prereleases**
+   - `workflow_dispatch` can be used to create a test prerelease without merging.
+   - An optional `release_label` is appended to the generated prerelease tag.
+
+4. **Generated release naming**
    - The release tag is generated automatically from UTC time plus the merge commit SHA.
    - Example: `pre-20260417021530-1a2b3c4`
+   - With a manual label: `pre-20260417021530-1a2b3c4-test`
 
 ---
 
@@ -63,9 +72,10 @@ Recommended versioning for the next release line:
    - Use this downstream repo to verify any release automation change before opening
      an upstream PR.
 
-2. **Merge a test branch to downstream `master`**
-   - Use a downstream-only branch or temporary merge to trigger the release workflow.
-   - The workflow will generate its own prerelease tag automatically.
+2. **Run the release workflow manually**
+   - Use `workflow_dispatch` on the downstream repo when you want a test release
+     without merging to `master`.
+   - Optionally set `release_label=test` or similar to make the generated tag clearer.
 
 3. **Verify the GitHub release**
    - Confirm the workflow succeeds.
@@ -89,6 +99,10 @@ Recommended versioning for the next release line:
 - **Is auto-tagging enabled?**
   Stable semver tags are not generated automatically. The merge-driven workflow creates
   its own prerelease tag from UTC time plus commit SHA.
+
+- **Can I create a test release without merging to `master`?**
+  Yes - run the `Release` workflow manually with `workflow_dispatch`. That keeps PR
+  submissions clean while still allowing downstream test releases on demand.
 
 - **Are workflow-created releases stable releases?**
   No - the workflow creates prereleases. A repo owner must manually promote a release

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -2,6 +2,9 @@
 
 [Semantic Versioning 2.0.0 reference](https://github.com/semver/semver/blob/master/semver.md)
 
+This downstream fork is the proving ground for release automation changes before they
+are proposed upstream.
+
 ### 1. New Feature or Breaking‑Change Release (Minor/Major)
 
 1. **Merge & Verify**
@@ -25,9 +28,12 @@
      - Run `go generate ./...`
      - Build artifacts with `main.version=vX.Y.Z`
      - Zip as `go-mud-release-vX.Y.Z.zip`
-     - Publish the GitHub Release for `vX.Y.Z`
+     - Publish a GitHub prerelease for `vX.Y.Z`
+     - Leave the release unmarked as `Latest`
 
 5. **Announce**
+   - After review, the upstream owner can edit the release in GitHub and promote it
+     to `Latest`.
    - Share the release link with the team or via configured notifications.
 
 ---
@@ -48,7 +54,32 @@
    - Pushing the tag triggers the same release workflow.
 
 4. **Publish**
-   - The workflow publishes the release automatically after the build completes.
+   - The workflow publishes the release automatically as a prerelease after the build
+     completes.
+
+---
+
+### 3. Downstream First-Test Flow
+
+1. **Validate in this fork first**
+   - Use this downstream repo to verify any release automation change before opening
+     an upstream PR.
+
+2. **Push a disposable test tag**
+   ```bash
+   git tag vX.Y.Z-test.1
+   git push origin vX.Y.Z-test.1
+   ```
+
+3. **Verify the GitHub release**
+   - Confirm the workflow succeeds.
+   - Confirm the zip asset is attached.
+   - Confirm GitHub marks the release as a prerelease.
+   - Confirm GitHub does not mark it as `Latest`.
+
+4. **Clean up if needed**
+   - Delete the test tag and release after validation if you do not want to keep them
+     in downstream history.
 
 ---
 
@@ -59,6 +90,10 @@
 
 - **Is auto-tagging enabled?**
   No - releases are manual. Create and push the version tag yourself when you want to publish.
+
+- **Are workflow-created releases stable releases?**
+  No - the workflow creates prereleases. A repo owner must manually promote a release
+  to `Latest` in GitHub when it is approved.
 
 - **When should I bump minor vs. patch?**
   - **Minor** for new, backward‑compatible features.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -8,10 +8,9 @@ are proposed upstream.
 Recommended versioning for the next release line:
 
 - Start the next stable release at `v0.10.0`.
-- Use normal stable tags as `v0.10.x`.
-- Use SemVer prerelease tags for downstream validation, not ad hoc `-test` tags.
-- Prefer `v0.10.x-pre.YYYYMMDDHHMMSS` for disposable downstream runs.
-- Prefer `v0.10.x-rc.N` for a release candidate you may want to share or promote.
+- Keep the binary's embedded version in source as a normal semver such as `0.10.0`.
+- Let merge-driven prereleases use generated tags like `pre-YYYYMMDDHHMMSS-<sha7>`.
+- Reserve manual semver tags like `v0.10.x` for a future stable-release process if needed.
 
 ### 1. New Feature or Breaking‑Change Release (Minor/Major)
 
@@ -24,20 +23,17 @@ Recommended versioning for the next release line:
 - **Minor** (`0.Y.0`) when you add functionality in a backward compatible manner
 - **Patch** (`0.0.Z`) when you make backward compatible bug fixes
 
-3. **Create Git Tag**
-   ```bash
-   git tag v0.10.0
-   git push origin v0.10.0
-   ```
-   This triggers the `Release` workflow.
+3. **Merge to `master`**
+   - Merging to `master` triggers the `Release` workflow automatically.
 
 4. **Monitor Release**
    - GitHub Actions will:
      - Run `go generate ./...`
-     - Build per-platform binaries with `main.version=v0.10.0`
-     - Archive `_datafiles` as `go-mud-datafiles-v0.10.0.zip`
-     - Generate `go-mud-v0.10.0-SHA256SUMS.txt`
-     - Publish a GitHub prerelease for `v0.10.0`
+     - Build per-platform binaries with `main.version` set from `main.go`
+     - Create a generated prerelease tag like `pre-YYYYMMDDHHMMSS-<sha7>`
+     - Archive `_datafiles` as `go-mud-datafiles-pre-YYYYMMDDHHMMSS-<sha7>.zip`
+     - Generate `go-mud-pre-YYYYMMDDHHMMSS-<sha7>-SHA256SUMS.txt`
+     - Publish a GitHub prerelease for that generated tag
      - Leave the release unmarked as `Latest`
 
 5. **Announce**
@@ -47,24 +43,17 @@ Recommended versioning for the next release line:
 
 ---
 
-### 2. Basic Patch Release (x.y.Z)
+### 2. Merge-Driven Prerelease Policy
 
-1. **Merge Bug‑Fix PR**
-   - Once the fix is in `master` and CI is green.
+1. **Pull requests do not publish release binaries**
+   - PRs should run normal CI only.
 
-2. **Determine Patch Bump**
-   ```bash
-   # for example, after v0.10.0:
-   git tag v0.10.1
-   git push origin v0.10.1
-   ```
+2. **Merges to `master` do publish release binaries**
+   - A push to `master` runs the `Release` workflow and publishes a prerelease.
 
-3. **Tag & Push**
-   - Pushing the tag triggers the same release workflow.
-
-4. **Publish**
-   - The workflow publishes the release automatically as a prerelease after the build
-     completes.
+3. **Generated release naming**
+   - The release tag is generated automatically from UTC time plus the merge commit SHA.
+   - Example: `pre-20260417021530-1a2b3c4`
 
 ---
 
@@ -74,17 +63,9 @@ Recommended versioning for the next release line:
    - Use this downstream repo to verify any release automation change before opening
      an upstream PR.
 
-2. **Push a disposable prerelease tag**
-   ```bash
-   git tag v0.10.0-pre.20260417014024
-   git push origin v0.10.0-pre.20260417014024
-   ```
-
-   Or, for a numbered candidate:
-   ```bash
-   git tag v0.10.0-rc.1
-   git push origin v0.10.0-rc.1
-   ```
+2. **Merge a test branch to downstream `master`**
+   - Use a downstream-only branch or temporary merge to trigger the release workflow.
+   - The workflow will generate its own prerelease tag automatically.
 
 3. **Verify the GitHub release**
    - Confirm the workflow succeeds.
@@ -103,10 +84,11 @@ Recommended versioning for the next release line:
 ### FAQ / Guidelines
 
 - **Does every merge to `master` trigger a release?**
-  No - only pushing a Git tag matching `v*.*.*` triggers a release.
+  Yes - every push to `master` runs the release workflow and publishes a prerelease.
 
 - **Is auto-tagging enabled?**
-  No - releases are manual. Create and push the version tag yourself when you want to publish.
+  Stable semver tags are not generated automatically. The merge-driven workflow creates
+  its own prerelease tag from UTC time plus commit SHA.
 
 - **Are workflow-created releases stable releases?**
   No - the workflow creates prereleases. A repo owner must manually promote a release
@@ -118,9 +100,8 @@ Recommended versioning for the next release line:
   verify the assets.
 
 - **What tag format should we use going forward?**
-  Start the next release line at `v0.10.x`. Use `v0.10.x` for stable releases,
-  `v0.10.x-pre.YYYYMMDDHHMMSS` for disposable downstream validation, and
-  `v0.10.x-rc.N` for numbered release candidates.
+  Keep the source/binary version on the `0.10.x` line. Let the workflow generate
+  prerelease tags like `pre-YYYYMMDDHHMMSS-<sha7>` on merges to `master`.
 
 - **When should I bump minor vs. patch?**
   - **Minor** for new, backward‑compatible features.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -34,9 +34,9 @@ Recommended versioning for the next release line:
 4. **Monitor Release**
    - GitHub Actions will:
      - Run `go generate ./...`
-     - Build artifacts with `main.version=v0.10.0`
-     - Zip as `go-mud-release-v0.10.0.zip`
-     - Generate `go-mud-release-v0.10.0.zip.sha256`
+     - Build per-platform binaries with `main.version=v0.10.0`
+     - Archive `_datafiles` as `go-mud-datafiles-v0.10.0.zip`
+     - Generate `go-mud-v0.10.0-SHA256SUMS.txt`
      - Publish a GitHub prerelease for `v0.10.0`
      - Leave the release unmarked as `Latest`
 
@@ -88,8 +88,9 @@ Recommended versioning for the next release line:
 
 3. **Verify the GitHub release**
    - Confirm the workflow succeeds.
-   - Confirm the zip asset is attached.
-   - Confirm the `.sha256` checksum asset is attached.
+   - Confirm the per-platform binaries are attached.
+   - Confirm the `_datafiles` zip asset is attached.
+   - Confirm the checksum manifest asset is attached.
    - Confirm GitHub marks the release as a prerelease.
    - Confirm GitHub does not mark it as `Latest`.
 
@@ -112,8 +113,9 @@ Recommended versioning for the next release line:
   to `Latest` in GitHub when it is approved.
 
 - **What assets should a release include?**
-  Each release should include the bundled zip and a matching `.sha256` checksum file
-  so testers can verify the download before unpacking it.
+  Each release should include separate per-platform binaries, a `_datafiles` zip,
+  and a checksum manifest so testers can download only what they need and still
+  verify the assets.
 
 - **What tag format should we use going forward?**
   Start the next release line at `v0.10.x`. Use `v0.10.x` for stable releases,

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -36,6 +36,7 @@ Recommended versioning for the next release line:
      - Run `go generate ./...`
      - Build artifacts with `main.version=v0.10.0`
      - Zip as `go-mud-release-v0.10.0.zip`
+     - Generate `go-mud-release-v0.10.0.zip.sha256`
      - Publish a GitHub prerelease for `v0.10.0`
      - Leave the release unmarked as `Latest`
 
@@ -88,6 +89,7 @@ Recommended versioning for the next release line:
 3. **Verify the GitHub release**
    - Confirm the workflow succeeds.
    - Confirm the zip asset is attached.
+   - Confirm the `.sha256` checksum asset is attached.
    - Confirm GitHub marks the release as a prerelease.
    - Confirm GitHub does not mark it as `Latest`.
 
@@ -108,6 +110,10 @@ Recommended versioning for the next release line:
 - **Are workflow-created releases stable releases?**
   No - the workflow creates prereleases. A repo owner must manually promote a release
   to `Latest` in GitHub when it is approved.
+
+- **What assets should a release include?**
+  Each release should include the bundled zip and a matching `.sha256` checksum file
+  so testers can verify the download before unpacking it.
 
 - **What tag format should we use going forward?**
   Start the next release line at `v0.10.x`. Use `v0.10.x` for stable releases,

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -2,9 +2,6 @@
 
 [Semantic Versioning 2.0.0 reference](https://github.com/semver/semver/blob/master/semver.md)
 
-This downstream fork is the proving ground for release automation changes before they
-are proposed upstream.
-
 Recommended versioning for the next release line:
 
 - Start the next stable release at `v0.10.0`.
@@ -15,22 +12,24 @@ Recommended versioning for the next release line:
 ### 1. New Feature or Breaking‑Change Release (Minor/Major)
 
 1. **Merge & Verify**
+
 - Merge all feature or breaking‑change PRs into `master`.
 - Ensure CI (tests, linter, codegen) all pass on `master`.
 
-2. **Determine Version Bump**
+1. **Determine Version Bump**
+
 - **Major** (`X.0.0`) when you make incompatible changes
 - **Minor** (`0.Y.0`) when you add functionality in a backward compatible manner
 - **Patch** (`0.0.Z`) when you make backward compatible bug fixes
 
-3. **Merge to `master`**
+1. **Merge to `master`**
    - Merging to `master` triggers the `Release` workflow automatically.
 
-   Or, for a manual downstream test without merging:
+   Or, for a manual test without merging:
    - Run the `Release` workflow with `workflow_dispatch`.
    - Optionally provide a short `release_label` such as `test`.
 
-4. **Monitor Release**
+2. **Monitor Release**
    - GitHub Actions will:
      - Run `go generate ./...`
      - Build per-platform binaries with `main.version` set from `main.go`
@@ -40,9 +39,9 @@ Recommended versioning for the next release line:
      - Publish a GitHub prerelease for that generated tag
      - Leave the release unmarked as `Latest`
 
-5. **Announce**
-   - After review, the upstream owner can edit the release in GitHub and promote it
-     to `Latest`.
+3. **Announce**
+   - After review, a repo owner can edit the release in GitHub and promote it to
+     `Latest`.
    - Share the release link with the team or via configured notifications.
 
 ---
@@ -66,18 +65,14 @@ Recommended versioning for the next release line:
 
 ---
 
-### 3. Downstream First-Test Flow
+### 3. Manual Test Release Flow
 
-1. **Validate in this fork first**
-   - Use this downstream repo to verify any release automation change before opening
-     an upstream PR.
-
-2. **Run the release workflow manually**
-   - Use `workflow_dispatch` on the downstream repo when you want a test release
+1. **Run the release workflow manually**
+   - Use `workflow_dispatch` when you want a test release
      without merging to `master`.
    - Optionally set `release_label=test` or similar to make the generated tag clearer.
 
-3. **Verify the GitHub release**
+2. **Verify the GitHub release**
    - Confirm the workflow succeeds.
    - Confirm the per-platform binaries are attached.
    - Confirm the `_datafiles` zip asset is attached.
@@ -85,9 +80,9 @@ Recommended versioning for the next release line:
    - Confirm GitHub marks the release as a prerelease.
    - Confirm GitHub does not mark it as `Latest`.
 
-4. **Clean up if needed**
+3. **Clean up if needed**
    - Delete the test tag and release after validation if you do not want to keep them
-     in downstream history.
+     in repository history.
 
 ---
 
@@ -102,7 +97,7 @@ Recommended versioning for the next release line:
 
 - **Can I create a test release without merging to `master`?**
   Yes - run the `Release` workflow manually with `workflow_dispatch`. That keeps PR
-  submissions clean while still allowing downstream test releases on demand.
+  submissions clean while still allowing on-demand test releases.
 
 - **Are workflow-created releases stable releases?**
   No - the workflow creates prereleases. A repo owner must manually promote a release

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Compute release metadata
         id: meta
+        env:
+          RELEASE_LABEL: ${{ inputs.release_label }}
         run: |
           binary_version="$(
             sed -n 's/^const VERSION = \"\\([^\"]*\\)\"$/\\1/p' main.go
@@ -45,8 +47,15 @@ jobs:
 
           release_stamp="$(date -u +%Y%m%d%H%M%S)"
           release_tag="pre-${release_stamp}-${GITHUB_SHA::7}"
-          if [ -n "${{ inputs.release_label }}" ]; then
-            release_tag="${release_tag}-${{ inputs.release_label }}"
+          release_label="${RELEASE_LABEL:-}"
+          if [ -n "$release_label" ]; then
+            case "$release_label" in
+              *[!A-Za-z0-9._-]*)
+                echo "release_label must match [A-Za-z0-9._-]+" >&2
+                exit 1
+                ;;
+            esac
+            release_tag="${release_tag}-${release_label}"
           fi
 
           {
@@ -162,6 +171,7 @@ jobs:
             bin/${{ env.CHECKSUMS_FILE }}
           name: ${{ env.RELEASE_TAG }}
           tag_name: ${{ env.RELEASE_TAG }}
+          target_commitish: ${{ github.sha }}
           prerelease: true
           make_latest: false
           generate_release_notes: true

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -159,22 +159,19 @@ jobs:
             > "${{ env.CHECKSUMS_FILE }}"
 
       - name: Release with notes
-        uses: softprops/action-gh-release@v3.0.0
-        with:
-          files: |
-            bin/gomud-windows_x64.exe
-            bin/gomud-darwin_arm64
-            bin/gomud-darwin_x64
-            bin/gomud-linux_x64
-            bin/gomud-linux_arm5
-            bin/${{ env.DATAFILES_ARCHIVE }}
-            bin/${{ env.CHECKSUMS_FILE }}
-          name: ${{ env.RELEASE_TAG }}
-          tag_name: ${{ env.RELEASE_TAG }}
-          target_commitish: ${{ github.sha }}
-          prerelease: true
-          make_latest: false
-          generate_release_notes: true
-          fail_on_unmatched_files: true
+        run: |
+          gh release create "$RELEASE_TAG" \
+            bin/gomud-windows_x64.exe \
+            bin/gomud-darwin_arm64 \
+            bin/gomud-darwin_x64 \
+            bin/gomud-linux_x64 \
+            bin/gomud-linux_arm5 \
+            "bin/$DATAFILES_ARCHIVE" \
+            "bin/$CHECKSUMS_FILE" \
+            --title "$RELEASE_TAG" \
+            --target "$GITHUB_SHA" \
+            --prerelease \
+            --latest=false \
+            --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -5,6 +5,12 @@ name: Release
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      release_label:
+        description: Optional prerelease label suffix, e.g. test or rc
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,6 +45,9 @@ jobs:
 
           release_stamp="$(date -u +%Y%m%d%H%M%S)"
           release_tag="pre-${release_stamp}-${GITHUB_SHA::7}"
+          if [ -n "${{ inputs.release_label }}" ]; then
+            release_tag="${release_tag}-${{ inputs.release_label }}"
+          fi
 
           {
             echo "binary_version=${binary_version}"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -94,7 +94,11 @@ jobs:
         uses: softprops/action-gh-release@v3.0.0
         with:
           files: bin/${{ env.RELEASE_FILENAME }}-${{ env.RELEASE_VERSION }}.zip
+          name: ${{ env.RELEASE_VERSION }} prerelease
           tag_name: ${{ env.RELEASE_VERSION }}
+          prerelease: true
+          make_latest: false
+          generate_release_notes: true
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -43,8 +43,8 @@ jobs:
           {
             echo "binary_version=${binary_version}"
             echo "release_tag=${release_tag}"
-            echo "datafiles_archive=go-mud-datafiles-${release_tag}.zip"
-            echo "checksums_file=go-mud-${release_tag}-SHA256SUMS.txt"
+            echo "datafiles_archive=gomud-all-datafiles-${release_tag}.zip"
+            echo "checksums_file=gomud-${release_tag}-SHA256SUMS.txt"
           } >> "$GITHUB_OUTPUT"
 
   build:
@@ -74,31 +74,31 @@ jobs:
         run: >-
           env GOOS=windows GOARCH=amd64 go build -v
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
-          -o bin/go-mud-windows_x64.exe .
+          -o bin/gomud-windows_x64.exe .
 
       - name: Build darwin/arm64
         run: >-
           env GOOS=darwin GOARCH=arm64 go build -v
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
-          -o bin/go-mud-darwin_arm64 .
+          -o bin/gomud-darwin_arm64 .
 
       - name: Build darwin/amd64
         run: >-
           env GOOS=darwin GOARCH=amd64 go build -v
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
-          -o bin/go-mud-darwin_x64 .
+          -o bin/gomud-darwin_x64 .
 
       - name: Build linux/amd64
         run: >-
           env GOOS=linux GOARCH=amd64 go build -v
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
-          -o bin/go-mud-linux_x64 .
+          -o bin/gomud-linux_x64 .
 
       - name: Build linux/arm5
         run: >-
           env GOOS=linux GOARCH=arm GOARM=5 go build -v
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
-          -o bin/go-mud-linux_arm5 .
+          -o bin/gomud-linux_arm5 .
 
       - name: Upload bin
         uses: actions/upload-artifact@v4
@@ -132,11 +132,11 @@ jobs:
         run: |
           cd bin
           sha256sum \
-            go-mud-windows_x64.exe \
-            go-mud-darwin_arm64 \
-            go-mud-darwin_x64 \
-            go-mud-linux_x64 \
-            go-mud-linux_arm5 \
+            gomud-windows_x64.exe \
+            gomud-darwin_arm64 \
+            gomud-darwin_x64 \
+            gomud-linux_x64 \
+            gomud-linux_arm5 \
             "${{ env.DATAFILES_ARCHIVE }}" \
             > "${{ env.CHECKSUMS_FILE }}"
 
@@ -144,11 +144,11 @@ jobs:
         uses: softprops/action-gh-release@v3.0.0
         with:
           files: |
-            bin/go-mud-windows_x64.exe
-            bin/go-mud-darwin_arm64
-            bin/go-mud-darwin_x64
-            bin/go-mud-linux_x64
-            bin/go-mud-linux_arm5
+            bin/gomud-windows_x64.exe
+            bin/gomud-darwin_arm64
+            bin/gomud-darwin_x64
+            bin/gomud-linux_x64
+            bin/gomud-linux_arm5
             bin/${{ env.DATAFILES_ARCHIVE }}
             bin/${{ env.CHECKSUMS_FILE }}
           name: ${{ env.RELEASE_TAG }} prerelease

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,8 +3,8 @@ name: Release
 
 "on":
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,14 +13,45 @@ concurrency:
 permissions:
   contents: write
 
-env:
-  RELEASE_VERSION: ${{ github.ref_name }}
-  DATAFILES_ARCHIVE: go-mud-datafiles-${{ github.ref_name }}.zip
-  CHECKSUMS_FILE: go-mud-${{ github.ref_name }}-SHA256SUMS.txt
-
 jobs:
+  prep:
+    runs-on: ubuntu-24.04
+    outputs:
+      binary_version: ${{ steps.meta.outputs.binary_version }}
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      datafiles_archive: ${{ steps.meta.outputs.datafiles_archive }}
+      checksums_file: ${{ steps.meta.outputs.checksums_file }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Compute release metadata
+        id: meta
+        run: |
+          binary_version="$(
+            sed -n 's/^const VERSION = \"\\([^\"]*\\)\"$/\\1/p' main.go
+          )"
+          if [ -z "$binary_version" ]; then
+            echo "Could not determine binary version from main.go" >&2
+            exit 1
+          fi
+
+          release_stamp="$(date -u +%Y%m%d%H%M%S)"
+          release_tag="pre-${release_stamp}-${GITHUB_SHA::7}"
+
+          {
+            echo "binary_version=${binary_version}"
+            echo "release_tag=${release_tag}"
+            echo "datafiles_archive=go-mud-datafiles-${release_tag}.zip"
+            echo "checksums_file=go-mud-${release_tag}-SHA256SUMS.txt"
+          } >> "$GITHUB_OUTPUT"
+
   build:
     runs-on: ubuntu-24.04
+    needs: prep
+    env:
+      BINARY_VERSION: ${{ needs.prep.outputs.binary_version }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -42,31 +73,31 @@ jobs:
       - name: Build windows amd64
         run: >-
           env GOOS=windows GOARCH=amd64 go build -v
-          -ldflags "-X main.version=${{ env.RELEASE_VERSION }}"
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/go-mud-windows_x64.exe .
 
       - name: Build darwin/arm64
         run: >-
           env GOOS=darwin GOARCH=arm64 go build -v
-          -ldflags "-X main.version=${{ env.RELEASE_VERSION }}"
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/go-mud-darwin_arm64 .
 
       - name: Build darwin/amd64
         run: >-
           env GOOS=darwin GOARCH=amd64 go build -v
-          -ldflags "-X main.version=${{ env.RELEASE_VERSION }}"
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/go-mud-darwin_x64 .
 
       - name: Build linux/amd64
         run: >-
           env GOOS=linux GOARCH=amd64 go build -v
-          -ldflags "-X main.version=${{ env.RELEASE_VERSION }}"
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/go-mud-linux_x64 .
 
       - name: Build linux/arm5
         run: >-
           env GOOS=linux GOARCH=arm GOARM=5 go build -v
-          -ldflags "-X main.version=${{ env.RELEASE_VERSION }}"
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/go-mud-linux_arm5 .
 
       - name: Upload bin
@@ -77,7 +108,13 @@ jobs:
 
   release:
     runs-on: ubuntu-24.04
-    needs: build
+    needs:
+      - prep
+      - build
+    env:
+      RELEASE_TAG: ${{ needs.prep.outputs.release_tag }}
+      DATAFILES_ARCHIVE: ${{ needs.prep.outputs.datafiles_archive }}
+      CHECKSUMS_FILE: ${{ needs.prep.outputs.checksums_file }}
     steps:
       - name: Download builds
         uses: actions/download-artifact@v4
@@ -114,8 +151,8 @@ jobs:
             bin/go-mud-linux_arm5
             bin/${{ env.DATAFILES_ARCHIVE }}
             bin/${{ env.CHECKSUMS_FILE }}
-          name: ${{ env.RELEASE_VERSION }} prerelease
-          tag_name: ${{ env.RELEASE_VERSION }}
+          name: ${{ env.RELEASE_TAG }} prerelease
+          tag_name: ${{ env.RELEASE_TAG }}
           prerelease: true
           make_latest: false
           generate_release_notes: true

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -16,6 +16,7 @@ permissions:
 env:
   RELEASE_FILENAME: go-mud-release
   RELEASE_VERSION: ${{ github.ref_name }}
+  RELEASE_ARCHIVE: go-mud-release-${{ github.ref_name }}.zip
 
 jobs:
   build:
@@ -87,13 +88,22 @@ jobs:
       - name: Archive release
         run: >-
           zip -r
-          bin/${{ env.RELEASE_FILENAME }}-${{ env.RELEASE_VERSION }}.zip
+          bin/${{ env.RELEASE_ARCHIVE }}
           bin/
+
+      - name: Generate release checksum
+        run: >-
+          sha256sum
+          bin/${{ env.RELEASE_ARCHIVE }}
+          >
+          bin/${{ env.RELEASE_ARCHIVE }}.sha256
 
       - name: Release with notes
         uses: softprops/action-gh-release@v3.0.0
         with:
-          files: bin/${{ env.RELEASE_FILENAME }}-${{ env.RELEASE_VERSION }}.zip
+          files: |
+            bin/${{ env.RELEASE_ARCHIVE }}
+            bin/${{ env.RELEASE_ARCHIVE }}.sha256
           name: ${{ env.RELEASE_VERSION }} prerelease
           tag_name: ${{ env.RELEASE_VERSION }}
           prerelease: true

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -160,7 +160,7 @@ jobs:
             bin/gomud-linux_arm5
             bin/${{ env.DATAFILES_ARCHIVE }}
             bin/${{ env.CHECKSUMS_FILE }}
-          name: ${{ env.RELEASE_TAG }} prerelease
+          name: ${{ env.RELEASE_TAG }}
           tag_name: ${{ env.RELEASE_TAG }}
           prerelease: true
           make_latest: false

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,9 +14,9 @@ permissions:
   contents: write
 
 env:
-  RELEASE_FILENAME: go-mud-release
   RELEASE_VERSION: ${{ github.ref_name }}
-  RELEASE_ARCHIVE: go-mud-release-${{ github.ref_name }}.zip
+  DATAFILES_ARCHIVE: go-mud-datafiles-${{ github.ref_name }}.zip
+  CHECKSUMS_FILE: go-mud-${{ github.ref_name }}-SHA256SUMS.txt
 
 jobs:
   build:
@@ -85,25 +85,35 @@ jobs:
           name: bin-artifact
           path: bin/
 
-      - name: Archive release
+      - name: Archive datafiles
         run: >-
           zip -r
-          bin/${{ env.RELEASE_ARCHIVE }}
-          bin/
+          bin/${{ env.DATAFILES_ARCHIVE }}
+          bin/_datafiles
 
-      - name: Generate release checksum
-        run: >-
-          sha256sum
-          bin/${{ env.RELEASE_ARCHIVE }}
-          >
-          bin/${{ env.RELEASE_ARCHIVE }}.sha256
+      - name: Generate release checksums
+        run: |
+          cd bin
+          sha256sum \
+            go-mud-windows_x64.exe \
+            go-mud-darwin_arm64 \
+            go-mud-darwin_x64 \
+            go-mud-linux_x64 \
+            go-mud-linux_arm5 \
+            "${{ env.DATAFILES_ARCHIVE }}" \
+            > "${{ env.CHECKSUMS_FILE }}"
 
       - name: Release with notes
         uses: softprops/action-gh-release@v3.0.0
         with:
           files: |
-            bin/${{ env.RELEASE_ARCHIVE }}
-            bin/${{ env.RELEASE_ARCHIVE }}.sha256
+            bin/go-mud-windows_x64.exe
+            bin/go-mud-darwin_arm64
+            bin/go-mud-darwin_x64
+            bin/go-mud-linux_x64
+            bin/go-mud-linux_arm5
+            bin/${{ env.DATAFILES_ARCHIVE }}
+            bin/${{ env.CHECKSUMS_FILE }}
           name: ${{ env.RELEASE_VERSION }} prerelease
           tag_name: ${{ env.RELEASE_VERSION }}
           prerelease: true

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -52,7 +52,7 @@ jobs:
           {
             echo "binary_version=${binary_version}"
             echo "release_tag=${release_tag}"
-            echo "datafiles_archive=gomud-all-datafiles-${release_tag}.zip"
+            echo "datafiles_archive=gomud-ALL-datafiles-${release_tag}.zip"
             echo "checksums_file=gomud-${release_tag}-SHA256SUMS.txt"
           } >> "$GITHUB_OUTPUT"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode
-AGENTS.md
+bin/
 private-notes.txt
 _datafiles/**/users/*
 _datafiles/**/plugin-data/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+AGENTS.md
 private-notes.txt
 _datafiles/**/users/*
 _datafiles/**/plugin-data/*


### PR DESCRIPTION
## Summary

- publish release binaries only after changes land on `master`
- allow manual test releases through `workflow_dispatch`
- publish workflow-created releases as prereleases, never as `Latest`
- upload per-platform binaries, a `_datafiles` archive, and a checksum manifest
- document the downstream prerelease flow and ignore generated `bin/` output

## Example

<img width="954" height="925" alt="image" src="https://github.com/user-attachments/assets/49b81801-eecb-473e-baf2-23ac56050eda" />

## Why

- release binaries should not be produced during PR iteration
- downstream still needs a way to test the release path without merging to `master`
- separate assets are easier for end users than a single all-in-one bundle
- manual test releases need safe, predictable generated tags
- release publishing should avoid a third-party action in the write-token step

## Trigger Model

- PRs do not run the release workflow
- pushes to non-`master` branches do not run the release workflow
- pushes to `master` do run the release workflow
- `workflow_dispatch` can run the same release flow manually for downstream testing
- each release gets a generated prerelease tag using UTC time plus the commit SHA
- optional manual `release_label` values are validated as `[A-Za-z0-9._-]+`
- manually generated release tags are pinned to the dispatched commit SHA

## Implementation

- switch the release workflow trigger from tag pushes to pushes on `master`
- add `workflow_dispatch` with an optional safe `release_label` suffix
- compute generated prerelease metadata in a prep job
- keep the binary's embedded version tied to the semver in `main.go`
- publish releases with GitHub CLI `gh release create`
- keep releases marked as prereleases and not `Latest`
- use GitHub-generated release notes
- update `.github/RELEASING.md` for the new downstream prerelease process
- ignore generated `bin/` build output
- upload these assets:
  - `gomud-ALL-datafiles-<generated-tag>.zip`
  - `gomud-windows_x64.exe`
  - `gomud-darwin_arm64`
  - `gomud-darwin_x64`
  - `gomud-linux_x64`
  - `gomud-linux_arm5`
  - `gomud-<generated-tag>-SHA256SUMS.txt`

## Validation

- `actionlint .github/workflows/build-and-release.yml`
- `yamllint .github/workflows/build-and-release.yml`
- `make ci-local`
- `make js-lint`
- focused `bash` and `zsh` checks for the `release_label` validation pattern

## Stacking

- upstream-ready branch replays the downstream stacked release commits onto `upstream/master`


## Upstream Move

- moved from downstream draft PR: https://github.com/clabs-public-forks/GoMud/pull/12
- replayed only the release automation commits from `fix/windows-release-build..test/release-prerelease-automation` onto upstream `master`
- upstream Windows-build prerequisite is tracked separately in https://github.com/GoMudEngine/GoMud/pull/488
