### PR TITLE
[CI] Fix release version detection in build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -38,7 +38,7 @@ jobs:
           RELEASE_LABEL: ${{ inputs.release_label }}
         run: |
           binary_version="$(
-            sed -n 's/^const VERSION = \"\\([^\"]*\\)\"$/\\1/p' main.go
+            awk -F'"' '/^const VERSION = "/ { print $2; exit }' main.go
           )"
           if [ -z "$binary_version" ]; then
             echo "Could not determine binary version from main.go" >&2


### PR DESCRIPTION
## Summary
- replace the brittle `sed` capture in `build-and-release.yml` with a simpler `awk` parser for `main.go`
- keep `main.go` as the source of truth for the binary release version
- fix the `Compute release metadata` step in the Release workflow

## Root cause
- run `24581446599` failed in job `71880061944`
- the workflow used an over-escaped `sed` expression, so it did not match `const VERSION = "..."` in `main.go`
- that left `binary_version` empty and aborted the release before any build steps ran

## Validation
- confirmed the parser extracts `0.9.1` from `main.go`
- ran `make ci-local`
- verified the `build-and-release.yml` dry run now succeeds through `prep`, `build`, and `release`