### PR TITLE
[Tools] Add AI `AGENTS.md` support

### DIFF
--- a/.agents/code_review.md
+++ b/.agents/code_review.md
@@ -1,0 +1,27 @@
+# GoMud Code Review
+
+Use this checklist for `/review` and pre-PR local review.
+
+## Review Focus
+
+- Prioritize bugs, behavior regressions, missing tests, unsafe defaults, and user-visible breakage.
+- Lead with findings ordered by severity; include file and line references.
+- If there are no findings, say that clearly and list any checks not run.
+- Prefer concrete fixes over broad style advice.
+- When JavaScript files change, check whether the current lint rules and lint scope still match the intended review contract.
+
+## Verification Map
+
+- Go runtime or config changes: run `make validate`; add targeted `go test ./internal/<pkg>` or `make test` for broad/shared changes.
+- Frontend JavaScript changes: run `make js-lint`; use browser or Playwright checks for user-visible UI behavior.
+- `.github/` workflow changes: run `make ci-local` when practical.
+- Docs-only changes: skip full tests unless behavior or commands changed; use `make help` when command docs changed.
+- Shell script changes: run `shellcheck` and `shfmt` if available, plus the relevant Makefile target.
+
+## Repo Rules
+
+- Prefer Makefile targets over ad hoc commands.
+- Treat `make js-lint` as the JavaScript lint source of truth.
+- If JavaScript files changed, update the lint rules or lint scope when the code change makes the current policy incomplete or misleading.
+- Remember GitHub required check names are `lint` and `test`.
+- Update docs only when setup, usage, behavior, configuration, or developer workflow changed.

--- a/.agents/skills/gh-fix-ci/SKILL.md
+++ b/.agents/skills/gh-fix-ci/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: "gh-fix-ci"
+description: "Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions. Use GitHub PR metadata and patch context when available, and use `gh` for Actions check and log inspection before implementing any approved fix."
+---
+
+
+# GitHub Actions CI Fix
+
+## Overview
+
+Forked from: <https://github.com/openai/skills/tree/main/skills/.curated/gh-fix-ci>
+
+Use this skill when the task is specifically about failing GitHub Actions checks on a pull request. This workflow is hybrid by design:
+
+- Use GitHub PR metadata, changed files, and review context when available.
+- Use `gh` for GitHub Actions checks and logs because the connector does not expose that workflow end to end.
+- Summarize the root cause first, propose a focused fix plan, and implement only after explicit approval.
+
+Prereq: authenticate with GitHub CLI once, then confirm with `gh auth status`. Repo and workflow scopes are typically required for Actions inspection.
+
+## GoMud notes
+
+- Prefer upstream `GoMudEngine/GoMud` Actions history when the fork does not have useful runs.
+- If `gh auth status` reports invalid token state in this repo, try the host-shell `GITHUB_TOKEN` login path before falling back to unauthenticated inspection.
+- Use repo-native checks after a local fix: `make validate`, `make test`, `make js-lint`, or `make ci-local` depending on the touched files.
+- Required PR checks are expected to be named `lint` and `test`.
+- For workflow changes under `.github/`, use `make ci-local` when practical; it runs the local `act` validation path.
+
+## Inputs
+
+- `repo`: path inside the repo (default `.`)
+- `pr`: PR number or URL (optional; defaults to current branch PR)
+- `gh` authentication for the repo host
+
+## Quick start
+
+- `python "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --pr "<number-or-url>"`
+- Add `--json` if you want machine-friendly output for summarization.
+
+## Workflow
+
+1. Verify gh authentication.
+   - Run `gh auth status` in the repo.
+   - If unauthenticated, ask the user to run `gh auth login` (ensuring repo + workflow scopes) before proceeding.
+2. Resolve the PR.
+   - If the user provides a PR number or URL, use that directly.
+   - Otherwise prefer the current branch PR with `gh pr view --json number,url`.
+   - When repo and PR are known, fetch PR metadata and patch context through the GitHub app or `gh`.
+3. Inspect failing checks (GitHub Actions only).
+   - Preferred: run the bundled script (handles gh field drift and job-log fallbacks):
+     - `python "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --pr "<number-or-url>"`
+     - Add `--json` for machine-friendly output.
+   - Manual fallback:
+     - `gh pr checks <pr> --json name,state,bucket,link,startedAt,completedAt,workflow`
+       - If a field is rejected, rerun with the available fields reported by `gh`.
+     - For each failing check, extract the run id from `detailsUrl` and run:
+       - `gh run view <run_id> --json name,workflowName,conclusion,status,url,event,headBranch,headSha`
+       - `gh run view <run_id> --log`
+     - If the run log says it is still in progress, fetch job logs directly:
+       - `gh api "/repos/<owner>/<repo>/actions/jobs/<job_id>/logs" > "<path>"`
+4. Scope non-GitHub Actions checks.
+   - If `detailsUrl` is not a GitHub Actions run, label it as external and only report the URL.
+   - Do not attempt Buildkite or other providers; keep the workflow lean.
+5. Summarize failures for the user.
+   - Provide the failing check name, run URL (if any), and a concise log snippet.
+   - Call out missing logs explicitly and do not over-claim certainty.
+6. Propose a focused fix plan and wait for approval.
+   - Keep the plan tied directly to the failing checks and the observed root cause.
+7. Implement after approval.
+   - Apply the approved fix locally.
+   - Run the most relevant local verification available.
+8. Recheck status and summarize residual risk.
+   - Suggest re-running the relevant tests and `gh pr checks`.
+   - Report what is still unverified, what may still be flaky, and whether any failing checks were external and therefore not actionable here.
+
+## Bundled Resources
+
+### scripts/inspect_pr_checks.py
+
+Fetch failing PR checks, pull GitHub Actions logs, and extract a failure snippet. Exits non-zero when failures remain so it can be used in automation.
+
+Usage examples:
+- `python "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --pr "123"`
+- `python "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --pr "https://github.com/org/repo/pull/123" --json`
+- `python "<path-to-skill>/scripts/inspect_pr_checks.py" --repo "." --max-lines 200 --context 40`
+
+## Guardrails
+
+- Do not imply that the GitHub app can replace `gh` for Actions log retrieval.
+- Treat non-GitHub Actions providers as report-only unless the user explicitly wants a separate investigation path.
+- If the failure is clearly unrelated to the local diff, say so before proposing code changes.

--- a/.agents/skills/gh-fix-ci/agents/openai.yaml
+++ b/.agents/skills/gh-fix-ci/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CI Debug"
+  short_description: "Debug failing GitHub Actions checks"
+  default_prompt: "Use $gh-fix-ci to inspect the failing GitHub Actions checks on this PR, summarize the root cause, and propose the smallest viable fix."

--- a/.agents/skills/gh-fix-ci/scripts/inspect_pr_checks.py
+++ b/.agents/skills/gh-fix-ci/scripts/inspect_pr_checks.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from shutil import which
+from typing import Any, Iterable, Sequence
+
+FAILURE_CONCLUSIONS = {
+    "failure",
+    "cancelled",
+    "timed_out",
+    "action_required",
+}
+
+FAILURE_STATES = {
+    "failure",
+    "error",
+    "cancelled",
+    "timed_out",
+    "action_required",
+}
+
+FAILURE_BUCKETS = {"fail"}
+
+FAILURE_MARKERS = (
+    "error",
+    "fail",
+    "failed",
+    "traceback",
+    "exception",
+    "assert",
+    "panic",
+    "fatal",
+    "timeout",
+    "segmentation fault",
+)
+
+DEFAULT_MAX_LINES = 160
+DEFAULT_CONTEXT_LINES = 30
+PENDING_LOG_MARKERS = (
+    "still in progress",
+    "log will be available when it is complete",
+)
+
+
+class GhResult:
+    def __init__(self, returncode: int, stdout: str, stderr: str):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def run_gh_command(args: Sequence[str], cwd: Path) -> GhResult:
+    process = subprocess.run(
+        ["gh", *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+    )
+    return GhResult(process.returncode, process.stdout, process.stderr)
+
+
+def run_gh_command_raw(args: Sequence[str], cwd: Path) -> tuple[int, bytes, str]:
+    process = subprocess.run(
+        ["gh", *args],
+        cwd=cwd,
+        capture_output=True,
+    )
+    stderr = process.stderr.decode(errors="replace")
+    return process.returncode, process.stdout, stderr
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect failing GitHub PR checks, fetch GitHub Actions logs, and extract a "
+            "failure snippet."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--repo", default=".", help="Path inside the target Git repository.")
+    parser.add_argument(
+        "--pr", default=None, help="PR number or URL (defaults to current branch PR)."
+    )
+    parser.add_argument("--max-lines", type=int, default=DEFAULT_MAX_LINES)
+    parser.add_argument("--context", type=int, default=DEFAULT_CONTEXT_LINES)
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text output.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = find_git_root(Path(args.repo))
+    if repo_root is None:
+        print("Error: not inside a Git repository.", file=sys.stderr)
+        return 1
+
+    if not ensure_gh_available(repo_root):
+        return 1
+
+    pr_value = resolve_pr(args.pr, repo_root)
+    if pr_value is None:
+        return 1
+
+    checks = fetch_checks(pr_value, repo_root)
+    if checks is None:
+        return 1
+
+    failing = [c for c in checks if is_failing(c)]
+    if not failing:
+        print(f"PR #{pr_value}: no failing checks detected.")
+        return 0
+
+    results = []
+    for check in failing:
+        results.append(
+            analyze_check(
+                check,
+                repo_root=repo_root,
+                max_lines=max(1, args.max_lines),
+                context=max(1, args.context),
+            )
+        )
+
+    if args.json:
+        print(json.dumps({"pr": pr_value, "results": results}, indent=2))
+    else:
+        render_results(pr_value, results)
+
+    return 1
+
+
+def find_git_root(start: Path) -> Path | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=start,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def ensure_gh_available(repo_root: Path) -> bool:
+    if which("gh") is None:
+        print("Error: gh is not installed or not on PATH.", file=sys.stderr)
+        return False
+    result = run_gh_command(["auth", "status"], cwd=repo_root)
+    if result.returncode == 0:
+        return True
+    message = (result.stderr or result.stdout or "").strip()
+    print(message or "Error: gh not authenticated.", file=sys.stderr)
+    return False
+
+
+def resolve_pr(pr_value: str | None, repo_root: Path) -> str | None:
+    if pr_value:
+        return pr_value
+    result = run_gh_command(["pr", "view", "--json", "number"], cwd=repo_root)
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip()
+        print(message or "Error: unable to resolve PR.", file=sys.stderr)
+        return None
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        print("Error: unable to parse PR JSON.", file=sys.stderr)
+        return None
+    number = data.get("number")
+    if not number:
+        print("Error: no PR number found.", file=sys.stderr)
+        return None
+    return str(number)
+
+
+def fetch_checks(pr_value: str, repo_root: Path) -> list[dict[str, Any]] | None:
+    primary_fields = ["name", "state", "conclusion", "detailsUrl", "startedAt", "completedAt"]
+    result = run_gh_command(
+        ["pr", "checks", pr_value, "--json", ",".join(primary_fields)],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        message = "\n".join(filter(None, [result.stderr, result.stdout])).strip()
+        available_fields = parse_available_fields(message)
+        if available_fields:
+            fallback_fields = [
+                "name",
+                "state",
+                "bucket",
+                "link",
+                "startedAt",
+                "completedAt",
+                "workflow",
+            ]
+            selected_fields = [field for field in fallback_fields if field in available_fields]
+            if not selected_fields:
+                print("Error: no usable fields available for gh pr checks.", file=sys.stderr)
+                return None
+            result = run_gh_command(
+                ["pr", "checks", pr_value, "--json", ",".join(selected_fields)],
+                cwd=repo_root,
+            )
+            if result.returncode != 0:
+                message = (result.stderr or result.stdout or "").strip()
+                print(message or "Error: gh pr checks failed.", file=sys.stderr)
+                return None
+        else:
+            print(message or "Error: gh pr checks failed.", file=sys.stderr)
+            return None
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        print("Error: unable to parse checks JSON.", file=sys.stderr)
+        return None
+    if not isinstance(data, list):
+        print("Error: unexpected checks JSON shape.", file=sys.stderr)
+        return None
+    return data
+
+
+def is_failing(check: dict[str, Any]) -> bool:
+    conclusion = normalize_field(check.get("conclusion"))
+    if conclusion in FAILURE_CONCLUSIONS:
+        return True
+    state = normalize_field(check.get("state") or check.get("status"))
+    if state in FAILURE_STATES:
+        return True
+    bucket = normalize_field(check.get("bucket"))
+    return bucket in FAILURE_BUCKETS
+
+
+def analyze_check(
+    check: dict[str, Any],
+    repo_root: Path,
+    max_lines: int,
+    context: int,
+) -> dict[str, Any]:
+    url = check.get("detailsUrl") or check.get("link") or ""
+    run_id = extract_run_id(url)
+    job_id = extract_job_id(url)
+    base: dict[str, Any] = {
+        "name": check.get("name", ""),
+        "detailsUrl": url,
+        "runId": run_id,
+        "jobId": job_id,
+    }
+
+    if run_id is None:
+        base["status"] = "external"
+        base["note"] = "No GitHub Actions run id detected in detailsUrl."
+        return base
+
+    metadata = fetch_run_metadata(run_id, repo_root)
+    log_text, log_error, log_status = fetch_check_log(
+        run_id=run_id,
+        job_id=job_id,
+        repo_root=repo_root,
+    )
+
+    if log_status == "pending":
+        base["status"] = "log_pending"
+        base["note"] = log_error or "Logs are not available yet."
+        if metadata:
+            base["run"] = metadata
+        return base
+
+    if log_error:
+        base["status"] = "log_unavailable"
+        base["error"] = log_error
+        if metadata:
+            base["run"] = metadata
+        return base
+
+    snippet = extract_failure_snippet(log_text, max_lines=max_lines, context=context)
+    base["status"] = "ok"
+    base["run"] = metadata or {}
+    base["logSnippet"] = snippet
+    base["logTail"] = tail_lines(log_text, max_lines)
+    return base
+
+
+def extract_run_id(url: str) -> str | None:
+    if not url:
+        return None
+    for pattern in (r"/actions/runs/(\d+)", r"/runs/(\d+)"):
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    return None
+
+
+def extract_job_id(url: str) -> str | None:
+    if not url:
+        return None
+    match = re.search(r"/actions/runs/\d+/job/(\d+)", url)
+    if match:
+        return match.group(1)
+    match = re.search(r"/job/(\d+)", url)
+    if match:
+        return match.group(1)
+    return None
+
+
+def fetch_run_metadata(run_id: str, repo_root: Path) -> dict[str, Any] | None:
+    fields = [
+        "conclusion",
+        "status",
+        "workflowName",
+        "name",
+        "event",
+        "headBranch",
+        "headSha",
+        "url",
+    ]
+    result = run_gh_command(["run", "view", run_id, "--json", ",".join(fields)], cwd=repo_root)
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def fetch_check_log(
+    run_id: str,
+    job_id: str | None,
+    repo_root: Path,
+) -> tuple[str, str, str]:
+    log_text, log_error = fetch_run_log(run_id, repo_root)
+    if not log_error:
+        return log_text, "", "ok"
+
+    if is_log_pending_message(log_error) and job_id:
+        job_log, job_error = fetch_job_log(job_id, repo_root)
+        if job_log:
+            return job_log, "", "ok"
+        if job_error and is_log_pending_message(job_error):
+            return "", job_error, "pending"
+        if job_error:
+            return "", job_error, "error"
+        return "", log_error, "pending"
+
+    if is_log_pending_message(log_error):
+        return "", log_error, "pending"
+
+    return "", log_error, "error"
+
+
+def fetch_run_log(run_id: str, repo_root: Path) -> tuple[str, str]:
+    result = run_gh_command(["run", "view", run_id, "--log"], cwd=repo_root)
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout or "").strip()
+        return "", error or "gh run view failed"
+    return result.stdout, ""
+
+
+def fetch_job_log(job_id: str, repo_root: Path) -> tuple[str, str]:
+    repo_slug = fetch_repo_slug(repo_root)
+    if not repo_slug:
+        return "", "Error: unable to resolve repository name for job logs."
+    endpoint = f"/repos/{repo_slug}/actions/jobs/{job_id}/logs"
+    returncode, stdout_bytes, stderr = run_gh_command_raw(["api", endpoint], cwd=repo_root)
+    if returncode != 0:
+        message = (stderr or stdout_bytes.decode(errors="replace")).strip()
+        return "", message or "gh api job logs failed"
+    if is_zip_payload(stdout_bytes):
+        return "", "Job logs returned a zip archive; unable to parse."
+    return stdout_bytes.decode(errors="replace"), ""
+
+
+def fetch_repo_slug(repo_root: Path) -> str | None:
+    result = run_gh_command(["repo", "view", "--json", "nameWithOwner"], cwd=repo_root)
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    name_with_owner = data.get("nameWithOwner")
+    if not name_with_owner:
+        return None
+    return str(name_with_owner)
+
+
+def normalize_field(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def parse_available_fields(message: str) -> list[str]:
+    if "Available fields:" not in message:
+        return []
+    fields: list[str] = []
+    collecting = False
+    for line in message.splitlines():
+        if "Available fields:" in line:
+            collecting = True
+            continue
+        if not collecting:
+            continue
+        field = line.strip()
+        if not field:
+            continue
+        fields.append(field)
+    return fields
+
+
+def is_log_pending_message(message: str) -> bool:
+    lowered = message.lower()
+    return any(marker in lowered for marker in PENDING_LOG_MARKERS)
+
+
+def is_zip_payload(payload: bytes) -> bool:
+    return payload.startswith(b"PK")
+
+
+def extract_failure_snippet(log_text: str, max_lines: int, context: int) -> str:
+    lines = log_text.splitlines()
+    if not lines:
+        return ""
+
+    marker_index = find_failure_index(lines)
+    if marker_index is None:
+        return "\n".join(lines[-max_lines:])
+
+    start = max(0, marker_index - context)
+    end = min(len(lines), marker_index + context)
+    window = lines[start:end]
+    if len(window) > max_lines:
+        window = window[-max_lines:]
+    return "\n".join(window)
+
+
+def find_failure_index(lines: Sequence[str]) -> int | None:
+    for idx in range(len(lines) - 1, -1, -1):
+        lowered = lines[idx].lower()
+        if any(marker in lowered for marker in FAILURE_MARKERS):
+            return idx
+    return None
+
+
+def tail_lines(text: str, max_lines: int) -> str:
+    if max_lines <= 0:
+        return ""
+    lines = text.splitlines()
+    return "\n".join(lines[-max_lines:])
+
+
+def render_results(pr_number: str, results: Iterable[dict[str, Any]]) -> None:
+    results_list = list(results)
+    print(f"PR #{pr_number}: {len(results_list)} failing checks analyzed.")
+    for result in results_list:
+        print("-" * 60)
+        print(f"Check: {result.get('name', '')}")
+        if result.get("detailsUrl"):
+            print(f"Details: {result['detailsUrl']}")
+        run_id = result.get("runId")
+        if run_id:
+            print(f"Run ID: {run_id}")
+        job_id = result.get("jobId")
+        if job_id:
+            print(f"Job ID: {job_id}")
+        status = result.get("status", "unknown")
+        print(f"Status: {status}")
+
+        run_meta = result.get("run", {})
+        if run_meta:
+            branch = run_meta.get("headBranch", "")
+            sha = (run_meta.get("headSha") or "")[:12]
+            workflow = run_meta.get("workflowName") or run_meta.get("name") or ""
+            conclusion = run_meta.get("conclusion") or run_meta.get("status") or ""
+            print(f"Workflow: {workflow} ({conclusion})")
+            if branch or sha:
+                print(f"Branch/SHA: {branch} {sha}")
+            if run_meta.get("url"):
+                print(f"Run URL: {run_meta['url']}")
+
+        if result.get("note"):
+            print(f"Note: {result['note']}")
+
+        if result.get("error"):
+            print(f"Error fetching logs: {result['error']}")
+            continue
+
+        snippet = result.get("logSnippet") or ""
+        if snippet:
+            print("Failure snippet:")
+            print(indent_block(snippet, prefix="  "))
+        else:
+            print("No snippet available.")
+    print("-" * 60)
+
+
+def indent_block(text: str, prefix: str = "  ") -> str:
+    return "\n".join(f"{prefix}{line}" for line in text.splitlines())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: security-review
+description: |
+  Manual-only skill.
+
+  Use ONLY when the user explicitly invokes:
+  $security-review
+
+  Never select this skill via semantic matching.
+---
+
+# Security Review
+
+## Activation guard
+
+If "$security-review" is NOT present in the user request:
+- Exit immediately
+- Do not analyze anything
+- Do not load references
+
+---
+
+## Token policy
+
+- Default: no reference files
+- Load at most ONE reference file
+- Only load references if strictly required
+- Prefer repo evidence over general guidance
+- Keep output concise and high-signal
+
+---
+
+## Modes
+
+Ask the user which mode to use before proceeding with this skill:
+
+### Light mode (default)
+
+Use for:
+- narrow code paths
+- quick checks
+- implementation guidance
+
+Rules:
+- no references unless absolutely necessary
+- only high-confidence findings
+- minimal output
+
+---
+
+### Full review mode
+
+Use ONLY if explicitly requested (e.g. “full security review”, “threat model”)
+
+Rules:
+- define scope first
+- inspect repo before references
+- load at most one reference initially
+
+---
+
+## Workflow
+
+1. Identify scope (files, components, boundaries)
+2. Locate:
+   - entrypoints
+   - auth boundaries
+   - user input paths
+   - sensitive data handling
+3. Analyze only what is in scope
+4. Escalate only if risk justifies it
+
+---
+
+## Priority risks
+
+Focus on real, high-impact issues:
+
+- auth / authorization flaws
+- injection risks
+- SSRF / request forgery
+- unsafe parsing / deserialization
+- file upload / path traversal
+- secrets exposure
+- tenant isolation failures
+- insecure defaults
+
+Ignore:
+- style issues
+- speculative edge cases
+- generic checklists
+
+---
+
+## Output format
+
+For each issue:
+
+- Issue: what is wrong
+- Location: where it is
+- Impact: why it matters
+- Abuse path: how it could be exploited
+- Fix: smallest safe remediation
+
+If no issues: say so clearly.
+
+---
+
+## Reference usage
+
+Only if necessary, choose ONE relevant GoMud reference:
+
+- golang backend
+- general browser JavaScript frontend
+- jQuery frontend for admin pages
+
+If no strong match -> use none
+
+---
+
+## Hard rules
+
+- Only run when "$security-review" is present
+- Never trigger implicitly
+- Never scan entire repo unless explicitly asked
+- Never load multiple references unless absolutely required
+- Never inflate output with generic advice

--- a/.agents/skills/security-review/agents/openai.yaml
+++ b/.agents/skills/security-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Security Review"
+  short_description: "Threat models and secure code review"
+  default_prompt: "Use $security-review to threat model this codebase and review it for security weaknesses."

--- a/.agents/skills/security-review/references/golang-general-backend-security.md
+++ b/.agents/skills/security-review/references/golang-general-backend-security.md
@@ -1,0 +1,826 @@
+# Go (Golang) Security Spec (Go 1.25.x, Standard Library, net/http)
+
+This document is designed as a **security spec** that supports:
+1) **Secure-by-default code generation** for new Go code.
+2) **Security review / vulnerability hunting** in existing Go code (passive “notice issues while working” and active “scan the repo and report findings”).
+
+It is intentionally written as a set of **normative requirements** (“MUST/SHOULD/MAY”) plus **audit rules** (what bad patterns look like, how to detect them, and how to fix/mitigate them).
+
+--------------------------------------------------------------------
+
+## 0) Safety, boundaries, and anti-abuse constraints (MUST FOLLOW)
+
+- MUST NOT request, output, log, or commit secrets (API keys, passwords, private keys, session cookies, JWTs, database URLs with credentials, signing keys, client secrets).
+- MUST NOT “fix” security by disabling protections (e.g., `InsecureSkipVerify`, `GOSUMDB=off` for public modules, wildcard CORS + credentials, removing auth checks, disabling CSRF defenses on cookie-auth apps).
+- MUST provide **evidence-based findings** during audits: cite file paths, code snippets, build/deploy configs, and concrete values that justify the claim.
+- MUST treat uncertainty honestly: if a control might exist in infrastructure (reverse proxy, WAF, service mesh, platform config), report it as “not visible in app code; verify at runtime/config.”
+- MUST keep fixes minimal, correct, and production-safe; avoid introducing breaking changes without warning (especially around auth/session flows, and proxies).
+
+--------------------------------------------------------------------
+
+## 1) Operating modes
+
+### 1.1 Generation mode (default)
+When asked to write new Go code or modify existing code:
+- MUST follow every **MUST** requirement in this spec.
+- SHOULD follow every **SHOULD** requirement unless the user explicitly says otherwise.
+- MUST prefer safe-by-default APIs and proven libraries over custom security code.
+- MUST avoid introducing new risky sinks (shell execution, dynamic template execution, serving user files as HTML, unsafe redirects, weak crypto, unbounded parsing, etc.).
+
+### 1.2 Passive review mode (always on while editing)
+While working anywhere in a Go repo (even if the user did not ask for a security scan):
+- MUST “notice” violations of this spec in touched/nearby code.
+- SHOULD mention issues as they come up, with a brief explanation + safe fix.
+
+### 1.3 Active audit mode (explicit scan request)
+When the user asks to “scan”, “audit”, or “hunt for vulns”:
+- MUST systematically search the codebase for violations of this spec.
+- MUST output findings in a structured format (see §2.3).
+
+Recommended audit order:
+1) Build/deploy entrypoints: `main.go`, `cmd/*`, Dockerfiles, Kubernetes manifests, systemd units, CI workflows.
+2) Go toolchain & dependency policy: Go version, modules, `go.mod/go.sum`, proxy/sumdb settings, govulncheck usage.
+3) Secret management and config loading (env, files, secret stores) + logging patterns.
+4) HTTP server configuration (timeouts, body limits, proxy trust, security headers).
+5) AuthN/AuthZ boundaries, session/cookie settings, token validation.
+6) CSRF protections for cookie-authenticated state-changing endpoints.
+7) Template usage and output encoding (XSS), and any “render template from string” behavior (SSTI).
+8) File handling (uploads/downloads/path traversal/temp files), static file serving.
+9) Injection sinks: SQL, OS command execution, SSRF/outbound fetch, open redirects.
+10) Concurrency/resource exhaustion (unbounded goroutines/queues, missing timeouts/contexts).
+11) Use of `unsafe` / `cgo` / `reflect` in security-sensitive paths.
+12) Debug/diagnostic endpoints (pprof/expvar/metrics) exposure.
+13) Cryptography usage (randomness, password hashing).
+
+--------------------------------------------------------------------
+
+## 2) Definitions and review guidance
+
+### 2.1 Untrusted input (treat as attacker-controlled unless proven otherwise)
+Examples include:
+- `*http.Request` fields: `r.URL.Path`, `r.URL.RawQuery`, `r.Form`, `r.PostForm`, headers, cookies, `r.Body`
+- Path parameters from routers (including values extracted from URL paths)
+- JSON/XML/YAML bodies, multipart form parts, uploaded files
+- Any data from external systems (webhooks, third-party APIs, message queues)
+- Any persisted user content (DB rows) that originated from users
+- Configuration values that might be attacker-influenced in some deployments (headers set by upstream proxies, environment variables in multi-tenant systems)
+
+### 2.2 State-changing request
+A request is state-changing if it can create/update/delete data, change auth/session state, trigger side effects (purchase, email send, webhook send), or initiate privileged actions.
+
+### 2.3 Required audit finding format
+For each issue found, output:
+
+- Rule ID:
+- Severity: Critical / High / Medium / Low
+- Location: file path + function/handler name + line(s)
+- Evidence: the exact code/config snippet
+- Impact: what could go wrong, who can exploit it
+- Fix: safe change (prefer minimal diff)
+- Mitigation: defense-in-depth if immediate fix is hard
+- False positive notes: what to verify if uncertain (edge configs, proxy behavior, auth assumptions)
+
+--------------------------------------------------------------------
+
+## 3) Secure baseline: minimum production configuration (MUST in production)
+
+This is the smallest “production baseline” that prevents common Go misconfigurations.
+
+### 3.1 Toolchain, patching, and dependency hygiene (MUST)
+- MUST run a supported Go major version and keep to the latest patch releases.
+- MUST treat Go standard library patch releases as security-relevant (many security fixes land in stdlib components like `net/http`, `crypto/*`, parsing packages).
+- MUST use Go modules with committed `go.mod` and `go.sum`.
+- MUST NOT disable module authenticity mechanisms for public modules (checksum DB) unless you have a controlled, documented replacement.
+- MUST run `govulncheck` (source scan and/or binary scan) in CI and address findings.
+
+### 3.2 HTTP server baseline (MUST for network-facing services)
+If the program serves HTTP (directly or via a framework built on `net/http`):
+- MUST configure an `http.Server` with explicit timeouts and header limits.
+- MUST set request body size limits (global and per-route as needed).
+- MUST avoid exposing diagnostic endpoints (pprof/expvar) publicly.
+- SHOULD set a consistent set of security headers (or verify they are set at the edge).
+- MUST set cookie security attributes for any cookies you issue.
+- SHOULD implement rate limiting and abuse controls for auth and expensive endpoints.
+
+Illustrative baseline skeleton (adjust to your project):
+- Create a dedicated mux (avoid implicit global defaults unless intentionally managed).
+- Wrap handlers with: panic-safe error handling, request ID, logging, auth, and limits.
+
+--------------------------------------------------------------------
+
+## 4) Rules (generation + audit)
+
+Each rule contains: required practice, insecure patterns, detection hints, and remediation.
+
+### GO-DEPLOY-001: Keep the Go toolchain and standard library updated (security releases)
+Severity: Medium
+
+NOTE: Upgrading dependencies and the core Go version can break projects in unexpected ways. Focus on only security-critical dependencies and if noticed, let the user know rather than upgrading automatically.
+
+Required:
+- MUST run a supported Go major release and apply patch releases promptly.
+- SHOULD treat patch releases as security-relevant, even if your application code didn’t change.
+
+Insecure patterns:
+- Production builds pinned to old Go versions without a patching process.
+- Docker images like `golang:1.xx` or custom base images that are not updated regularly.
+- CI pipelines that intentionally suppress Go updates.
+
+Detection hints:
+- Inspect CI (`.github/workflows`, `gitlab-ci.yml`, etc.) for `go-version:` or toolchain setup.
+- Inspect Dockerfiles for `FROM golang:` tags.
+- Inspect `go.mod` `go` directive and any toolchain pinning.
+
+Fix:
+- Upgrade to the latest patch of a supported Go version.
+- Add an automated check (CI) that fails when Go is below an approved minimum.
+
+Notes:
+- Go publishes regular minor releases that frequently include security fixes across standard library packages.
+
+---
+
+### GO-SUPPLY-001: Go module authenticity MUST NOT be disabled for public dependencies
+Severity: High
+
+Required:
+- MUST keep module checksum verification enabled for public modules.
+- SHOULD commit `go.sum` and treat changes as security-sensitive.
+- MUST NOT use insecure module fetching settings for public modules.
+- MAY configure private module behavior using `GOPRIVATE`/`GONOSUMDB` for private repos, but must do so narrowly and intentionally.
+
+Insecure patterns:
+- `GOSUMDB=off` in CI or production build environments for public modules.
+- `GONOSUMDB=*` or overly broad patterns that effectively disable verification.
+- `GOINSECURE=*` or broad `GOINSECURE` patterns for public modules.
+- `GOPROXY=direct` everywhere without a clear policy.
+
+Detection hints:
+- Search build configs for `GOSUMDB`, `GONOSUMDB`, `GOINSECURE`, `GOPROXY`, `GOPRIVATE`.
+- Look for documentation/scripts that recommend disabling checksum DB “to make builds work”.
+
+Fix:
+- Restore defaults for public module verification.
+- For private modules:
+  - Set `GOPRIVATE=your.private.domain/*`
+  - Configure an internal proxy or direct fetching, and restrict `GONOSUMDB` to private patterns only.
+
+Notes:
+- Disabling checksum verification removes an important integrity layer against targeted or compromised upstream delivery.
+
+---
+
+### GO-CONFIG-001: Secrets must be externalized and never logged or committed
+Severity: High (Critical if credentials are committed)
+
+Required:
+- MUST load secrets from environment variables, secret managers, or secure config files with restricted permissions.
+- MUST NOT hard-code secrets in Go source, test fixtures that may reach production, or build args.
+- MUST NOT log secrets or full credential-bearing connection strings.
+- SHOULD fail closed in production if required secrets are missing.
+
+Insecure patterns:
+- String constants containing tokens/keys/passwords.
+- `.env` files or config files with secrets committed to repo.
+- Logging `os.Environ()`, dumping full configs, or printing DSNs.
+
+Detection hints:
+- Search for suspicious literals (`API_KEY`, `SECRET`, `PASSWORD`, `Authorization:`).
+- Inspect config loaders and logging statements.
+- Inspect CI logs or debug print paths.
+
+Fix:
+- Move secrets to a secret store / environment variables.
+- Redact sensitive fields in logs.
+- Add secret scanning to CI and pre-commit.
+
+---
+
+### GO-HTTP-001: HTTP servers MUST set timeouts and MaxHeaderBytes
+Severity: High (DoS risk)
+
+Required:
+- MUST set: `ReadHeaderTimeout`, and SHOULD set `ReadTimeout`, `WriteTimeout`, `IdleTimeout` as appropriate for the service.
+- MUST set `MaxHeaderBytes` to a justified limit for your application.
+- MUST NOT rely on default zero-values for timeouts in production for internet-facing servers.
+
+Insecure patterns:
+- `http.ListenAndServe(":8080", handler)` with a default `http.Server` (no explicit timeouts).
+- `&http.Server{}` with timeouts left at zero.
+- Missing `MaxHeaderBytes`.
+
+Detection hints:
+- Search for `http.ListenAndServe(`, `ListenAndServeTLS(`, `Server{` and inspect configured fields.
+- Check for reverse proxies; even with a proxy, app-level timeouts still matter.
+
+Fix:
+- Use `http.Server{ReadHeaderTimeout: ..., ReadTimeout: ..., WriteTimeout: ..., IdleTimeout: ..., MaxHeaderBytes: ...}`.
+- Calibrate timeouts per endpoint type (streaming vs JSON APIs).
+
+Notes:
+- Net/http documents that these timeouts exist and that zero/negative values mean “no timeout”; production services should choose explicit values.
+
+---
+
+### GO-HTTP-002: Request body and multipart parsing MUST be size-bounded
+Severity: Medium (DoS risk; can be High for upload-heavy apps)
+
+Required:
+- MUST enforce a global maximum request body size for endpoints that accept bodies.
+- MUST enforce strict multipart upload limits and avoid unbounded form parsing.
+- SHOULD enforce per-route limits when some endpoints legitimately need larger bodies.
+- SHOULD set upstream (proxy) limits as defense-in-depth.
+
+Insecure patterns:
+- Reading `r.Body` with `io.ReadAll(r.Body)` without a size cap.
+- Calling `r.ParseMultipartForm(...)` with overly large limits (or forgetting size controls).
+- Accepting file uploads with no limits on file size, number of parts, or total body size.
+
+Detection hints:
+- Search for `io.ReadAll(r.Body)`, `json.NewDecoder(r.Body)`, `ParseMultipartForm`, `FormFile`, `multipart`.
+- Look for missing `http.MaxBytesReader` or equivalent per-handler limiting.
+- Look for “upload” endpoints and check limits.
+
+Fix:
+- Wrap request bodies with `http.MaxBytesReader(w, r.Body, maxBytes)` before parsing.
+- For multipart, set conservative limits and validate file sizes/part counts explicitly.
+- Set proxy limits (e.g., at ingress) in addition to app limits.
+
+Notes:
+- There are known vulnerability classes and advisories related to excessive resource consumption in multipart/form parsing; treat unbounded parsing as a security issue.
+
+---
+
+### GO-DEPLOY-002: Diagnostic endpoints (pprof/expvar/metrics) MUST NOT be publicly exposed
+Severity: High
+
+NOTE: This only applies to production configurations. These endpoints are often used for debug or dev endpoints. If found, confirm that it would be reachable from the actual production deployment.
+
+Required:
+- MUST NOT expose `net/http/pprof` handlers on a public internet-facing listener without strong access controls.
+- SHOULD run diagnostics on a separate, internal-only listener (loopback/VPC-only) and require auth.
+- MUST review what diagnostic endpoints reveal (stack traces, memory, command lines, environment, internal URLs).
+
+Insecure patterns:
+- Side-effect import `import _ "net/http/pprof"` in a server binary with a public mux.
+- `/debug/pprof/*` reachable without auth.
+- `/debug/vars` (expvar) reachable without auth.
+
+Detection hints:
+- Search for `net/http/pprof` imports (including blank imports).
+- Search for route prefixes `/debug/pprof`, `/debug/vars`.
+- Check whether `http.DefaultServeMux` is used and whether any debug handlers register globally.
+
+Fix:
+- Remove diagnostics from production builds, or bind them to an internal-only listener.
+- Add strong authentication/authorization (and ideally network-level restrictions).
+
+Notes:
+- pprof is typically imported for its side effect of registering HTTP handlers under `/debug/pprof/`.
+
+---
+
+### GO-HTTP-003: Reverse proxy and forwarded header trust MUST be explicit
+Severity: High (auth, URL generation, logging/auditing correctness)
+
+Required:
+- If behind a reverse proxy, MUST define which proxy is trusted and how client IP/scheme/host are derived.
+- MUST NOT trust `X-Forwarded-For`, `X-Forwarded-Proto`, `Forwarded`, or similar headers from the open internet.
+- MUST ensure “secure cookie” logic, redirects, and absolute URL generation do not rely on spoofable headers.
+
+Insecure patterns:
+- Using `r.Header.Get("X-Forwarded-For")` as the client IP without validating the proxy boundary.
+- Deriving “is HTTPS” from `X-Forwarded-Proto` without confirming it came from a trusted proxy.
+- Using forwarded `Host` values for password reset links without allowlisting.
+
+Detection hints:
+- Search for `X-Forwarded-For`, `X-Forwarded-Proto`, `Forwarded`, `Real-IP`, and any custom “client IP” helpers.
+- Inspect ingress/proxy configs; if not visible, mark as “verify at edge”.
+
+Fix:
+- Enforce proxy trust at the edge and in app:
+  - Accept forwarded headers only from known proxy IP ranges.
+  - Prefer platform-provided mechanisms where available.
+- If generating external links, use a configured allowlisted canonical origin (not the request’s Host header).
+
+---
+
+### GO-HTTP-004: Security headers SHOULD be set (in app or at the edge)
+Severity: Medium
+
+Required (typical web app serving browsers):
+- SHOULD set:
+  - `Content-Security-Policy` (CSP) appropriate to the app. NOTE: It is most important to set the CSP's script-src. All other directives are not as important and can generally be excluded for the ease of development.
+  - `X-Content-Type-Options: nosniff`
+  - Clickjacking protection (`X-Frame-Options` and/or CSP `frame-ancestors`)
+  - `Referrer-Policy` and `Permissions-Policy` where appropriate
+- MUST ensure cookies have secure attributes (see GO-HTTP-005).
+
+NOTE:
+- These headers may be set via reverse proxy/CDN; if not visible in app code, report as “verify at edge”.
+
+Insecure patterns:
+- No security headers anywhere (app or edge) for a browser-facing app.
+- CSP missing for apps rendering untrusted content.
+
+Detection hints:
+- Search for middleware setting headers: `w.Header().Set("Content-Security-Policy", ...)`, etc.
+- Search for reverse proxy config that sets headers.
+
+Fix:
+- Add centralized header middleware in Go, or configure at the edge.
+- Keep CSP realistic; avoid `unsafe-inline` where possible.
+
+---
+
+### GO-HTTP-005: Cookies MUST use secure attributes in production
+Severity: Medium
+
+Required (production, HTTPS):
+- MUST set `Secure` on cookies that carry auth/session state. IMPORTANT NOTE: Only set `Secure` in production environment when TLS is configured. When running in a local dev environment over HTTP, do not set `Secure` property on cookies. You should do this conditionally based on if the app is running in production mode. You should also include a property like `SESSION_COOKIE_SECURE` which can be used to disable `Secure` cookies when testing over HTTP.
+- MUST set `HttpOnly` on auth/session cookies.
+- SHOULD set `SameSite=Lax` by default (or `Strict` if compatible), and only use `None` when necessary (and only with `Secure`).
+- SHOULD set bounded lifetimes (`Max-Age`/`Expires`) appropriate to the app.
+
+Insecure patterns:
+- Setting auth/session cookies without `Secure` in HTTPS deployments.
+- Cookies without `HttpOnly` for session identifiers.
+- `SameSite=None` for cookie-authenticated apps without a strong CSRF strategy.
+
+Detection hints:
+- Search for `http.SetCookie`, `&http.Cookie{`, `Set-Cookie`.
+- Inspect cookie flags in auth/session code.
+
+Fix:
+- Set the correct fields on `http.Cookie` and centralize cookie creation.
+
+Notes:
+- SameSite is defense-in-depth and does not replace CSRF protections for cookie-auth apps.
+
+---
+
+### GO-HTTP-006: Cookie-authenticated state-changing endpoints MUST be CSRF-protected
+Severity: High
+
+- IMPORTANT NOTE: If cookies are not used for auth (e.g., pure bearer token in Authorization header with no ambient cookies), CSRF is not a risk for those endpoints.
+
+Required:
+- MUST protect all state-changing endpoints (POST/PUT/PATCH/DELETE) that rely on cookies for authentication.
+- SHOULD use a well-tested CSRF library/middleware rather than rolling your own.
+- MAY use additional defenses (Origin/Referer checks, Fetch Metadata, SameSite cookies), but tokens remain the primary defense for cookie-authenticated apps.
+If tokens are impractical, or for small applications:
+* MUST at a minimum require a custom header to be set and set the session cookie SESSION_COOKIE_SAMESITE=lax, as this is the strongest method besides requiring a form token, and may be much easier to implement.
+
+
+Insecure patterns:
+- Cookie-authenticated JSON endpoints that mutate state with no CSRF checks.
+- Using GET for state-changing actions.
+
+Detection hints:
+- Enumerate all non-GET routes and identify auth mechanism.
+- Look for CSRF middleware usage; if absent, treat as suspicious in browser-facing apps.
+
+Fix:
+- Add CSRF middleware and ensure it covers all state-changing routes.
+- If the service is an API intended for non-browser clients, avoid cookie auth; use Authorization headers.
+
+---
+
+### GO-HTTP-007: CORS must be explicit and least-privilege
+Severity: Medium (High if misconfigured with credentials)
+
+Required:
+- If CORS is not needed, MUST keep it disabled.
+- If CORS is needed:
+  - MUST allowlist trusted origins (do not reflect arbitrary origins)
+  - MUST be careful with credentialed requests; do not combine broad origins with cookies
+  - SHOULD restrict allowed methods/headers
+
+Insecure patterns:
+- `Access-Control-Allow-Origin: *` paired with cookies (`Access-Control-Allow-Credentials: true`).
+- Reflecting `Origin` without validation.
+
+Detection hints:
+- Search for `Access-Control-Allow-` header setting.
+- Search for CORS middleware configuration.
+
+Fix:
+- Implement strict origin allowlists and minimal methods/headers.
+- Ensure cookie-auth endpoints are not exposed cross-origin unless required.
+
+---
+
+### GO-XSS-001: Use html/template and avoid bypassing auto-escaping with untrusted data
+Severity: High
+
+Required:
+- MUST use `html/template` for HTML rendering (not `text/template`).
+- MUST NOT convert untrusted data into “trusted” template types (`template.HTML`, `template.JS`, `template.URL`, etc.).
+- SHOULD keep templates static and controlled by developers; treat dynamic templates as high risk.
+- MUST NOT serve user-uploaded HTML/JS as active content unless explicitly intended and safely sandboxed.
+
+Insecure patterns:
+- `text/template` used to generate HTML.
+- Using `template.HTML(userInput)` or similar typed wrappers.
+- Directly writing unescaped user content into HTML responses.
+
+Detection hints:
+- Search for `text/template`, `template.New(...).Parse(...)`, and typed wrappers like `template.HTML(`.
+- Inspect handlers that return HTML with string concatenation.
+
+Fix:
+- Use `html/template` and pass untrusted data as data, not markup.
+- If you must allow limited HTML, use a vetted HTML sanitizer and still be careful with attributes/URLs.
+
+---
+
+### GO-SSTI-001: Never parse/execute templates from untrusted input (SSTI)
+Severity: Critical
+
+Required:
+- MUST NOT call `template.Parse` / `template.ParseFiles` / `template.New(...).Parse(...)` on template text influenced by untrusted input.
+- MUST treat “user-defined templates” as a special high-risk design:
+  - MUST use heavy sandboxing and strict allowlists
+  - MUST isolate execution (process/container boundary) if truly required
+
+Insecure patterns:
+- `tmpl := template.Must(template.New("x").Parse(r.FormValue("tmpl")))`
+- Reading templates from uploads / DB entries and executing them in the same trust domain as server code.
+
+Detection hints:
+- Search for `.Parse(` and trace the origin of the template string.
+- Look for “custom email templates”, “user theming templates”, etc.
+
+Fix:
+- Replace with safe substitution mechanisms (no code execution).
+- If templates must be user-controlled, isolate and sandbox aggressively.
+
+---
+
+### GO-PATH-001: Prevent path traversal and unsafe file serving
+Severity: High
+
+Required:
+- MUST NOT pass user-controlled paths to `os.Open`, `os.ReadFile`, `http.ServeFile`, or `http.FileServer` without strict validation and base-dir enforcement.
+- MUST treat `..`, absolute paths, and OS-specific path tricks as hostile input.
+- SHOULD store user uploads outside any static web root; serve through controlled handlers.
+- MUST avoid directory listing for sensitive file trees.
+
+Insecure patterns:
+- `http.ServeFile(w, r, r.URL.Query().Get("path"))`
+- `os.Open(filepath.Join(baseDir, userPath))` without checking that the result stays under `baseDir`
+- `http.FileServer(http.Dir("."))` serving the project root or user-writable directories
+
+Detection hints:
+- Search for `ServeFile(`, `FileServer(`, `http.Dir(`, `os.Open(`, `ReadFile(`, `filepath.Join(`.
+- Trace whether path components come from request/DB.
+
+Fix:
+- Use an allowlist of file identifiers (e.g., database IDs) mapped to server-side paths.
+- Enforce base directory containment after cleaning and joining.
+- Serve active formats as downloads (`Content-Disposition: attachment`) unless explicitly intended.
+
+---
+
+### GO-UPLOAD-001: File uploads must be validated, stored safely, and served safely
+Severity: High
+
+Required:
+- MUST enforce upload size limits (app + edge).
+- MUST validate file type using allowlists and content checks (not only extensions).
+- MUST store uploads outside executable/static roots when possible.
+- SHOULD generate server-side filenames (random IDs) and avoid trusting original names.
+- MUST serve potentially active formats safely (download attachment) unless explicitly intended.
+
+Insecure patterns:
+- Accepting arbitrary file types and serving them back inline.
+- Using user-supplied filename as storage path.
+- Missing size/type validation.
+
+Detection hints:
+- Search for `multipart`, `FormFile`, `ParseMultipartForm`, `io.Copy` to disk.
+- Check where files are stored and how they are served.
+
+Fix:
+- Implement allowlist validation + safe storage + safe serving.
+- Add scanning/quarantine workflows where applicable.
+
+---
+
+### GO-INJECT-001: Prevent SQL injection (parameterized queries / ORM)
+Severity: High
+
+Required:
+- MUST use parameterized queries or an ORM that parameterizes under the hood.
+- MUST NOT build SQL by string concatenation / `fmt.Sprintf` / string interpolation with untrusted input.
+
+Insecure patterns:
+- `fmt.Sprintf("SELECT ... WHERE id=%s", r.URL.Query().Get("id"))`
+- `query := "UPDATE users SET role='" + role + "' WHERE id=" + id`
+
+Detection hints:
+- Grep for `SELECT`, `INSERT`, `UPDATE`, `DELETE` and check how query strings are built.
+- Trace untrusted data into `db.Query`, `db.Exec`, `QueryRow`, etc.
+
+Fix:
+- Replace with placeholders (`?`, `$1`, etc.) and pass parameters separately.
+- Validate and type-check IDs before use.
+
+---
+
+### GO-INJECT-002: Prevent OS command injection; avoid shelling out with untrusted input
+Severity: Critical to High (depends on exposure)
+
+Required:
+- MUST avoid executing external commands with attacker-controlled strings.
+- If subprocess is necessary:
+  - MUST use `exec.CommandContext` with an argument list (not `sh -c`).
+  - MUST NOT pass untrusted input to a shell (`bash -c`, `sh -c`, PowerShell).
+  - SHOULD use strict allowlists for any variable component (subcommand, flags, filenames).
+- MUST assume CLI tools may interpret attacker-controlled args as flags or special values.
+
+Insecure patterns:
+- `exec.Command("sh", "-c", userString)`
+- `exec.Command("bash", "-c", fmt.Sprintf("tool %s", user))`
+- Calling the shell to get glob expansion for user-supplied globs.
+
+Detection hints:
+- Search for `os/exec`, `exec.Command(`, `CommandContext(`, `"sh"`, `"bash"`, `"-c"`.
+- Trace untrusted input into command name/args.
+
+Fix:
+- Use library APIs instead of subprocesses.
+- Hardcode command and allowlist/validate args.
+- If a shell is unavoidable, escape robustly and treat as high risk (prefer avoiding).
+
+Notes:
+- The Go `os/exec` package intentionally does invoke a shell; introducing `sh -c` reintroduces shell injection hazards.
+
+---
+
+### GO-SSRF-001: Prevent SSRF in outbound HTTP requests
+Severity: Medium (High in cloud/LAN environments)
+
+- Note: For small stand alone projects this is less important. It is most important when deploying into an LAN or with other services listening on the same server.
+
+Required:
+- MUST treat outbound requests to user-provided URLs as high risk.
+- SHOULD allowlist hosts/domains for any user-influenced URL fetch.
+- SHOULD block access to localhost/private IP ranges/link-local addresses and cloud metadata endpoints.
+- MUST restrict schemes to `http`/`https` (no `file:`, `gopher:`, etc.).
+- MUST set client timeouts and restrict redirects.
+
+Insecure patterns:
+- `http.Get(r.URL.Query().Get("url"))`
+- “URL preview” / “webhook test” endpoints that fetch arbitrary URLs.
+
+Detection hints:
+- Search for `http.Get`, `client.Do`, and URL values derived from requests/DB.
+- Identify features that fetch remote resources.
+
+Fix:
+- Parse URLs strictly; enforce scheme and allowlisted hostnames.
+- Resolve DNS and enforce IP-range restrictions (with care for DNS rebinding).
+- Set timeouts, disable redirects unless needed, and cap response sizes.
+
+---
+
+### GO-HTTPCLIENT-001: Outbound HTTP clients MUST set timeouts and close bodies
+Severity: High (DoS and resource exhaustion)
+
+Required:
+- MUST set an overall timeout on `http.Client` usage (or equivalent per-request deadlines via context + transport timeouts).
+- MUST ensure `resp.Body.Close()` is called for all successful requests (typically `defer resp.Body.Close()` immediately after error check).
+- SHOULD limit response body reads (do not `io.ReadAll` unbounded responses).
+- SHOULD restrict redirects for security-sensitive fetches (SSRF, auth flows).
+
+Insecure patterns:
+- Using `http.DefaultClient` / `http.Get` for user-influenced destinations with no timeout policy.
+- Missing `defer resp.Body.Close()` leading to resource leaks.
+- `io.ReadAll(resp.Body)` with no limit.
+
+Detection hints:
+- Search for `http.Get(`, `http.Post(`, `client := &http.Client{}` without `Timeout`, `client.Do(` and missing closes.
+- Search for `io.ReadAll(resp.Body)`.
+
+Fix:
+- Use a configured client with timeouts.
+- Always close response bodies.
+- Use bounded readers (`io.LimitReader`) for large/untrusted responses.
+
+Notes:
+- The net/http package exposes `DefaultClient` as a zero-valued `http.Client`, which can easily lead to “no timeout” behavior unless configured.
+
+---
+
+### GO-REDIRECT-001: Prevent open redirects
+Severity: Medium (can be High with auth flows)
+
+Required:
+- MUST validate redirect targets derived from untrusted input (`next`, `redirect`, `return_to`).
+- SHOULD prefer only same-site relative paths.
+- SHOULD fall back to a safe default on validation failure.
+
+Insecure patterns:
+- `http.Redirect(w, r, r.URL.Query().Get("next"), http.StatusFound)` with no validation.
+
+Detection hints:
+- Search for `http.Redirect(` and check origin of the location.
+
+Fix:
+- Allowlist internal paths or known domains.
+- Reject absolute URLs unless explicitly needed and allowlisted.
+
+---
+
+### GO-CRYPTO-001: Cryptographic randomness MUST come from crypto/rand
+Severity: High (Critical if used for auth/session tokens or keys)
+
+Required:
+- MUST use `crypto/rand` for:
+  - session IDs, password reset tokens, API keys, CSRF tokens, nonces
+  - encryption keys, signing keys, salts when required
+- MUST NOT use `math/rand` for any security-sensitive value.
+- SHOULD use built-in helpers that produce appropriately strong tokens when available.
+
+Insecure patterns:
+- `math/rand.Seed(time.Now().UnixNano())` followed by token generation for auth or sessions.
+- Using UUIDv4-like constructs built from `math/rand`.
+
+Detection hints:
+- Search for `math/rand`, `rand.Seed`, `rand.Intn` in code that touches auth/session/token flows.
+- Search for custom token generators.
+
+Fix:
+- Switch to `crypto/rand` (`rand.Reader`, `rand.Read`, or secure token helpers).
+- Ensure sufficient entropy and use URL-safe encoding.
+
+Notes:
+- The crypto/rand package provides secure randomness APIs and token generation helpers.
+
+---
+
+### GO-AUTH-001: Password storage MUST use adaptive hashing (bcrypt/argon2id) and safe comparisons
+Severity: High
+
+Required:
+- MUST hash passwords using an adaptive password hashing function (bcrypt or argon2id).
+- MUST NOT store plaintext passwords or reversible encryption of passwords.
+- MUST compare secrets in constant time when relevant (tokens, MACs, API keys) to reduce timing leaks.
+- SHOULD ensure password policies do not exceed algorithm constraints (e.g., bcrypt has input length limits; handle long passphrases appropriately).
+
+Insecure patterns:
+- `sha256(password)` stored as password hash.
+- Plaintext password storage.
+- Comparing secrets with `==` in timing-sensitive contexts.
+
+Detection hints:
+- Search for `sha1`, `sha256`, `md5` used on passwords.
+- Search for `bcrypt`/`argon2` usage; if absent, suspect.
+- Search for `==` comparisons on tokens/API keys.
+
+Fix:
+- Use `bcrypt.GenerateFromPassword` / `CompareHashAndPassword` or argon2id with recommended parameters.
+- Use constant-time compare helpers when comparing MACs/tokens.
+
+Notes:
+- Go provides bcrypt in `golang.org/x/crypto/bcrypt`, and constant-time comparisons in `crypto/subtle`.
+
+---
+
+### GO-CONC-001: Data races and concurrency hazards MUST be treated as security-relevant
+Severity: Medium to High (depends on what races affect)
+
+Required:
+- MUST run tests with the race detector (`go test -race`) in CI for security-sensitive services.
+- MUST fix detected races; do not suppress without deep justification.
+- SHOULD treat shared mutable state in handlers as high risk; enforce synchronization or avoid shared mutability.
+
+Insecure patterns:
+- Global maps/slices mutated from multiple goroutines without a mutex.
+- Caches or auth/session state stored in globals without concurrency protection.
+- Racy access to authorization state (can lead to bypasses or inconsistent enforcement).
+
+Detection hints:
+- Search for `var someMap = map[...]...` used in handlers.
+- Look for missing `sync.Mutex`, `sync.Map`, channels, or other synchronization.
+- Ensure CI includes `-race` and that it runs relevant tests.
+
+Fix:
+- Add proper synchronization or redesign to avoid shared mutable state.
+- Add race tests and run them continuously.
+
+Notes:
+- The Go race detector only finds races that occur in executed code paths; improve test coverage and run realistic workloads with `-race` where feasible.
+
+---
+
+### GO-UNSAFE-001: Use of unsafe/cgo MUST be minimized and audited like memory-unsafe code
+Severity: High (Critical in high-risk code paths)
+
+Required:
+- SHOULD avoid importing `unsafe` in application code unless absolutely necessary.
+- If `unsafe` is used, MUST treat it as “manual memory safety” requiring careful review and test coverage.
+- If `cgo` is used, MUST treat the C/C++ boundary as memory-unsafe; apply secure coding practices on the C side and isolate where possible.
+
+Insecure patterns:
+- Widespread `unsafe.Pointer` casts in parsing, serialization, auth, or network code.
+- `cgo` used for parsing or security boundaries without sandboxing.
+
+Detection hints:
+- Search for `import "unsafe"`, `unsafe.Pointer`, `// #cgo`, `import "C"`.
+- Prioritize review where unsafe touches untrusted input.
+
+Fix:
+- Replace unsafe/cgo usage with safe standard library alternatives where possible.
+- Isolate unsafe code in small, well-tested modules with fuzz/race tests.
+
+Notes:
+- The unsafe package explicitly provides operations that step around Go’s type safety guarantees.
+
+--------------------------------------------------------------------
+
+## 5) Practical scanning heuristics (how to “hunt”)
+
+When actively scanning, use these high-signal patterns:
+
+Toolchain & dependencies:
+- `FROM golang:` (Dockerfiles), `go-version:` (CI), `toolchain go` (go.mod), pinned old versions
+- `GOSUMDB=off`, `GOINSECURE`, `GONOSUMDB`, `GOPROXY=direct`
+- `replace` directives in `go.mod` to forks/paths
+- `govulncheck` missing in CI
+
+HTTP server hardening:
+- `http.ListenAndServe(`, `ListenAndServeTLS(`, `&http.Server{` with missing timeouts
+- `ReadHeaderTimeout: 0`, `ReadTimeout: 0`, `WriteTimeout: 0`, `IdleTimeout: 0`, missing `MaxHeaderBytes`
+
+Body parsing / DoS:
+- `io.ReadAll(r.Body)`, `json.NewDecoder(r.Body)` without size cap
+- `ParseMultipartForm`, `FormFile`, `multipart.NewReader` without explicit limits
+- Missing `http.MaxBytesReader`
+
+Debug exposure:
+- `import _ "net/http/pprof"`
+- `/debug/pprof`, `/debug/vars`
+
+Templates / XSS / SSTI:
+- `text/template` used for HTML output
+- `template.HTML(`, `template.JS(`, `template.URL(` with user-controlled data
+- `.Parse(` on user-controlled strings
+
+Files:
+- `http.ServeFile(` with user path
+- `http.FileServer(http.Dir(` pointing at repo root or uploads
+- `os.Open(filepath.Join(base, user))` without containment checks
+
+Injection:
+- SQL building with `fmt.Sprintf`, string concatenation near `db.Query/Exec`
+- `exec.Command("sh","-c", ...)`, `exec.Command("bash","-c", ...)`
+
+SSRF / outbound HTTP:
+- `http.Get(userURL)`, `client.Do(req)` where URL comes from request/DB
+- Missing client timeout, missing `resp.Body.Close()`, unbounded `io.ReadAll(resp.Body)`
+
+Crypto:
+- `math/rand` in token/session generation
+- `InsecureSkipVerify: true`
+- Password hashing with `sha256`/`md5` instead of bcrypt/argon2
+
+Concurrency:
+- Shared maps/slices mutated from handlers without locks
+- CI lacking `go test -race`
+
+Always try to confirm:
+- data origin (untrusted vs trusted)
+- sink type (template/SQL/subprocess/files/http)
+- protective controls present (limits, validation, allowlists, middleware, network controls)
+
+--------------------------------------------------------------------
+
+## 6) Sources (accessed 2026-01-28)
+
+Primary Go documentation:
+- Go Security Policy — https://go.dev/doc/security/policy
+- Go Release History (security fixes in patch releases) — https://go.dev/doc/devel/release
+- Go 1.25 Release Notes — https://go.dev/doc/go1.25
+- net/http (server timeouts, MaxHeaderBytes, DefaultClient) — https://pkg.go.dev/net/http
+- html/template (auto-escaping and trusted-template assumptions) — https://pkg.go.dev/html/template
+- crypto/tls (MinVersion defaults, InsecureSkipVerify warnings) — https://pkg.go.dev/crypto/tls
+- crypto/rand (secure randomness, token helpers) — https://pkg.go.dev/crypto/rand
+- crypto/subtle (constant-time comparisons) — https://pkg.go.dev/crypto/subtle
+- os/exec (no shell by default; command execution guidance) — https://pkg.go.dev/os/exec
+- unsafe (bypasses type safety) — https://go.dev/src/unsafe/unsafe.go
+- net/http/pprof (debug endpoints) — https://pkg.go.dev/net/http/pprof
+- cmd/go (module authentication via go.sum/checksum DB; env vars like GOINSECURE) — https://pkg.go.dev/cmd/go
+- Module Mirror and Checksum Database Launched (Go blog) — https://go.dev/blog/module-mirror-launch
+- govulncheck documentation — https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
+- Go Race Detector documentation — https://go.dev/doc/articles/race_detector
+- bcrypt (password hashing) — https://pkg.go.dev/golang.org/x/crypto/bcrypt
+- Go vulnerability entry example (multipart resource consumption) — https://pkg.go.dev/vuln/GO-2023-1569
+
+OWASP Cheat Sheet Series (general web security):
+- Session Management — https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+- CSRF Prevention — https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+- SSRF Prevention — https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+- XSS Prevention — https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+- HTTP Security Response Headers — https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html

--- a/.agents/skills/security-review/references/javascript-general-web-frontend-security.md
+++ b/.agents/skills/security-review/references/javascript-general-web-frontend-security.md
@@ -1,0 +1,747 @@
+# Frontend JavaScript/TypeScript Web Security Spec (Vanilla Browser JS/TS, Modern Browsers)
+
+This document is designed as a **security spec** that supports:
+
+1. **Secure-by-default code generation** for new frontend JavaScript/TypeScript (no specific framework assumed).
+2. **Security review / vulnerability hunting** in existing frontend code (passive “notice issues while working” and active “scan the repo and report findings”).
+
+It is intentionally written as a set of **normative requirements** (“MUST/SHOULD/MAY”) plus **audit rules** (what bad patterns look like, how to detect them, and how to fix/mitigate them).
+
+---
+
+## 0) Safety, boundaries, and anti-abuse constraints (MUST FOLLOW)
+
+* MUST NOT request, output, log, hard-code, or commit secrets (API keys intended to be secret, private keys, passwords, OAuth refresh tokens, session tokens, cookies).
+  Notes:
+
+  * Frontend code is inherently observable by end users. If a value must remain secret, it must not be in browser-delivered code.
+  * If the project uses “public” keys (e.g., publishable analytics keys), they MUST be treated as non-secret and scoped accordingly.
+
+* MUST NOT “fix” security by disabling protections (e.g., weakening CSP with `unsafe-inline`/`unsafe-eval` without justification, removing origin checks for `postMessage`, switching to `innerHTML` for convenience, accepting arbitrary redirects/URLs, or turning off sanitization).
+
+* MUST provide **evidence-based findings** during audits: cite file paths, code snippets, and relevant HTML/CSP/config values that justify the claim.
+
+* MUST treat uncertainty honestly:
+
+  * Security headers (CSP, frame-ancestors, etc.) might be set by server/edge/CDN rather than in repo code. If not visible, report as “not visible here; verify at runtime/edge config.” (Also note that `<meta http-equiv=...>` only simulates a subset of headers; don’t assume other security headers exist just because a meta tag exists.) ([MDN Web Docs][1])
+
+---
+
+## 1) Operating modes
+
+### 1.1 Generation mode (default)
+
+When asked to write new frontend JS/TS code or modify existing code:
+
+* MUST follow every **MUST** requirement in this spec.
+* SHOULD follow every **SHOULD** requirement unless the user explicitly says otherwise.
+* MUST prefer safe-by-default browser APIs and proven libraries over custom security code (especially for HTML sanitization).
+* MUST avoid introducing new risky sinks (DOM XSS injection sinks like `innerHTML`, navigation to `javascript:` URLs, dynamic code execution via `eval`/`Function`, unsafe `postMessage`, unsafe third-party script loading, etc.). ([OWASP Cheat Sheet Series][2])
+
+### 1.2 Passive review mode (always on while editing)
+
+While working anywhere in a frontend repo (even if the user did not ask for a security scan):
+
+* MUST “notice” violations of this spec in touched/nearby code.
+* SHOULD mention issues as they come up, with a brief explanation + safe fix.
+
+### 1.3 Active audit mode (explicit scan request)
+
+When the user asks to “scan”, “audit”, or “hunt for vulns”:
+
+* MUST systematically search the codebase for violations of this spec.
+* MUST output findings in a structured format (see §2.3).
+
+Recommended audit order:
+
+1. HTML entrypoints (`index.html`, server-rendered templates), script/style includes, and any CSP delivery (header vs meta). ([W3C][3])
+2. DOM XSS sinks (`innerHTML`, `document.write`, `insertAdjacentHTML`, event-handler attributes) and their data sources (URL params/hash, storage, postMessage, API responses). ([OWASP Cheat Sheet Series][2])
+3. Navigation/redirect handling (`window.location*`, link targets, URL allowlists) including `javascript:` URL hazards. ([MDN Web Docs][4])
+4. Cross-origin communication (`postMessage`, iframe embed patterns, sandboxing). ([MDN Web Docs][5])
+5. Storage of sensitive data (localStorage/sessionStorage) and assumptions about trust. ([OWASP Cheat Sheet Series][6])
+6. Third-party scripts / tag managers / CDNs, and integrity controls (SRI) and policy controls (CSP). ([OWASP Cheat Sheet Series][7])
+7. DOM clobbering gadgets and unsafe reliance on `window`/`document` named properties. ([OWASP Cheat Sheet Series][8])
+
+---
+
+## 2) Definitions and review guidance
+
+### 2.1 Untrusted input (treat as attacker-controlled unless proven otherwise)
+
+Examples include:
+
+* URL-derived data: `location.href`, `location.search`, `location.hash`, `document.baseURI`, `new URLSearchParams(location.search)`, routing fragments. ([OWASP Cheat Sheet Series][2])
+* DOM content that may include user-controlled markup (comments, profiles, CMS content, markdown-to-HTML output, etc.), especially if inserted dynamically. ([OWASP Cheat Sheet Series][2])
+* `postMessage` event data (`event.data`) and metadata (`event.origin`) from other windows/frames. ([MDN Web Docs][5])
+* Browser storage: `localStorage`, `sessionStorage`, IndexedDB (contents can be attacker-influenced via XSS or local machine access; never treat as “trusted”). ([OWASP Cheat Sheet Series][6])
+* Any data returned from network calls (even if from “your API”), because it may contain stored attacker content that becomes dangerous only when inserted into the DOM. ([OWASP Cheat Sheet Series][2])
+
+### 2.2 Dangerous sink (DOM XSS / code execution sink)
+
+A sink is any API/operation that can execute script or interpret attacker-controlled strings as HTML/JS/URL in a security-sensitive way. High-signal sinks include:
+
+* HTML parsing / insertion: `innerHTML`, `outerHTML`, `insertAdjacentHTML`, `document.write`, `document.writeln`. ([OWASP Cheat Sheet Series][2])
+* Dynamic code execution: `eval`, `new Function`, `setTimeout("...")`, `setInterval("...")`. ([MDN Web Docs][10])
+* Navigation to script-bearing URLs (e.g., `javascript:`) via setters like `Location.href`/`window.location` (and via link `href` if attacker-controlled). ([MDN Web Docs][4])
+* Setting event handler attributes from strings, e.g. `setAttribute("onclick", "...")`. ([OWASP Cheat Sheet Series][2])
+
+### 2.3 Required audit finding format
+
+For each issue found, output:
+
+* Rule ID:
+* Severity: Critical / High / Medium / Low
+* Location: file path + function/class/module + line(s)
+* Evidence: the exact code/config snippet
+* Impact: what could go wrong, who can exploit it
+* Fix: safe change (prefer minimal diff)
+* Mitigation: defense-in-depth if immediate fix is hard
+* False positive notes: what to verify if uncertain
+
+---
+
+## 3) Secure baseline: minimum production configuration (MUST in production)
+
+This is the smallest baseline that prevents common frontend JS/TS security misconfigurations. Some items are “in repo” (HTML/JS) and some may live at the server/edge.
+
+### 3.1 Content Security Policy (CSP) baseline (SHOULD; MUST for high-risk apps)
+
+* SHOULD deliver CSP via HTTP response headers when possible.
+* MAY deliver CSP via an HTML `<meta http-equiv="Content-Security-Policy" ...>` tag when you cannot set headers (e.g., purely static hosting constraints). ([MDN Web Docs][1])
+* If using CSP via `<meta http-equiv>`, MUST understand the limitations:
+
+  * The policy only applies to content that follows the meta element (so it must appear very early, before any scripts/resources you want governed). ([W3C][3])
+  * The following directives are **not supported** in a meta-delivered policy and will be ignored: `report-uri`, `frame-ancestors`, and `sandbox`. ([W3C][3])
+  * “Report-only” CSP cannot be set via a meta element. ([W3C][3])
+
+Practical baseline goals:
+
+* Avoid script sources `unsafe-inline` and `unsafe-eval` (they significantly weaken CSP’s value against XSS). ([MDN Web Docs][10])
+* Prefer nonce- or hash-based script policies if you need inline scripts. ([MDN Web Docs][10])
+* Consider enabling Trusted Types enforcement where feasible. ([MDN Web Docs][11])
+
+### 3.2 Third-party scripts baseline (SHOULD)
+
+* SHOULD minimize third-party script execution and treat it as equivalent privilege to first-party JS (it runs with your origin’s privileges). ([OWASP Cheat Sheet Series][7])
+* SHOULD use Subresource Integrity (SRI) for third-party scripts/styles loaded from CDNs. ([MDN Web Docs][12])
+
+### 3.3 Cross-window communication baseline (SHOULD)
+
+* SHOULD restrict `postMessage` communications to explicit origins, and validate both origin and message shape. ([MDN Web Docs][5])
+
+---
+
+## 4) Rules (generation + audit)
+
+Each rule contains: required practice, insecure patterns, detection hints, and remediation.
+
+### JS-XSS-001: Do not inject untrusted HTML into the DOM (avoid `innerHTML` and friends)
+
+Severity: Critical if you can prove attacker-controlled input can reach these APIs; otherwise Medium
+
+
+Required:
+
+* MUST treat `innerHTML`, `outerHTML`, and `insertAdjacentHTML` as dangerous sinks when their input can contain untrusted data. ([OWASP Cheat Sheet Series][2])
+* MUST prefer safe DOM APIs that do not parse HTML:
+
+  * `textContent` for text. ([OWASP Cheat Sheet Series][2])
+  * `document.createElement`, `appendChild`, `setAttribute` for non-event-handler attributes. ([OWASP Cheat Sheet Series][2])
+* If HTML insertion is truly required, SHOULD sanitize with a well-reviewed HTML sanitizer and strongly consider enforcing Trusted Types to confine usage to audited code paths. ([MDN Web Docs][11])
+
+Insecure patterns:
+
+* `el.innerHTML = userInput`
+* `el.insertAdjacentHTML('beforeend', userInput)`
+* `el.outerHTML = userInput`
+
+Detection hints:
+
+* Search for: `.innerHTML`, `.outerHTML`, `insertAdjacentHTML(`.
+* Trace the origin of inserted string: URL params/hash, postMessage, storage, API responses, DOM attributes. ([OWASP Cheat Sheet Series][2])
+
+Fix:
+
+* Replace with `textContent` for plain text. ([OWASP Cheat Sheet Series][2])
+* For structured UI, build DOM nodes explicitly.
+* For “rich text” requirements:
+
+  * Sanitize using an allowlist-based sanitizer.
+  * Prefer returning safe “components” instead of arbitrary HTML strings.
+  * Use Trusted Types enforcement to ensure only `TrustedHTML` reaches sinks where supported. ([MDN Web Docs][11])
+
+Mitigation:
+
+* Deploy a strict CSP and consider Trusted Types enforcement (`require-trusted-types-for 'script'`). ([MDN Web Docs][10])
+
+False positive notes:
+
+* If the string is provably constant or fully generated from trusted constants, it may be safe. Still prefer safer APIs.
+
+---
+
+### JS-XSS-002: Avoid `document.write` / `document.writeln` (XSS + document clobbering hazards)
+
+Severity: Critical if you can prove attacker-controlled input can reach these APIs; otherwise Medium 
+
+Required:
+
+* MUST avoid `document.write()` and `document.writeln()` in production code (they are XSS vectors and can be abused with crafted HTML even if some browsers block injected `<script>` in certain situations). ([MDN Web Docs][13])
+* If legacy use is unavoidable, MUST ensure no untrusted input reaches these APIs and SHOULD enforce Trusted Types (`TrustedHTML`) where supported. ([MDN Web Docs][14])
+
+Insecure patterns:
+
+* `document.write(userInput)`
+* `document.writeln(getParam('q'))`
+
+Detection hints:
+
+* Search for `document.write(`, `document.writeln(`. ([OWASP Cheat Sheet Series][2])
+
+Fix:
+
+* Replace with DOM manipulation (`createElement`, `appendChild`) or safe text insertion (`textContent`). ([OWASP Cheat Sheet Series][2])
+
+Mitigation:
+
+* Strict CSP + Trusted Types enforcement reduces blast radius if a sink remains. ([MDN Web Docs][10])
+
+---
+
+### JS-XSS-003: Do not use string-to-code execution (`eval`, `new Function`, string timeouts)
+
+Severity: Critical if you can prove attacker-controlled input can reach these APIs; otherwise Medium
+
+Required:
+
+* MUST NOT pass untrusted data to:
+
+  * `eval()`
+  * `new Function(...)`
+  * `setTimeout("...")` / `setInterval("...")` with string arguments ([MDN Web Docs][10])
+* SHOULD avoid these APIs entirely in modern frontend code; refactor to non-eval logic. ([MDN Web Docs][10])
+* MUST NOT “fix CSP breakage” by adding `unsafe-eval` unless there is a documented, reviewed justification and compensating controls. ([MDN Web Docs][10])
+
+Insecure patterns:
+
+* `eval(userInput)`
+* `new Function("return " + userInput)()`
+* `setTimeout(userInput, 0)` where userInput is a string
+
+Detection hints:
+
+* Search for `eval(`, `new Function`, `setTimeout("`, `setInterval("`.
+* Also search for construction of code strings used later.
+
+Fix:
+
+* Replace dynamic code with:
+
+  * structured data + explicit branching/handlers,
+  * JSON parsing (`JSON.parse`) instead of `eval` for JSON. ([OWASP Cheat Sheet Series][2])
+
+Mitigation:
+
+* CSP that blocks `eval()`-like APIs by default, and avoid `unsafe-eval`. ([MDN Web Docs][10])
+* Consider Trusted Types for controlled cases, but treat it as a hardening layer, not a license to keep eval patterns. ([MDN Web Docs][10])
+
+---
+
+### JS-XSS-004: Do not set event handler attributes from strings (e.g., `setAttribute("onclick", "...")`)
+
+Severity: High
+
+Required:
+
+* MUST NOT use `setAttribute("on…", string)` or similar patterns with untrusted data; this coerces strings into executable code in the event-handler context. ([OWASP Cheat Sheet Series][2])
+* SHOULD prefer `addEventListener` with function references.
+
+Insecure patterns:
+
+* `el.setAttribute("onclick", userInput)`
+* `el.onclick = userControlledString` (string assignment)
+
+Detection hints:
+
+* Search for `.setAttribute("on`, `.onclick =`, `.onmouseover =`, etc.
+* Trace whether RHS can be influenced by URL/hash/storage/postMessage. ([OWASP Cheat Sheet Series][2])
+
+Fix:
+
+* Replace with `addEventListener("click", () => { ... })`.
+* If dynamic dispatch is needed, use an allowlisted mapping from identifiers to functions (no string eval). ([OWASP Cheat Sheet Series][2])
+
+---
+
+### JS-URL-001: Sanitize and allowlist URLs before navigation (especially `window.location` / `location.replace`)
+
+Severity: Low (High if you can prove an attacker can fully control the URL)
+
+IMPORTANT: This can cause a lot of false positives. Please perform extra analysis to determine if the url is fully attacker controlled. If not fully attacker controlled, then this is informational at best.
+
+NOTE: It may be important functionality to be able to redirect to any given url. If that is the goal of the feature, then at a minimum, ensure it checks the schema even if the origin is allowed to be anything.
+
+Required:
+
+* MUST treat any assignment to navigation targets as security-sensitive:
+
+  * `window.location = ...`
+  * `location.href = ...`
+  * `location.assign(...)`
+  * `location.replace(...)` ([MDN Web Docs][4])
+* MUST prevent navigation to `javascript:` URLs (and generally other script-bearing/active schemes), especially when input is derived from URL params, storage, or messages. ([MDN Web Docs][4]). Only allow `http:` and `https:`.
+* SHOULD validate/allowlist the destination. A safe baseline is:
+
+  * Allow only same-origin relative paths, OR
+  * Allow only a strict allowlist of origins and protocols (typically `https:` and optionally `http:` for localhost dev). ([OWASP Cheat Sheet Series][8])
+
+Insecure patterns:
+
+* `location.replace(getParam("next"))`
+* `window.location = userSuppliedUrl`
+* `location.assign(window.redirectTo || "/")` where `redirectTo` can be clobbered or attacker-set ([OWASP Cheat Sheet Series][8])
+
+Detection hints:
+
+* Search for `window.location`, `location.href`, `location.assign`, `location.replace`.
+* Search for common redirect parameters: `next`, `returnTo`, `redirect`, `url`, `continue`.
+* Search for `javascript:` literal usage. ([MDN Web Docs][4])
+
+Fix:
+
+* Parse and validate with `new URL(value, location.origin)` and then enforce:
+
+  * `url.protocol` in `{ "https:" }` (and only include `http:` in explicit dev-only code paths),
+  * `url.origin` equals `location.origin` for internal redirects, or in a strict allowlist for external redirects,
+  * optionally allow only specific path prefixes. ([MDN Web Docs][4])
+* If validation fails, navigate to a safe default (home/dashboard).
+
+Mitigation:
+
+* Deploy strict CSP and Trusted Types enforcement to reduce the impact of DOM XSS sinks, but note that Trusted Types do not prevent every possible unsafe navigation scenario on their own. ([W3C][15])
+
+False positive notes:
+
+IMPORTANT: This can cause a lot of false positives. Please perform extra analysis to determine if the url is fully attacker controlled. If not fully attacker controlled, then this is informational at best.
+
+* Some apps intentionally support external redirects (SSO, payment flows). Those MUST be allowlisted and documented.
+
+---
+
+### JS-URL-002: Sanitize URLs before inserting into DOM URL contexts (`href`, `src`, etc.)
+
+Severity: Low (High if you can prove an attacker can fully control the URL)
+
+IMPORTANT: This can cause a lot of false positives. Please perform extra analysis to determine if the url is fully attacker controlled. If not fully attacker controlled, then this is informational at best.
+
+Required:
+
+* MUST treat setting URL-bearing DOM attributes/properties as security-sensitive, especially:
+
+  * `a.href`, `img.src`, `script.src`, `iframe.src`, `form.action`, `link.href`.
+* MUST prevent script-bearing schemes (`javascript:` and other active schemes) when values can be attacker-influenced. ([MDN Web Docs][4])
+* SHOULD prefer setting properties (e.g., `a.href = url.toString()`) after parsing and validation, rather than string concatenation.
+
+Insecure patterns:
+
+* `link.href = getParam("u")`
+* `el.setAttribute("href", userInput)` without validation
+* constructing URLs via concatenation with untrusted pieces
+
+Detection hints:
+
+* Search for `.href =`, `.src =`, `.action =`, `setAttribute("href"`, `setAttribute("src"`.
+* Search for `javascript:` / `data:` usage in URLs. ([MDN Web Docs][4])
+
+IMPORTANT: This can cause a lot of false positives. Please perform extra analysis to determine if the url is fully attacker controlled. If not fully attacker controlled, then this is informational at best.
+
+Fix:
+
+* Use `new URL(...)` and validate:
+
+  * protocol allowlist
+  * avoid passing user-provided values into `<script src>` at all (treat as code execution). ([OWASP Cheat Sheet Series][8])
+
+---
+
+### JS-CSP-001: Use CSP; meta delivery is allowed
+
+Severity: Medium to High (depends on threat model; High when handling untrusted content)
+
+NOTE: It is most important to set the CSP's script-src. All other directives are not as important and can generally be excluded for the ease of development.
+
+Required:
+
+* SHOULD deploy a CSP as a major defense-in-depth against XSS. ([MDN Web Docs][10])
+* MAY provide CSP via `<meta http-equiv="Content-Security-Policy" ...>` when headers are not available. ([MDN Web Docs][1])
+* If CSP is delivered via meta, MUST:
+
+  * place it early (before scripts/resources you want governed), and
+  * not rely on unsupported directives in meta policies (`report-uri`, `frame-ancestors`, `sandbox`). ([W3C][3])
+* MUST avoid adding `unsafe-inline` as a “quick fix” for CSP issues unless explicitly required and reviewed (it defeats much of CSP’s purpose). ([MDN Web Docs][10])
+* MUST avoid adding `unsafe-eval` unless explicitly required and reviewed (it allows eval-like APIs that are commonly abused). ([MDN Web Docs][10])
+
+Insecure patterns:
+
+* No CSP present anywhere (repo HTML or server/edge) for an app that renders untrusted content.
+* CSP includes `script-src 'unsafe-inline'` and/or `script-src 'unsafe-eval'` without strong justification. ([MDN Web Docs][10])
+* CSP delivered via meta but includes `frame-ancestors` (it will be ignored in meta). ([W3C][3])
+
+Detection hints:
+
+* Search HTML for `<meta http-equiv="Content-Security-Policy"`.
+* Search server/edge configs for `Content-Security-Policy` header.
+* If CSP is only in meta, check it appears before any `<script>` tags you want governed. ([W3C][3])
+
+Fix:
+
+* Prefer header-delivered CSP at the server/edge.
+* If constrained to meta, keep a strong allowlist CSP and document the limitations; implement clickjacking protections (e.g., `frame-ancestors`) at the server/edge, not in meta. ([W3C][3])
+
+---
+
+### JS-CSP-002: Prefer strict CSP (nonces/hashes); avoid inline/eval patterns in code
+
+Severity: Medium
+
+NOTE: It is most important to set the CSP's script-src. All other directives are not as important and can generally be excluded for the ease of development.
+
+Required:
+
+* SHOULD design frontend code to work under a strict CSP:
+
+  * avoid inline scripts and inline event handlers,
+  * avoid eval-like APIs (see JS-XSS-003),
+  * allow scripts via nonce or hash when needed. ([MDN Web Docs][10])
+
+Insecure patterns:
+
+* Large amounts of inline script blocks and inline `onclick="..."` handlers.
+* Libraries that require `unsafe-eval`.
+
+Detection hints:
+
+* Search for `<script>` blocks with inline code, `onclick="`, `onload="`, etc.
+* Search for CSP directives containing `unsafe-inline` or `unsafe-eval`. ([MDN Web Docs][10])
+
+Fix:
+
+* Move inline scripts into external JS files (same-origin).
+* Use nonces/hashes for any unavoidable inline blocks. ([MDN Web Docs][10])
+
+---
+
+### JS-TT-001: Use Trusted Types to reduce DOM XSS attack surface (where supported)
+
+Severity: Low
+
+Required:
+
+* SHOULD consider enabling Trusted Types enforcement with CSP `require-trusted-types-for 'script'` to make many DOM XSS sinks reject raw strings. ([MDN Web Docs][11])
+* If using Trusted Types, SHOULD also use the CSP `trusted-types` directive to restrict which policies can be created (reduces policy sprawl and improves auditability). ([MDN Web Docs][16])
+* MUST keep Trusted Types policy code small, heavily reviewed, and used as the only path to produce trusted values for sinks. ([W3C][15])
+
+Insecure patterns:
+
+* “Trusted Types enabled” but policy simply returns input unchanged (no sanitization/validation).
+* Many ad-hoc policies created across the codebase without restriction.
+* Belief that Trusted Types alone prevents all unsafe navigations or all XSS classes. (It targets DOM injection sinks; it is not a universal sandbox.) ([W3C][15])
+
+Detection hints:
+
+* Search for CSP directives: `require-trusted-types-for` and `trusted-types`.
+* Search code for `trustedTypes.createPolicy(` and inspect policy implementations. ([MDN Web Docs][11])
+
+Fix:
+
+* Add a small set of well-reviewed policies (e.g., `createHTML` that sanitizes).
+* Restrict allowed policies via `trusted-types <policyName...>`.
+* Migrate sinks to require `TrustedHTML` / `TrustedScriptURL` as appropriate. ([MDN Web Docs][11])
+
+---
+
+### JS-MSG-001: `postMessage` must use strict origin validation and explicit targetOrigin
+
+Severity: Medium (High if dangerous behavior can be triggered via postMessage)
+
+Required:
+
+* When sending messages, MUST set an explicit `targetOrigin` (not `*`) to avoid sending data to an unexpected origin after redirects or window origin changes. ([MDN Web Docs][5])
+* When receiving messages, MUST:
+
+  * Validate `event.origin` exactly against an allowlist of expected origins (no substring matching). ([OWASP Cheat Sheet Series][6])
+  * Consider validating `event.source` (expected window reference) when applicable. ([MDN Web Docs][5])
+  * Validate `event.data` structure (schema/shape) and treat it purely as data (never evaluate it as code and never insert into DOM with `innerHTML`). ([OWASP Cheat Sheet Series][6])
+
+Insecure patterns:
+
+* `otherWindow.postMessage(payload, "*")`
+* `window.addEventListener("message", (e) => { doSomething(e.data) })` with no `origin` check
+* `if (e.origin.includes("trusted.com"))` (substring checks)
+* `el.innerHTML = e.data` ([OWASP Cheat Sheet Series][6])
+
+Detection hints:
+
+* Search for `postMessage(`, `addEventListener("message"`, `onmessage =`.
+* Audit all handlers for explicit allowlist checks on `event.origin`. ([OWASP Cheat Sheet Series][6])
+
+Fix:
+
+* Define an allowlist:
+
+  * `const ALLOWED = new Set(["https://app.example.com", "https://accounts.example.com"]);`
+  NOTE: For ease of development, you can use the current page's origin `window.location.origin` as a safe default origin.
+* On receive:
+
+  * `if (!ALLOWED.has(event.origin)) return;`
+  * Validate `event.data` with a strict schema and reject unknown/extra fields.
+* On send:
+
+  * use the exact expected origin string as `targetOrigin`. ([OWASP Cheat Sheet Series][6])
+
+Mitigation:
+
+* Combine with a strict CSP and avoid DOM sinks in message paths. ([MDN Web Docs][10])
+
+---
+
+### JS-STORAGE-001: Web Storage is not a safe place for secrets (and is attacker-influencable)
+
+Severity: Low
+
+Required:
+
+* MUST NOT store sensitive secrets or session identifiers in `localStorage` (or `sessionStorage`) if compromise would matter; a single XSS can exfiltrate everything in storage. ([OWASP Cheat Sheet Series][6])
+* MUST treat values read from storage as untrusted input (attackers can load malicious values into storage via XSS). ([OWASP Cheat Sheet Series][6])
+* SHOULD prefer server-set cookies with `HttpOnly` for session identifiers (JS cannot set `HttpOnly`, so avoid storing session IDs in JS-accessible storage). ([OWASP Cheat Sheet Series][6])
+* SHOULD avoid hosting multiple unrelated apps on the same origin if they rely on storage separation (storage is origin-wide). ([OWASP Cheat Sheet Series][6])
+
+Insecure patterns:
+
+* `localStorage.setItem("access_token", token)`
+* `localStorage.setItem("session", sessionId)`
+* Assuming `localStorage` is “trusted because same-origin.”
+
+Detection hints:
+
+* Search for `localStorage.getItem`, `localStorage.setItem`, `sessionStorage.*`.
+* Flag storage keys named `token`, `jwt`, `session`, `auth`, `refresh`. ([OWASP Cheat Sheet Series][6])
+
+Fix:
+
+* Use server-managed sessions or short-lived tokens delivered and rotated securely, with careful XSS defenses (CSP/Trusted Types) and minimal JS exposure.
+* If storage must be used for non-sensitive state, keep it non-auth and validate/escape before use.
+
+---
+
+### JS-SUPPLY-001: Third-party JavaScript is a major supply-chain risk; minimize and control it
+
+Severity: Low
+
+Required:
+
+* MUST treat third-party JS as equivalent to first-party JS in privilege (it can execute arbitrary code in your origin and access DOM data). ([OWASP Cheat Sheet Series][7])
+* SHOULD minimize third-party scripts and prefer:
+
+  * self-hosting / script mirroring,
+  * strict CSP allowlists,
+  * SRI for any CDN-hosted scripts,
+  * ongoing monitoring for unexpected changes. ([OWASP Cheat Sheet Series][7])
+
+Insecure patterns:
+
+* Loading arbitrary remote scripts from many vendors without review.
+* Using tag managers that can dynamically inject scripts with no integrity controls.
+* Allowing scripts from broad wildcards in CSP (e.g., `script-src *`). ([MDN Web Docs][10])
+
+Detection hints:
+
+* Search HTML for `<script src="https://...">` and `tag manager` snippets.
+* Search CSP `script-src` sources for wildcards or overly broad domains.
+* Search for dynamic script injection: `document.createElement("script")`, `script.src = ...`, `appendChild(script)`. ([OWASP Cheat Sheet Series][8])
+
+Fix:
+
+* Remove unnecessary third-party tags.
+* Self-host or mirror scripts where possible.
+* Lock down CSP `script-src` to the smallest set of trusted sources.
+* Add SRI for CDN scripts/styles. ([OWASP Cheat Sheet Series][7])
+
+---
+
+### JS-SRI-001: Use Subresource Integrity (SRI) for third-party scripts/styles
+
+Severity: Low
+
+Required:
+
+* SHOULD use SRI to ensure browsers only load third-party resources if they match an expected cryptographic hash. ([MDN Web Docs][12])
+* MUST update SRI hashes whenever the underlying resource changes (pin versions; avoid “latest” URLs).
+
+Insecure patterns:
+
+* `<script src="https://cdn.example.com/lib.js"></script>` with no `integrity`.
+* Loading `latest` or unpinned third-party resources.
+
+Detection hints:
+
+* Search for `<script src="https://` and `<link rel="stylesheet" href="https://` without `integrity=`.
+* Check whether `integrity` is present and uses strong hashes (sha256/384/512 are typical). ([MDN Web Docs][12])
+
+Fix:
+
+* Add `integrity="sha384-..."` (or appropriate) and ensure proper CORS mode where needed.
+* Prefer self-hosting critical libraries.
+
+---
+
+### FS-DOMC-001: Prevent DOM clobbering (avoid relying on `window`/`document` named properties)
+
+Severity: Medium to High (can become Critical if it enables script loading or `javascript:` navigation)
+
+Required:
+
+* MUST NOT rely on implicit global variables or `window.someName` / `document.someName` lookups that can be clobbered by injected HTML elements with matching `id`/`name`. ([OWASP Cheat Sheet Series][8])
+* MUST avoid patterns like `let x = window.redirectTo || "/safe"; location.assign(x);` where `redirectTo` could be clobbered to an `<a>` element whose `href` is attacker-controlled (including `javascript:`). ([OWASP Cheat Sheet Series][8])
+* SHOULD use explicit variable declarations, local scope, and explicit DOM queries (`getElementById`) rather than named property access. ([OWASP Cheat Sheet Series][8])
+* If the app inserts user-controlled markup (even sanitized), SHOULD ensure sanitization strategies consider `id`/`name` collisions. ([OWASP Cheat Sheet Series][8])
+
+Insecure patterns:
+
+* `const cfg = window.config || {};` used for security-sensitive URLs.
+* `const redirect = window.redirectTo || "/"; location.assign(redirect);` ([OWASP Cheat Sheet Series][8])
+* Loading scripts from `window.*` config values without strict validation.
+
+Detection hints:
+
+* Search for `window.` and `document.` used as config stores (especially `||` fallback patterns).
+* Search for usage of `location.assign/replace` with variables that come from `window`/`document` properties.
+* Search for dynamic script creation (`createElement('script')`) where `.src` comes from a non-local variable. ([OWASP Cheat Sheet Series][8])
+
+Fix:
+
+* Store config in module-scoped constants (not on `window`/`document`) and pass it explicitly.
+* Validate any URL-like config with protocol/origin allowlists (see FEJS-URL-001). ([OWASP Cheat Sheet Series][8])
+* Consider hardening: sanitization, CSP, and (in limited cases) freezing sensitive objects, but treat these as defense-in-depth, not a substitute for safe coding patterns. ([OWASP Cheat Sheet Series][8])
+
+---
+
+## 5) Practical scanning heuristics (how to “hunt”)
+
+When actively scanning, use these high-signal patterns:
+
+* DOM XSS sinks:
+
+  * `.innerHTML`, `.outerHTML`, `insertAdjacentHTML(`
+  * `document.write(`, `document.writeln(` ([OWASP Cheat Sheet Series][2])
+
+* Dangerous navigation / URL sinks:
+
+  * `window.location`, `location.href`, `location.assign`, `location.replace`
+  * `javascript:` literals (and other suspicious schemes like `data:text/html`) ([MDN Web Docs][4])
+
+* String-to-code execution:
+
+  * `eval(`, `new Function`, `setTimeout("`, `setInterval("` ([MDN Web Docs][10])
+
+* Event-handler string injection:
+
+  * `.setAttribute("on`, `.onclick =`, `.onload =` with strings ([OWASP Cheat Sheet Series][2])
+
+* `postMessage`:
+
+  * `postMessage(` with `"*"` as targetOrigin
+  * `addEventListener("message"` without strict `event.origin` allowlist checks ([MDN Web Docs][5])
+
+* Storage:
+
+  * `localStorage.setItem(` / `getItem(`, `sessionStorage.*`
+  * keys containing `token`, `jwt`, `session`, `auth`, `refresh` ([OWASP Cheat Sheet Series][6])
+
+* CSP and related:
+
+  * `Content-Security-Policy` header config (server/edge)
+  * `<meta http-equiv="Content-Security-Policy" ...>`
+  * CSP containing `unsafe-inline` or `unsafe-eval`
+  * `require-trusted-types-for` / `trusted-types` directives ([MDN Web Docs][1])
+
+* Third-party scripts:
+
+  * `<script src="https://...">` without `integrity=`
+  * Tag manager snippets and dynamic script injection code paths ([MDN Web Docs][12])
+
+
+* DOM clobbering gadgets:
+
+  * `window.<name> || ...` and `document.<name> || ...` patterns
+  * security-sensitive usage of `window`/`document` properties as config sources ([OWASP Cheat Sheet Series][8])
+
+Always try to confirm:
+
+* data origin (untrusted vs trusted),
+* sink type (HTML parse, navigation, code execution, message handling, storage),
+* protective controls present (CSP, Trusted Types, sanitizers, strict allowlists, schema validation).
+
+---
+
+## 6) Sources (accessed 2026-01-27)
+
+Primary standards / platform docs:
+
+* W3C Content Security Policy Level 2 (HTML `<meta>` delivery restrictions; unsupported directives in meta CSP): `https://www.w3.org/TR/CSP2/` ([W3C][3])
+* MDN: CSP Guide (strict CSP, nonces/hashes, `unsafe-inline`/`unsafe-eval`, eval blocking): `https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP` ([MDN Web Docs][10])
+* MDN: `<meta http-equiv>` (CSP via meta and warning about meta-based security headers): `https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/http-equiv` ([MDN Web Docs][1])
+* MDN: `frame-ancestors` (and note it’s not supported in `<meta>`): `https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors` ([MDN Web Docs][18])
+
+DOM XSS and dangerous sinks:
+
+* OWASP: DOM Based XSS Prevention Cheat Sheet (dangerous sinks + safe patterns like `textContent`): `https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html` ([OWASP Cheat Sheet Series][2])
+* MDN: `innerHTML` (security considerations): `https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML` ([MDN Web Docs][19])
+* MDN: `insertAdjacentHTML` (security considerations): `https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML` ([MDN Web Docs][20])
+* MDN: `document.write()` / `document.writeln()` (security considerations): `https://developer.mozilla.org/en-US/docs/Web/API/Document/write` and `https://developer.mozilla.org/en-US/docs/Web/API/Document/writeln` ([MDN Web Docs][13])
+
+URL scheme hazards:
+
+* MDN: `javascript:` URLs (execution on navigation; discouraged; references `window.location`): `https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/javascript` ([MDN Web Docs][4])
+
+Trusted Types:
+
+* W3C: Trusted Types spec (DOM XSS sinks include `Element.innerHTML` and `Location.href` setters; goals and limitations): `https://www.w3.org/TR/trusted-types/` ([W3C][15])
+* MDN: `require-trusted-types-for` directive: `https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for` ([MDN Web Docs][11])
+* MDN: `trusted-types` directive: `https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/trusted-types` ([MDN Web Docs][16])
+
+Cross-window messaging:
+
+* MDN: `window.postMessage` (security guidance: specify targetOrigin; validate origin): `https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage` ([MDN Web Docs][5])
+* OWASP: HTML5 Security Cheat Sheet (Web Messaging guidance: explicit origin, strict checks, no `innerHTML`): `https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html` ([OWASP Cheat Sheet Series][6])
+
+Third-party scripts and integrity:
+
+* OWASP: Third Party JavaScript Management Cheat Sheet (risks and mitigations including SRI/mirroring): `https://cheatsheetseries.owasp.org/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html` ([OWASP Cheat Sheet Series][7])
+* MDN: Subresource Integrity overview: `https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity` ([MDN Web Docs][12])
+* W3C: Subresource Integrity spec: `https://www.w3.org/TR/sri-2/` ([W3C][21])
+
+DOM clobbering:
+
+* OWASP: DOM Clobbering Prevention Cheat Sheet (named property access risk; example attacks involving `location.assign` and `javascript:`): `https://cheatsheetseries.owasp.org/cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.html` ([OWASP Cheat Sheet Series][8])
+
+[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/http-equiv "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/http-equiv"
+[2]: https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html "https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html"
+[3]: https://www.w3.org/TR/CSP2/ "Content Security Policy Level 2"
+[4]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/javascript "javascript: URLs - URIs | MDN"
+[5]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage "https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage"
+[6]: https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html "https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html"
+[7]: https://cheatsheetseries.owasp.org/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html "https://cheatsheetseries.owasp.org/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html"
+[8]: https://cheatsheetseries.owasp.org/cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.html "https://cheatsheetseries.owasp.org/cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.html"
+[9]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noopener "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noopener"
+[10]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP "https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP"
+[11]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for"
+[12]: https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity "https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity"
+[13]: https://developer.mozilla.org/en-US/docs/Web/API/Document/write "https://developer.mozilla.org/en-US/docs/Web/API/Document/write"
+[14]: https://developer.mozilla.org/en-US/docs/Web/API/Document/writeln "https://developer.mozilla.org/en-US/docs/Web/API/Document/writeln"
+[15]: https://www.w3.org/TR/trusted-types/ "https://www.w3.org/TR/trusted-types/"
+[16]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/trusted-types "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/trusted-types"
+[18]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors"
+[19]: https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML "https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML"
+[20]: https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML "https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML"
+[21]: https://www.w3.org/TR/sri-2/ "https://www.w3.org/TR/sri-2/"

--- a/.agents/skills/security-review/references/javascript-jquery-web-frontend-security.md
+++ b/.agents/skills/security-review/references/javascript-jquery-web-frontend-security.md
@@ -1,0 +1,678 @@
+# jQuery Frontend Security Spec (jQuery 4.0.x, modern browsers)
+
+This document is designed as a **security spec** that supports:
+
+1. **Secure-by-default code generation** for new jQuery-based frontend code.
+2. **Security review / vulnerability hunting** in existing jQuery-based code (passive “notice issues while working” and active “scan the repo and report findings”).
+
+It is intentionally written as a set of **normative requirements** (“MUST/SHOULD/MAY”) plus **audit rules** (what bad patterns look like, how to detect them, and how to fix/mitigate them).
+
+---
+
+## 0) Safety, boundaries, and anti-abuse constraints (MUST FOLLOW)
+
+* MUST NOT request, output, log, or commit secrets (API keys, passwords, private keys, session tokens, refresh tokens, CSRF tokens, session cookies).
+* MUST treat the browser as an attacker-controlled environment:
+
+  * Frontend checks (UI gating, “disable button”, hidden fields, client-side validation) MUST NOT be treated as authorization or a security boundary.
+  * Server-side authorization and validation MUST exist even if frontend is “correct”.
+* MUST NOT “fix” security by disabling protections (e.g., relaxing CSP to allow `unsafe-inline`, enabling JSONP “because it works”, adding broad CORS, disabling sanitization, suppressing security checks).
+* MUST provide evidence-based findings during audits: cite file paths, code snippets, and relevant configuration values.
+* MUST treat uncertainty honestly: if a protection might exist at the edge (CDN/WAF/reverse proxy headers like CSP), report it as “not visible in repo; verify at runtime/config”.
+
+---
+
+## 1) Operating modes
+
+### 1.1 Generation mode (default)
+
+When asked to write new jQuery code or modify existing jQuery code:
+
+* MUST follow every **MUST** requirement in this spec.
+* SHOULD follow every **SHOULD** requirement unless the user explicitly says otherwise.
+* MUST prefer safe-by-default patterns: text insertion, DOM node construction, allowlists, and proven sanitization libraries over custom escaping.
+* MUST avoid introducing new risky sinks (HTML string building, dynamic script loading, JSONP, inline script/event-handler attributes, unsafe URL assignment, unsafe object merging).
+
+### 1.2 Passive review mode (always on while editing)
+
+While working anywhere in a repo that uses jQuery (even if the user did not ask for a security scan):
+
+* MUST “notice” violations of this spec in touched/nearby code.
+* SHOULD mention issues as they come up, with a brief explanation + safe fix.
+
+### 1.3 Active audit mode (explicit scan request)
+
+When the user asks to “scan”, “audit”, or “hunt for vulns”:
+
+* MUST systematically search the codebase for violations of this spec.
+* MUST output findings in the structured format (see §2.3).
+
+Recommended audit order:
+
+1. jQuery sourcing, versions, and dependency hygiene (script tags, lockfiles, CDN usage, SRI).
+2. CSP / Trusted Types / security headers posture (in repo and at runtime if observable).
+3. DOM XSS: untrusted sources → jQuery sinks (`.html`, `.append`, `$("<…>")`, `.load`, etc.).
+4. Script execution sinks: JSONP, `dataType:"script"`, `$.getScript`, dynamic `<script>` insertion.
+5. URL/attribute assignment (`href`, `src`, `style`, `on*` attributes).
+6. Prototype pollution / unsafe object merging (`$.extend` patterns).
+7. AJAX auth patterns + CSRF for cookie-based sessions.
+8. Third-party plugins and untrusted content rendering paths (comments, WYSIWYG, markdown-to-HTML).
+
+---
+
+## 2) Definitions and review guidance
+
+### 2.1 Untrusted input (treat as attacker-controlled unless proven otherwise)
+
+Examples include:
+
+* Any data from the server that originates from users (user profiles, comments, “display name”, rich text, filenames).
+* Data from third-party APIs or services.
+* Browser-controlled sources:
+
+  * `location.href`, `location.search`, `location.hash`
+  * `document.URL`, `document.baseURI`, `document.referrer`
+  * `window.name`
+  * `localStorage` / `sessionStorage`
+  * `postMessage` event data (unless strict origin and schema validation exists)
+  * Any DOM content that could have been injected previously (stored XSS)
+
+### 2.2 High-risk “sinks” in jQuery contexts
+
+A sink is a code path where untrusted input can become interpreted as executable code or HTML.
+
+Key jQuery sink categories:
+
+* HTML insertion / parsing:
+
+  * DOM manipulation methods that accept HTML strings such as `.html()`, `.append()`, and related methods (see CVE notes below). ([NVD][1])
+  * `$(htmlString)` (when the argument can be interpreted as HTML markup).
+  * `jQuery.parseHTML(html, …, keepScripts)` especially with `keepScripts=true`. ([jQuery API][2])
+  * `.load(url)` (loads HTML into DOM; has special script execution behavior). ([jQuery API][3])
+* Script execution / dynamic code loading:
+
+  * `$.getScript()` / `$.ajax({ dataType: "script" })` (executes fetched JavaScript). ([jQuery API][4])
+  * JSONP (`dataType: "jsonp"` or implicit JSONP behavior) (executes remote JavaScript as a response). ([jQuery API][5])
+  * `eval`, `new Function`, `setTimeout("…")`, `setInterval("…")`, `$.globalEval` (if present)
+* Dangerous attribute assignment:
+
+  * Assigning untrusted strings to `href`, `src`, `srcdoc`, `style`, or event-handler attributes (`onload`, `onclick`, etc.)
+  * `javascript:` URLs are particularly dangerous and discouraged. ([MDN Web Docs][6])
+
+### 2.3 Required audit finding format
+
+For each issue found, output:
+
+* Rule ID:
+* Severity: Critical / High / Medium / Low
+* Location: file path + function/component + line(s)
+* Evidence: the exact code/config snippet
+* Impact: what could go wrong, who can exploit it
+* Fix: safe change (prefer minimal diff)
+* Mitigation: defense-in-depth if immediate fix is hard
+* False positive notes: what to verify if uncertain
+
+---
+
+## 3) Secure baseline: minimum production configuration (MUST in production)
+
+This is the smallest “production baseline” that prevents common jQuery-related security failures.
+
+### 3.1 Use a supported, patched jQuery version (MUST)
+
+* MUST use a supported jQuery major version and keep it updated.
+* As of 2026-01-27, the jQuery project ships jQuery 4.0.0 as the latest major release. ([blog.jquery.com][7])
+* If you must support very old browsers (notably IE < 11), jQuery 4 does not support them and you may need to stay on jQuery 3.x; treat this as a higher risk posture and patch aggressively. ([blog.jquery.com][7])
+
+### 3.2 Load jQuery safely (MUST)
+
+* MUST load jQuery only from:
+
+  * Your own build pipeline (bundled via npm/yarn + lockfile), or
+  * The official jQuery CDN / a trusted CDN with Subresource Integrity (SRI) enabled.
+* If loading from a CDN, SHOULD use SRI (`integrity`) and correct `crossorigin` settings; the jQuery project explicitly supports and recommends SRI on its CDN. (Retrieved from [jquery.com][8])
+
+### 3.3 CSP + Trusted Types (SHOULD, and MUST where available/required by policy)
+
+* SHOULD deploy a Content Security Policy (CSP) that reduces XSS impact (especially `script-src` restrictions and avoiding `unsafe-inline`). If not done through HTTP server, this can be done through the `<meta http-equiv="Content-Security-Policy" content="...">` tag. ([OWASP Cheat Sheet Series][9]) NOTE: It is most important to set the CSP's script-src. All other directives are not as important and can generally be excluded for the ease of development.
+* SHOULD consider Trusted Types as a strong defense-in-depth against DOM XSS. ([W3C][10])
+* If you deploy the CSP directive `require-trusted-types-for`, then code MUST route DOM-injection through Trusted Types policies. ([MDN Web Docs][11])
+* Note: jQuery 4.0 explicitly added Trusted Types support so that TrustedHTML can be used with jQuery manipulation methods without violating `require-trusted-types-for`. ([blog.jquery.com][7])
+
+### 3.4 Security headers and cookie posture (defense in depth; SHOULD)
+
+Even though these are typically set server-side, they materially reduce the blast radius of jQuery-related mistakes. However if the context is only the frontend web application, these cannot be acted on.
+
+* SHOULD set common security headers (CSP, `X-Content-Type-Options: nosniff`, clickjacking protection via `frame-ancestors` / `X-Frame-Options`, `Referrer-Policy`). ([OWASP Cheat Sheet Series][12])
+* SHOULD avoid storing long-lived secrets/tokens in places accessible to JavaScript (like `localStorage`) unless the threat model explicitly accepts “XSS == account takeover”. This is not jQuery-specific, but jQuery-heavy DOM manipulation increases the chance of DOM XSS regressions; reduce the payoff.
+
+---
+
+## 4) Rules (generation + audit)
+
+Each rule contains: required practice, insecure patterns, detection hints, and remediation.
+
+### JQ-SUPPLY-001: jQuery MUST be patched; do not run known vulnerable versions
+
+Severity: Medium (High if internet-facing app AND version is known-vulnerable)
+
+NOTE: Before performing an upgrade, get concent from the user and try to understand if they have reasons to keep it back. Upgrading can break applications in unexpected ways. Report and recommend upgrades rather than just performing them.
+
+Required:
+
+* MUST NOT use jQuery versions with known high-impact vulnerabilities when a patched version exists.
+* MUST upgrade past:
+
+  * CVE-2019-11358 (prototype pollution in jQuery before 3.4.0). ([NVD][13])
+  * CVE-2020-11022 / CVE-2020-11023 (XSS risks in DOM manipulation methods when handling untrusted HTML; patched in 3.5.0). ([NVD][1])
+
+Insecure patterns:
+
+* Script tags or package manifests referencing old jQuery (e.g., `jquery-1.*`, `jquery-2.*`, `jquery-3.3.*`, `jquery-3.4.*`, `jquery-3.4.1`, etc.).
+* Bundled vendor directories containing old minified jQuery without an upgrade path.
+
+Detection hints:
+
+* Search HTML/templates for `jquery-` and parse version strings.
+* Check `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`.
+* Check `vendor/`, `public/`, `static/`, `assets/`, `wwwroot/` for `jquery*.js`.
+
+Fix:
+
+* Upgrade to current jQuery (prefer latest stable major; as of 2026-01-27, 4.0.0 is current). ([blog.jquery.com][7])
+* If upgrade is constrained, at minimum upgrade beyond the CVE thresholds and add compensating controls (strong CSP, strict sanitization, remove risky APIs like JSONP, remove deep-extend of untrusted objects).
+
+Notes:
+
+* If a product requirement forces old versions, report as “accepted risk requiring compensating controls”.
+
+---
+
+### JQ-SUPPLY-002: Third-party script loading SHOULD use integrity and trusted origins
+
+Severity: High
+
+Required:
+
+* MUST load jQuery and plugins only from trusted origins.
+* If loaded from CDN, SHOULD use SRI (`integrity`) and correct `crossorigin` handling. ([jquery.com][8])
+
+Insecure patterns:
+
+* `<script src="https://…/jquery.min.js"></script>` with no `integrity`.
+* Loading jQuery from random third-party CDNs without an explicit trust decision.
+
+Detection hints:
+
+* Scan HTML for `<script src=` and check for `integrity=` + `crossorigin=`.
+* Identify dynamic script insertion with untrusted URLs (see JQ-EXEC-001).
+
+Fix:
+
+* Prefer bundling via npm + lockfile.
+* If using CDN, copy official script tag (jQuery CDN supports SRI). ([jquery.com][8])
+
+Note: If unable to get the correct SRI tag, skip this step but tell the user. If you end up using the wrong one the app will not function. In that case remove it and inform the user.
+
+---
+
+### JQ-XSS-001: Untrusted data MUST NOT be inserted as HTML via jQuery DOM-manipulation methods
+
+Severity: High (if attacker-controlled content reaches these sinks)
+
+Required:
+
+* MUST treat any HTML string insertion as a code execution boundary.
+* MUST use safe alternatives for untrusted text:
+
+  * `.text(untrusted)` (text, not HTML). ([jQuery API][14])
+  * `.val(untrusted)` for form fields. ([jQuery API][15])
+  * Create elements and set text/attributes safely instead of concatenating HTML strings.
+
+Insecure patterns (examples):
+
+* `$(selector).html(untrusted)`
+* `$(selector).append(untrusted)`
+* `$(selector).before(untrusted)` / `.after(untrusted)` / `.replaceWith(untrusted)` / `.wrap(untrusted)` (and similar)
+* Building markup: `"<div>" + untrusted + "</div>"` then passing to jQuery
+
+Detection hints:
+
+* Grep for: `.html(`, `.append(`, `.prepend(`, `.before(`, `.after(`, `.replaceWith(`, `.wrap(`, `.wrapAll(`, `.wrapInner(`
+* Trace dataflow into these calls from sources in §2.1.
+
+Fix:
+
+* Replace with `.text()` / `.val()` or node construction:
+
+  * `const $el = $("<span>").text(untrusted); container.append($el);`
+* If the output must contain limited markup, see JQ-XSS-002 (sanitization).
+
+Notes:
+
+* Older jQuery versions had additional edge cases even when attempting sanitization; patched in 3.5.0+. Still: never rely on “string sanitization” alone—prefer structured creation or proven sanitizers. ([GitHub][16])
+
+---
+
+### JQ-XSS-002: If rendering user-controlled HTML is required, it MUST be sanitized with a proven HTML sanitizer
+
+Severity: Medium (High if rich HTML is attacker-controlled and sanitizer is weak/misconfigured)
+
+Required:
+
+* MUST NOT “roll your own” HTML sanitizer with regexes.
+* If user-controlled HTML must be displayed (e.g., rich text comments), MUST sanitize using a well-maintained HTML sanitizer and a restrictive allowlist.
+
+  * DOMPurify is a common choice; use conservative configuration and keep it updated. ([GitHub][17])
+  * Where available, MAY consider the browser HTML Sanitizer API (note: limited browser availability). ([MDN Web Docs][18])
+* SHOULD pair sanitization with CSP and, where feasible, Trusted Types for defense in depth. ([OWASP Cheat Sheet Series][9])
+
+Insecure patterns:
+
+* Regex-based “strip `<script>`” or “escape `<`” attempts followed by `.html()` insertion.
+* DOMPurify (or similar) configured to allow overly broad tags/attributes, or configuration that’s not reviewed.
+
+Detection hints:
+
+* Search for “sanitize” helper functions, regex replacing `<`/`>` patterns, or “allow all tags” configs.
+* Identify features that render user-generated “rich text” or “custom HTML”.
+* Check if sanitizer results are inserted with `.html()` or equivalent sinks.
+
+Fix:
+
+* Introduce a sanitizer with strict allowlist.
+* Centralize the “sanitize then inject” pattern into a single reviewed module.
+* Add regression tests covering representative malicious inputs (don’t store payloads in logs or telemetry).
+
+False positive notes:
+
+* If content is guaranteed trusted (e.g., compiled templates shipped by you), document the trust boundary and why it is not attacker-controlled.
+
+---
+
+### JQ-XSS-003: `$(untrustedString)` and `jQuery.parseHTML` MUST NOT process attacker-controlled markup
+
+Severity: High (if attacker-controlled)
+
+Required:
+
+* MUST NOT pass attacker-controlled strings to `$()` when they might be interpreted as HTML.
+* MUST treat `jQuery.parseHTML(html, …, keepScripts)` as a high-risk primitive; keepScripts MUST be `false` for any untrusted input. ([jQuery API][2])
+
+Insecure patterns:
+
+* `const $node = $(untrusted);`
+* `$.parseHTML(untrusted, /* context */, true)` (scripts preserved)
+
+Detection hints:
+
+* Search for `$(` calls where the argument is not a static selector or static markup.
+* Search for `$.parseHTML(` and inspect the `keepScripts` argument.
+
+Fix:
+
+* Use DOM creation with constant tag names and `.text()` for untrusted values.
+* If parsing HTML is necessary, sanitize first (JQ-XSS-002) and keep scripts disabled.
+
+---
+
+### JQ-XSS-004: `.load()` MUST be treated as an HTML+script injection surface
+
+Severity: Medium (High if URL/content is attacker-controlled)
+
+Required:
+
+* MUST NOT use `.load()` with attacker-controlled URLs or attacker-controlled HTML fragments.
+* MUST understand jQuery `.load()` script behavior:
+
+  * Without a selector in the URL, content is passed to `.html()` before scripts are removed, which can execute scripts. ([jQuery API][3])
+* SHOULD prefer `fetch()`/XHR to retrieve data, then render with safe DOM creation or sanitize explicitly.
+
+Insecure patterns:
+
+* `$("#target").load(untrustedUrl)`
+* `$("#target").load("/path?param=" + untrusted)`
+
+Detection hints:
+
+* Search for `.load(` across JS/TS files.
+* Identify whether a selector is appended to the URL (the behavior differs). ([jQuery API][3])
+* Trace whether the URL can be influenced by user input.
+
+Fix:
+
+* Replace `.load()` with:
+
+  * `fetch()` to retrieve JSON, then render via `.text()` / node construction, or
+  * `fetch()` to retrieve HTML, sanitize it, then inject.
+* If `.load()` must remain, ensure the URL is constant or strictly allowlisted and the returned content is trusted.
+
+---
+
+### JQ-EXEC-001: Dynamic script execution and script fetching MUST NOT be reachable from untrusted input
+
+Severity: High
+
+Required:
+
+* MUST NOT fetch-and-execute scripts from untrusted or user-influenced URLs.
+* MUST treat these as code execution primitives:
+
+  * `$.getScript(url)` executes the fetched script in the global context. ([jQuery API][4])
+  * `$.ajax({ dataType: "script" })` and other script-typed requests that execute responses.
+* SHOULD remove these patterns unless there is a strong, reviewed justification.
+
+Insecure patterns:
+
+* `$.getScript(untrustedUrl)`
+* `$.ajax({ url: untrustedUrl, dataType: "script" })`
+* Dynamic `<script src=...>` injection where `src` is derived from untrusted input.
+
+Detection hints:
+
+* Search for `getScript(`, `dataType: "script"`, `globalEval`, `eval`, `new Function`.
+* Look for “plugin loader” or “theme loader” features that accept URLs.
+
+Fix:
+
+* Bundle scripts at build time.
+* If runtime-loading is required, restrict to allowlisted, versioned, integrity-checked assets (and ideally still avoid runtime code loading).
+
+---
+
+### JQ-AJAX-001: JSONP MUST be disabled unless the endpoint is fully trusted (and even then, avoid)
+
+Severity: Medium (High if attacker can influence URL/endpoint)
+
+Required:
+
+* MUST NOT use JSONP for untrusted endpoints because it executes JavaScript responses.
+* When using `$.ajax`, MUST explicitly disable JSONP for non-fully-trusted targets; jQuery’s own docs recommend setting `jsonp: false` “for security reasons” if you don’t trust the target. ([jQuery API][5])
+* SHOULD prefer CORS with JSON (`dataType: "json"`) and explicit origin allowlists server-side.
+
+Insecure patterns:
+
+* `dataType: "jsonp"`
+* URLs containing `callback=?` or patterns that trigger JSONP behavior. callback arguments are historically XSS vectors.
+* `$.get(untrustedUrl)` without pinning `dataType` and disabling JSONP (risk depends on options and jQuery behavior)
+
+Detection hints:
+
+* Search for `jsonp`, `dataType: "jsonp"`, `callback=?`.
+* Search for cross-domain AJAX where the URL is not hard-coded or allowlisted.
+
+Fix:
+
+* Use JSON over HTTPS with CORS configured server-side.
+* Set:
+
+  * `dataType: "json"`
+  * `jsonp: false` (defense in depth when URL might be ambiguous) ([jQuery API][5])
+
+---
+
+### JQ-AJAX-002: State-changing AJAX requests using cookie auth MUST be CSRF-protected
+
+Severity: High
+
+NOTE: This only matters when using cookie based auth. If the request use Authorization header, there is no CSRF potential.
+
+Required:
+
+* If authentication uses cookies, MUST protect state-changing requests (POST/PUT/PATCH/DELETE) against CSRF.
+* SHOULD use server-verified CSRF tokens; for AJAX calls, tokens are commonly sent in a custom header. ([OWASP Cheat Sheet Series][19])
+* MUST NOT treat “it’s an AJAX request” as CSRF protection by itself.
+
+Insecure patterns:
+
+* `$.post("/transfer", {...})` or `$.ajax({ method: "POST", ... })` with cookie auth and no CSRF token/header.
+* “CSRF protection” that only checks for `X-Requested-With` (defense-in-depth only, not primary).
+
+Detection hints:
+
+* Enumerate state-changing AJAX calls and locate whether they include CSRF tokens.
+* Identify how the server expects CSRF validation (meta tag, cookie-to-header double submit, synchronizer token, etc.).
+
+Fix:
+
+* Add CSRF token inclusion in a centralized place, e.g., `$.ajaxSetup({ headers: { "X-CSRF-Token": token } })`, and ensure server verifies.
+* Follow OWASP CSRF guidance for token properties and validation. ([OWASP Cheat Sheet Series][19])
+
+False positive notes:
+
+* If auth is not cookie-based (e.g., Authorization header bearer token) CSRF risk is different; verify actual auth mechanism.
+
+---
+
+### JQ-ATTR-001: Untrusted values MUST NOT be written into dangerous attributes without validation/allowlisting
+
+Severity: Low (High for events like onclick)
+
+Required:
+
+* MUST validate/allowlist URLs written into `href`, `src`, `action`, etc.
+* MUST block dangerous schemes; `javascript:` URLs are discouraged because they can execute code. ([MDN Web Docs][6])
+* MUST NOT set event-handler attributes (`onclick`, `onerror`, etc.) from strings.
+* SHOULD avoid writing untrusted strings into `style` attributes; prefer toggling predefined CSS classes.
+
+Insecure patterns:
+
+* `$("a").attr("href", untrustedUrl)`
+* `$("img").attr("src", untrustedUrl)`
+* `$(el).attr("style", untrustedCss)`
+* `$(el).attr("onclick", untrustedJs)`
+
+Detection hints:
+
+* Search for `.attr("href"`, `.attr("src"`, `.attr("style"`, `.prop("href"`, `.prop("src"`.
+* Trace whether inputs come from URL params, server JSON, DOM, or storage.
+
+Fix:
+
+* Parse and validate URLs with `new URL(value, location.origin)` and allowlist protocols (`https:` etc.) and hostnames when needed.
+* For navigation targets, prefer relative paths you construct rather than full URLs.
+* Replace `style` strings with `addClass/removeClass` using predefined class names.
+
+---
+
+### JQ-SELECTOR-001: User-controlled selector fragments MUST be escaped with `jQuery.escapeSelector`
+
+Severity: Medium (can become High if it enables wrong-element selection in security-relevant UI)
+
+Required:
+
+* If you must select by an ID/class that can contain special CSS characters, SHOULD use `jQuery.escapeSelector()` (available in jQuery 3.0+). ([jQuery API][20])
+* MUST NOT concatenate raw attacker-controlled strings into selector expressions.
+
+Insecure patterns:
+
+* `$("#" + untrustedId)`
+* `$("[data-id='" + untrusted + "']")` (especially without strict quoting/escaping)
+
+Detection hints:
+
+* Search for `"#" +`, `". " +`, or template strings used inside `$(` selectors.
+* Look for “select by user-supplied id”.
+
+Fix:
+
+* `$("#" + $.escapeSelector(untrustedId))` ([jQuery API][20])
+* Prefer stable internal IDs over user-derived selectors.
+
+Notes:
+
+* This is often “robustness”, but it can become security-relevant if incorrect selection causes UI to reveal/modify the wrong data or skip security-related prompts.
+
+---
+
+### JQ-PROTOTYPE-001: Do not deep-merge untrusted objects; prevent prototype pollution
+
+Severity: Medium
+
+Required:
+
+* MUST NOT deep-merge (`$.extend(true, …)`) attacker-controlled objects into application objects without filtering dangerous keys.
+* MUST ensure jQuery is >= 3.4.0 to avoid CVE-2019-11358 prototype pollution behavior. ([NVD][13])
+
+Insecure patterns:
+
+* `$.extend(true, target, untrustedObj)`
+* `$.extend(true, {}, defaults, untrustedObj)` where untrustedObj comes from URL/JSON/storage
+
+Detection hints:
+
+* Search for `$.extend(true` and inspect sources of merged objects.
+* Search for “merge options” / “apply config” patterns using untrusted JSON.
+
+Fix:
+
+* Prefer:
+
+  * Shallow merges with an allowlisted set of keys, or
+  * A safe merge helper that explicitly rejects `__proto__`, `prototype`, `constructor`, and nested occurrences.
+* Keep jQuery patched.
+
+---
+
+### JQ-CSP-001: CSP and Trusted Types SHOULD be used to make DOM XSS harder to introduce and exploit
+
+Severity: Medium
+
+Required:
+
+* SHOULD deploy CSP as defense-in-depth against XSS. ([OWASP Cheat Sheet Series][9])
+* If enabling Trusted Types (`require-trusted-types-for`), MUST ensure DOM injection goes through Trusted Types policies. ([MDN Web Docs][11])
+* When using jQuery 4, SHOULD take advantage of its Trusted Types support (TrustedHTML inputs). ([blog.jquery.com][7])
+
+Insecure patterns:
+
+* “Fixing” a jQuery feature by weakening CSP (`script-src 'unsafe-inline'` / `'unsafe-eval'`) without a compensating plan.
+* No CSP on applications that render user content or manipulate DOM heavily.
+
+Detection hints:
+
+* Look for CSP headers (server configs, framework middleware, meta tags).
+* If not visible in repo, flag as “verify at edge/runtime”.
+
+Fix:
+
+* Add CSP incrementally; start by eliminating inline scripts and inline event handlers, then tighten `script-src`.
+* Add Trusted Types where supported and feasible.
+
+---
+
+## 5) Practical scanning heuristics (how to “hunt”)
+
+When actively scanning, use these high-signal patterns:
+
+* jQuery version / sourcing:
+
+  * `jquery-*.js` in `vendor/` or `static/`
+  * `package.json` dependency `jquery` pinned to old versions
+  * CDN script tags lacking `integrity`/`crossorigin` ([jquery.com][8])
+* HTML injection sinks (DOM XSS):
+
+  * `.html(`, `.append(`, `.prepend(`, `.before(`, `.after(`, `.replaceWith(`, `.wrap(`
+  * `$(` where argument might be HTML / template strings
+  * `$.parseHTML(` especially with `keepScripts=true` ([jQuery API][2])
+  * `.load(` (and whether selector is appended; script behavior differs) ([jQuery API][3])
+* Script execution / dynamic code:
+
+  * `$.getScript(`, `dataType: "script"` ([jQuery API][4])
+  * `dataType: "jsonp"` or `jsonp:` usage; `callback=?` patterns ([jQuery API][5])
+  * `eval`, `new Function`, `setTimeout("…")`, `$.globalEval`
+* Dangerous attribute writes:
+
+  * `.attr("href", …)`, `.attr("src", …)`, `.attr("style", …)`
+  * Any assignment of `javascript:`-like schemes or suspicious URL construction ([MDN Web Docs][6])
+* Selector construction:
+
+  * `$("#" + user)` and similar; fix via `$.escapeSelector` ([jQuery API][20])
+* Prototype pollution:
+
+  * `$.extend(true, …, userObj)`; ensure jQuery >= 3.4.0 and filter dangerous keys ([NVD][13])
+* CSRF posture for AJAX:
+
+  * `$.post(` / `$.ajax({ method: ... })` with cookies and no CSRF token/header ([OWASP Cheat Sheet Series][19])
+* Defense-in-depth:
+
+  * Absence of CSP/security headers in configs (or not visible; require runtime verification) ([OWASP Cheat Sheet Series][12])
+
+Always try to confirm:
+
+* data origin (untrusted vs trusted)
+* sink type (HTML insertion / script execution / attribute / selector / object merge)
+* protective controls present (sanitizer, allowlists, CSP, Trusted Types, CSRF validation)
+
+---
+
+## 6) Sources (accessed 2026-01-27)
+
+Primary jQuery project documentation and release notes:
+
+* jQuery 4.0.0 release notes (Trusted Types/CSP changes; version info): `https://blog.jquery.com/2026/01/17/jquery-4-0-0/`. ([blog.jquery.com][7])
+* Download jQuery (latest version info; CDN + SRI guidance): `https://jquery.com/download/`. ([jquery.com][8])
+* jQuery API: `.html()`: `https://api.jquery.com/html/`. ([jQuery API][21])
+* jQuery API: `.text()`: `https://api.jquery.com/text/`. ([jQuery API][14])
+* jQuery API: `.append()`: `https://api.jquery.com/append/`. ([jQuery API][22])
+* jQuery API: `.load()` (script execution behavior): `https://api.jquery.com/load/`. ([jQuery API][3])
+* jQuery API: `jQuery.parseHTML(…, keepScripts)`: `https://api.jquery.com/jQuery.parseHTML/`. ([jQuery API][2])
+* jQuery API: `$.ajax()` (`jsonp: false` security note): `https://api.jquery.com/jQuery.ajax/`. ([jQuery API][5])
+* jQuery API: `$.getScript()` (executes script): `https://api.jquery.com/jQuery.getScript/`. ([jQuery API][4])
+* jQuery API: `jQuery.escapeSelector()`: `https://api.jquery.com/jQuery.escapeSelector/`. ([jQuery API][20])
+
+jQuery vulnerabilities / advisories:
+
+* NVD CVE-2019-11358 (prototype pollution; jQuery < 3.4.0): `https://nvd.nist.gov/vuln/detail/CVE-2019-11358`. ([NVD][13])
+* NVD CVE-2020-11022 (XSS risk in DOM manipulation methods; patched in 3.5.0): `https://nvd.nist.gov/vuln/detail/CVE-2020-11022`. ([NVD][1])
+* NVD CVE-2020-11023 (XSS risk involving `<option>`; patched in 3.5.0): `https://nvd.nist.gov/vuln/detail/CVE-2020-11023`. ([NVD][23])
+* GitHub Security Advisory GHSA-gxr4-xjj5-5px2 (jQuery htmlPrefilter XSS; patched in 3.5.0): `https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2`. ([GitHub][16])
+
+OWASP Cheat Sheet Series (web app security foundations relevant to jQuery usage):
+
+* XSS Prevention: `https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html`. ([OWASP Cheat Sheet Series][24])
+* DOM-based XSS Prevention: `https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html`. ([OWASP Cheat Sheet Series][25])
+* CSRF Prevention: `https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html`. ([OWASP Cheat Sheet Series][19])
+* HTTP Security Headers: `https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html`. ([OWASP Cheat Sheet Series][12])
+* Content Security Policy Cheat Sheet: `https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html`. ([OWASP Cheat Sheet Series][9])
+
+Browser/platform references (SRI, CSP, Trusted Types, and dangerous URL schemes):
+
+* MDN: Subresource Integrity (SRI): `https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity`. ([MDN Web Docs][26])
+* W3C: SRI specification: `https://www.w3.org/TR/sri-2/`. ([W3C][27])
+* MDN: CSP guide: `https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP`. ([MDN Web Docs][28])
+* MDN: `require-trusted-types-for` directive: `https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for`. ([MDN Web Docs][11])
+* MDN: Trusted Types API: `https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API`. ([MDN Web Docs][29])
+* W3C: Trusted Types specification: `https://www.w3.org/TR/trusted-types/`. ([W3C][10])
+* MDN: `javascript:` URL scheme warning: `https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/javascript`. ([MDN Web Docs][6])
+* DOMPurify project documentation: `https://github.com/cure53/DOMPurify`. ([GitHub][17])
+
+[1]: https://nvd.nist.gov/vuln/detail/cve-2020-11022?utm_source=chatgpt.com "CVE-2020-11022 Detail - NVD"
+[2]: https://api.jquery.com/jQuery.parseHTML/?utm_source=chatgpt.com "jQuery.parseHTML()"
+[3]: https://api.jquery.com/load/?utm_source=chatgpt.com ".load() | jQuery API Documentation"
+[4]: https://api.jquery.com/jQuery.getScript/?utm_source=chatgpt.com "jQuery.getScript()"
+[5]: https://api.jquery.com/jQuery.ajax/?utm_source=chatgpt.com "jQuery.ajax()"
+[6]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/javascript?utm_source=chatgpt.com "javascript: URLs - URIs - MDN Web Docs"
+[7]: https://blog.jquery.com/2026/01/17/jquery-4-0-0/ "jQuery 4.0.0 | Official jQuery Blog"
+[8]: https://jquery.com/download/ "Download jQuery | jQuery"
+[9]: https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html?utm_source=chatgpt.com "Content Security Policy - OWASP Cheat Sheet Series"
+[10]: https://www.w3.org/TR/trusted-types/?utm_source=chatgpt.com "Trusted Types"
+[11]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for?utm_source=chatgpt.com "Content-Security-Policy: require-trusted-types-for directive"
+[12]: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html?utm_source=chatgpt.com "HTTP Security Response Headers Cheat Sheet"
+[13]: https://nvd.nist.gov/vuln/detail/cve-2019-11358?utm_source=chatgpt.com "CVE-2019-11358 Detail - NVD"
+[14]: https://api.jquery.com/text/?utm_source=chatgpt.com ".text() | jQuery API Documentation"
+[15]: https://api.jquery.com/val/?utm_source=chatgpt.com ".val() | jQuery API Documentation"
+[16]: https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2 "Potential XSS vulnerability in jQuery.htmlPrefilter and related methods · Advisory · jquery/jquery · GitHub"
+[17]: https://github.com/cure53/DOMPurify?utm_source=chatgpt.com "DOMPurify - a DOM-only, super-fast, uber-tolerant XSS ..."
+[18]: https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API?utm_source=chatgpt.com "HTML Sanitizer API - MDN Web Docs"
+[19]: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html?utm_source=chatgpt.com "Cross-Site Request Forgery Prevention Cheat Sheet"
+[20]: https://api.jquery.com/jQuery.escapeSelector/?utm_source=chatgpt.com "jQuery.escapeSelector()"
+[21]: https://api.jquery.com/html/?utm_source=chatgpt.com ".html() | jQuery API Documentation"
+[22]: https://api.jquery.com/append/?utm_source=chatgpt.com ".append() | jQuery API Documentation"
+[23]: https://nvd.nist.gov/vuln/detail/cve-2020-11023?utm_source=chatgpt.com "CVE-2020-11023 Detail - NVD"
+[24]: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html?utm_source=chatgpt.com "Cross Site Scripting Prevention - OWASP Cheat Sheet Series"
+[25]: https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html?utm_source=chatgpt.com "DOM based XSS Prevention Cheat Sheet"
+[26]: https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity?utm_source=chatgpt.com "Subresource Integrity - Security - MDN Web Docs"
+[27]: https://www.w3.org/TR/sri-2/?utm_source=chatgpt.com "Subresource Integrity"
+[28]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP?utm_source=chatgpt.com "Content Security Policy (CSP) - HTTP - MDN Web Docs"
+[29]: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API?utm_source=chatgpt.com "Trusted Types API - MDN Web Docs"

--- a/.agents/skills/security-review/references/prompt-template.md
+++ b/.agents/skills/security-review/references/prompt-template.md
@@ -1,0 +1,255 @@
+# Threat Modeling Prompt Template for LLMs
+
+This reference provides a disciplined, repo-grounded prompt that produces AppSec-usable threat models. Use it when you need a reliable output contract and a consistent process to assemble the threat model output
+
+## System prompt
+
+Use this as a stable system prompt:
+
+````text
+You are a senior application security engineer producing a threat model that will be read by other AppSec engineers.
+
+Primary objective:
+- Generate a threat model that is specific to THIS repository and its real-world usage.
+- Prefer concrete, evidence-backed findings over generic vulnerability checklists.
+
+Evidence and grounding rules:
+- Do not invent components, data stores, endpoints, flows, or controls.
+- Every architectural claim must be backed by at least one "Evidence anchor" referencing a repo path
+  (and a symbol name, config key, or a short quoted snippet if available).
+- If information is missing, state assumptions explicitly and list the open questions needed to validate them.
+
+Security hygiene:
+- Never output secrets. If you encounter tokens/keys/passwords, redact them and only describe their presence and location.
+
+Threat modeling approach:
+- Model the system using data flows and trust boundaries.
+- Enumerate threats and produce attack goals and abuse paths
+- Prioritize threats using explicit likelihood and impact reasoning (qualitative is acceptable: low/medium/high).
+
+Scope discipline:
+- Clearly separate: production/runtime behavior vs CI/build/dev tooling vs tests/examples.
+- Clearly separate attacker-controlled inputs vs operator-controlled inputs vs developer-controlled inputs.
+- If a vulnerability class requires attacker control that likely does not exist for this repo's real usage, say so and downgrade severity.
+
+Communication quality:
+- Write for AppSec engineers: concise but specific.
+- Use precise terminology. Include mitigations and residual risks.
+- Avoid restating large blocks of README/spec; summarize and point to evidence.
+
+Diagram requirements:
+- Produce a single compact Mermaid flowchart showing primary components and trust boundaries.
+- Mermaid must render cleanly. Use a conservative subset:
+  - Use `flowchart TD` or `flowchart LR` and only `-->` arrows.
+  - Use simple node IDs (letters/numbers/underscores only) and quoted labels (e.g., `A["Label"]`); avoid `A(Label)` shape syntax.
+  - Do not use Mermaid `title` lines or `style` directives.
+  - Keep edge labels to plain words/spaces only via `-->|label|`; avoid `{}`, `[]`, `()`, or quotes in edge labels (if needed, drop the label).
+  - Keep node labels short and readable: do not include file paths, URLs, or socket paths (put those details in prose outside the diagram).
+- Wrap the diagram in a Markdown fenced block:
+  ```mermaid
+  <mermaid syntax here>
+  ```
+````
+
+## Repository summary prompt
+
+```
+We have a codebase located at {repo_directory/path}, currently on branch {branch_name}.
+
+Please produce a security-oriented summary of the repository (or the specified sub-path) with the goal of helping a follow-on security engineer quickly understand the system well enough to build an initial threat model and investigate potential security hypotheses.
+
+Objectives
+1.	Project overview
+	•	Identify the primary programming languages, frameworks, and build system.
+	•	Summarize the project’s core purpose and high-level architecture.
+	•	Describe major components, services, or modules and how they interact.
+2.	Security posture and entry points
+	•	Identify likely user entry points and trust boundaries.
+	•	Describe existing security layers (e.g., authentication, authorization, validation, sandboxing, isolation, privilege boundaries).
+	•	Call out security-critical components and assumptions that must hold for the system to remain secure.
+
+Guidance for Security Analysis
+
+Structure the summary so an application security engineer can quickly answer questions such as:
+	•	Where does user input originate?
+	•	How is untrusted data parsed, validated, and handled?
+	•	What security assumptions should not be violated?
+	•	Where are the most likely choke points for security bugs?
+
+Adapt the analysis to the project type. For example:
+	•	Web applications: where requests enter, how user data is parsed, routed, authenticated, and stored.
+	•	Command-line tools: supported inputs (arguments, files, environment variables, stdin) and how they are processed.
+	•	Network daemons: exposed ports, supported protocols, message formats, and request handling paths.
+	•	Operating system or low-level components: common vulnerability classes (e.g., memory corruption, logic flaws) that could lead to LPE or RCE.
+
+Be thorough but pragmatic: the goal is to help a security engineer quickly determine whether a discovered bug is security-relevant and where deeper investigation should focus.
+
+Tooling Notes
+
+If Ripgrep (rg) is available, use it to explore the codebase. When using grep or rg, always include the -I flag to avoid searching through binary files.
+```
+
+
+
+## User prompt template
+
+Use this as the task prompt, filling in what you know and marking the rest as assumptions:
+
+```text
+# Inputs
+Context (fill as available; otherwise infer and mark assumptions):
+- intended_usage: {intended_usage}
+- deployment_model: {deployment_model}
+- data_sensitivity: {data_sensitivity}
+- internet_exposure: {internet_exposure}
+- authn_authz_expectations: {authn_authz_expectations}
+- out_of_scope: {out_of_scope}
+
+Provided summaries (may be incomplete):
+- repository_summary: {repository_summary}
+
+
+In-scope code locations (if known):
+- in_scope_paths: {in_scope_paths}
+
+# Task
+Construct a repo-centric threat model that helps AppSec engineers understand the most important security risks and where to focus manual review.
+
+You MUST follow this process and reflect outputs in the final document:
+
+## Process
+1) Repo discovery (evidence collection)
+   a. Identify the repo shape:
+      - languages and frameworks
+      - how it runs (server/cli/library), entrypoints, build artifacts
+   b. Identify security-relevant surfaces and controls by searching for evidences, such as:
+      - network listeners/routes/endpoints; RPC handlers; message consumers
+      - authentication, session/token handling, authorization checks, RBAC/ACL logic
+      - parsing/serialization/deserialization (JSON/YAML/XML/protobuf), template rendering, eval/dynamic code
+      - file upload/read paths, archive extraction, image/document parsing
+      - database/queue/cache clients and query construction
+      - secrets/config loading, environment variables, key management
+      - SSRF-capable HTTP clients, webhooks, URL fetchers
+      - sandboxing/isolation, privilege boundaries, subprocess execution
+      - logging/auditing and error handling paths
+      - CI/build/release: pipelines, dependency management, artifact publishing
+   
+2) System model
+   a. Summarize the primary components (runtime plus critical build/CI components when relevant).
+   b. Enumerate data flows and trust boundaries.
+      - For each trust boundary, specify:
+        * source to destination
+        * data types crossing (e.g., credentials, PII, files, tokens, prompts)
+        * channel/protocol (HTTP/gRPC/IPC/file/db)
+        * security guarantees and validation (auth, mTLS, origin checks, schema validation, rate limits)
+   c. Provide a compact Mermaid diagram showing components and trust boundaries.
+
+3) Assets and security objectives
+   - List assets (data, credentials, integrity-critical state, availability-critical components, build artifacts).
+   - For each asset, state why it matters (confidentiality/integrity/availability, compliance, user harm).
+
+4) Attacker model
+   - Capabilities: realistic remote attacker assumptions based on intended usage and exposure.
+   - Non-capabilities: things attacker cannot plausibly do (unless explicitly in scope), to avoid inflated severity.
+
+5) Threat enumeration (concrete, system-specific)
+   - Generate threats as attacker stories tied to:
+     * entry points
+     * trust boundaries
+     * privileged components
+   - Prefer abuse paths (multi-step sequences) over single-line generic threats.
+
+6) Risk prioritization
+   - For each threat:
+     * Likelihood: low/medium/high with a 1 to 2 sentence justification
+     * Impact: low/medium/high with a 1 to 2 sentence justification
+     * Overall priority: critical/high/medium/low (based on likelihood x impact, adjusted for existing controls)
+   - Explicitly state which assumptions most affect risk.
+
+7) Validate assumptions and service context with the user (required before final report)
+   - Summarize key assumptions that materially affect scope or risk ranking.
+   - Ask 1 to 3 targeted questions to resolve missing service meta-context (service owner/environment, scale/users, deployment model, authn/authz, internet exposure, data sensitivity, multi-tenancy).
+   - Pause and wait for user feedback before producing the final report.
+   - If the user cannot answer, proceed with explicit assumptions and mark any conditional conclusions.
+
+8) Mitigations and recommendations
+   - For each high/critical threat:
+     * Existing mitigations (with evidence anchors)
+     * Gaps/weaknesses
+     * Recommended mitigations (code/config/process)
+     * Detection/monitoring ideas (logging, metrics, alerts)
+
+9) Focus paths for manual security review
+   - Output 2 to 30 repo-relative paths (files or directories) that merit deeper review.
+   - For each path, give a one-sentence reason tied to the threat model.
+
+10) Quality check
+   - Provide a short checklist confirming you covered:
+     * all entry points you discovered
+     * each trust boundary at least once in threats
+     * runtime vs CI/dev separation
+     * user clarifications (or explicit non-responses)
+     * assumptions and open questions
+
+## Required output format (exact)
+Before producing the final Markdown report, first provide an assumption-validation check-in:
+- List the key assumptions in 3 to 6 bullets.
+- Ask 1 to 3 targeted context questions.
+- Wait for the user response, then produce the final report below using the clarified context.
+
+Produce valid Markdown with these sections in this order:
+
+## Executive summary
+- 1 short paragraph on the top risk themes and highest-risk areas.
+
+## Scope and assumptions
+- In-scope paths, out-of-scope items, and explicit assumptions.
+- A short list of open questions that would materially change the risk ranking.
+
+
+## System model
+### Primary components
+### Data flows and trust boundaries
+Represent the system as a sequence of arrow-style bullets (e.g., Internet → API Server, User Input -> Application Logic, etc). For each boundary, document:
+	•	the primary data types crossing the boundary,
+	•	the communication channel or protocol,
+	•	the security guarantees (e.g., authentication, origin checks, encryption, rate limiting), and
+	•	any input validation, normalization, or schema enforcement performed.
+
+#### Diagram
+- Include a single, compact Mermaid diagram (`flowchart TD` or `flowchart LR`) showing primary components and trust boundaries (e.g., separate trust zones via subgraphs). Keep it compact, use only `-->`, avoid `title`/`style`, keep node labels short (no paths/URLs), and keep edge labels to plain words only (avoid `{}`, `[]`, `()`, or quotes).
+
+
+## Assets and security objectives
+- A table: Asset | Why it matters | Security objective (C/I/A)
+
+## Attacker model
+### Capabilities
+### Non-capabilities
+
+## Entry points and attack surfaces
+- A table: Surface | How reached | Trust boundary | Notes | Evidence (repo path / symbol)
+
+## Top abuse paths
+- 5 to 10 short abuse paths, each as a numbered sequence of steps (attacker goal -> steps -> impact).
+
+## Threat model table
+- A Markdown table with columns:
+  Threat ID | Threat source | Prerequisites | Threat action | Impact | Impacted assets | Existing controls (evidence) | Gaps | Recommended mitigations | Detection ideas | Likelihood | Impact severity | Priority
+
+Rules:
+- Threat IDs must be stable and formatted: TM-001, TM-002, ...
+- Priority must be one of: critical, high, medium, low.
+- Keep prerequisites to 1 to 2 sentences. Keep recommended mitigations concrete.
+
+## Criticality calibration
+- Define what counts as critical/high/medium/low for THIS repo and context.
+- Include 2 to 3 examples per level (tailored to the repo's assets and exposure).
+
+## Focus paths for security review
+- A table: Path | Why it matters | Related Threat IDs
+
+## Notes on use
+
+- Fill in known context, but allow the model to infer and mark assumptions.
+- Include 1–2 repo-path anchors per major claim; do not dump every match.

--- a/.agents/skills/security-review/references/security-controls-and-assets.md
+++ b/.agents/skills/security-review/references/security-controls-and-assets.md
@@ -1,0 +1,32 @@
+# Security Controls and Asset Categories
+
+Use this as a lightweight checklist to keep outputs consistent across teams. Prefer concrete, system-specific items over generic text.
+
+## Asset categories (pick only what applies)
+- User data (PII, content, uploads)
+- Authentication artifacts (passwords, tokens, sessions, cookies)
+- Authorization state (roles, policies, ACLs)
+- Secrets and keys (API keys, signing keys, encryption keys)
+- Configuration and feature flags
+- Models and weights (if ML systems)
+- Source code and build artifacts
+- Audit logs and telemetry
+- Availability-critical resources (queues, caches, rate limits, compute budgets)
+- Tenant isolation boundaries and metadata
+
+## Security control categories
+- Identity and access: authN, authZ, session handling, mTLS, key rotation
+- Input protection: schema validation, parsing hardening, upload scanning, sandboxing
+- Network safeguards: TLS, network policies, WAF, rate limiting, DoS controls
+- Data protection: encryption at rest/in transit, tokenization, redaction
+- Isolation: process sandboxing, container boundaries, tenant isolation, seccomp
+- Observability: audit logs, alerting, anomaly detection, tamper resistance
+- Supply chain: dependency pinning, SBOMs, provenance, signing
+- Change control: CI checks, deployment approvals, config guardrails
+
+## Mitigation phrasing patterns
+- "Enforce schema at <boundary> for <payload> before <component>."
+- "Require authZ check for <action> on <resource> in <service>."
+- "Isolate <parser/component> in a sandbox with <resource limits>."
+- "Rate limit <endpoint> by <key> and apply burst caps."
+- "Encrypt <data> at rest using <key management> and rotate <keys>."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Repository Guidelines
+
+## Goals
+
+- Make the smallest correct change that satisfies the task.
+- Keep PRs as small as practical to make review easier.
+- Split Go code changes into a separate PR when they are not required for the task at hand.
+- Preserve existing project conventions unless there is a clear reason to change them.
+- Keep durable repo conventions here; put repeatable workflows in `.agents/`.
+
+## Project Structure
+
+- `main.go` and `world.go` are the main server entrypoints; most application code lives under `internal/`.
+- Reusable game features live under `modules/`; bundled world data, HTML, localization, and sample scripts live under `_datafiles/`.
+- Generated module wiring is handled by `cmd/generate/module-imports.go`.
+- CI and contributor workflow docs live in `.github/`.
+- `ai-context/*.md` is supplemental architecture/background context; treat code, config, and Makefile targets as the source of truth.
+
+## Build, Test, and Run
+
+Use the `Makefile` as the source of truth:
+
+- `make help` lists supported developer targets.
+- `make run` regenerates module imports and starts the server locally.
+- `make build` validates and builds `./go-mud-server`.
+- `make run-docker` starts the Docker Compose environment from `compose.yml`.
+- `make validate` runs formatting checks and `go vet`.
+- `make test` runs code generation, JavaScript lint, and `go test -race ./...`.
+- `make ci-local` runs the local workflow/`act` validation path; use it when changing `.github/` files.
+
+## Style
+
+- Follow `.editorconfig`: 2-space indentation for Markdown, HTML, JavaScript, YAML, and CSS; tabs in `Makefile`.
+- Keep Go code `gofmt`-clean and package names lowercase.
+- Match existing naming patterns for Go identifiers, `*_test.go` tests, and `_datafiles/` names.
+
+## Implementation Rules
+
+- Keep secrets, tokens, and credentials out of code, logs, fixtures, and documentation.
+- Prefer explicit error propagation or clear surfaced failures over silent fallbacks.
+- When behavior changes, update or add relevant Go `testing` / `testify` tests.
+
+## Verification
+
+- Run the relevant existing checks for the files touched; prefer the smallest high-confidence set, then expand if needed.
+- Use `make js-lint` for frontend JavaScript changes.
+- Run `make test` before opening a PR.
+- Do not claim success without verification.
+- If checks cannot be run, state that clearly and explain why.
+
+## Codex Skills
+
+- Use `/review` before handoff when changes need bug/regression review or verification; follow `.agents/code_review.md`.
+- Use `$gh-fix-ci` for failing GitHub Actions PR checks; inspect logs with `gh` (if available) and prefer repo-native fixes plus Makefile checks.
+- Use `$security-review` only when explicitly requested for security review or threat modeling.
+
+## Documentation
+
+- Update docs when changes materially affect setup, usage, behavior, configuration, or developer workflows.
+- Keep docs scoped and aligned with the actual Docker and Makefile workflow.

--- a/ai-context/global-summary.md
+++ b/ai-context/global-summary.md
@@ -119,12 +119,12 @@ make client               # Connect telnet client to Docker instance
 1. Go 1.24+ required (specified in go.mod)
 2. Docker and Docker Compose for containerized development
 3. Make for build automation
-4. Node.js for JavaScript linting (via Docker)
-5. Environment variables for configuration overrides:
-   - `CONFIG_PATH` - Custom config.yaml path
+4. Docker is required for the default `make js-lint` path (`node:22`)
+5. Environment variables:
+   - `CONFIG_PATH` - Override config file path (defaults to `${DataFiles}/config-overrides.yaml`)
    - `LOG_PATH` - Log file location
    - `LOG_LEVEL` - Logging verbosity (LOW/MEDIUM/HIGH)
-   - `LOG_NOCOLOR` - Disable colored logging
+   - `LOG_NOCOLOR` - Disable colored log output
 
 ## Code Conventions
 
@@ -166,10 +166,11 @@ make client               # Connect telnet client to Docker instance
 ## Important Notes
 
 **Configuration Management:**
-- Main config in `_datafiles/config.yaml` (22K+ lines of comprehensive settings)
-- Override configs via `CONFIG_PATH` environment variable
+- Bundled base config lives at `_datafiles/config.yaml`
+- Runtime overrides default to `${DataFiles}/config-overrides.yaml`, or `CONFIG_PATH` if set
+- `DataFiles` defaults to `_datafiles/world/default`
 - Locked configurations prevent runtime modification of critical settings
-- YAML-based configuration with extensive validation
+- YAML-based configuration with validation and reload support
 
 **Networking:**
 - Default telnet ports: 33333, 44444
@@ -199,11 +200,11 @@ make client               # Connect telnet client to Docker instance
 - Log rotation to prevent disk space issues
 
 **Common Pitfalls:**
-- Always run `go generate ./...` before building (required for module imports)
+- Prefer `make` targets over ad hoc commands; `make build`, `make run`, `make test`, and `make ci-local` already include the expected generation/lint/test flow
 - JavaScript scripts must not exceed timeout limits or they will be killed
-- Room instance data is automatically generated - delete `rooms.instances` directories for fresh world state
+- Room instance data is automatically generated; delete `rooms.instances` directories for a fresh world state
 - Configuration changes in locked sections require config file modification, not runtime commands
-- Docker builds require copying `_datafiles` directory to include game content
+- Docker builds must include `_datafiles` so bundled game content is present at runtime
 
 **Deployment:**
 - Multi-stage Docker builds with Alpine Linux

--- a/ai-context/network-summary.md
+++ b/ai-context/network-summary.md
@@ -59,7 +59,7 @@ The GoMud network layer provides a sophisticated, multi-protocol networking syst
 - **Heartbeat**: Ping/pong monitoring (60-second intervals)
 - **Features**:
   - Real-time bidirectional communication
-  - Cross-origin request support for development
+  - Current upgrader accepts all origins (`CheckOrigin` returns `true`)
   - Automatic connection health monitoring
   - Text masking for password input
 
@@ -152,7 +152,8 @@ Network:
   HttpsPort: 0                  # HTTPS port (0 = disabled)
   HttpsRedirect: false          # Auto-redirect HTTP to HTTPS
   ZombieSeconds: 60             # Zombie connection timeout
-  AfkSeconds: 1800              # AFK timeout
+  AfkSeconds: 120               # AFK timeout
+  MaxIdleSeconds: 1800          # Idle disconnect timeout
   TimeoutMods: false            # Timeout moderators/admins
 ```
 
@@ -161,11 +162,17 @@ Network:
 FilePaths:
   WebDomain: "localhost"
   WebCDNLocation: ""            # Optional CDN for static files
+  DataFiles: "_datafiles/world/default"
   PublicHtml: "_datafiles/html/public"
   AdminHtml: "_datafiles/html/admin"
   HttpsCertFile: ""             # TLS certificate
   HttpsKeyFile: ""              # TLS private key
 ```
+
+### Config Loading Notes
+- The bundled base config is always loaded from `_datafiles/config.yaml`
+- Override data is loaded from `${DataFiles}/config-overrides.yaml` by default
+- Setting `CONFIG_PATH` changes the override file path, not the base config path
 
 ## Advanced Features
 


### PR DESCRIPTION
## Overview

`AGENTS.md` is an open-source, standardized Markdown file placed in a project’s root directory to provide context and instructions to AI coding agents, acting as a "README" for AI. It has become the adopted standard by AI coding tools such as Claude Code and Codex CLI, and is used by those tools out of the box.
 
This PR adds a GoMud-specific `AGENTS.md` and related `SKILLS.md` files to provide repo guidance to AI coding tools, so that AI-assisted maintenance follows GoMud's existing workflows instead of ad hoc prompts.

This PR follows the current best practices recommended by OpenAI: <https://developers.openai.com/codex/learn/best-practices>

**Note:** while this PR does not replace the existing guidance files found at `./ai-guidance/`, current best practices suggests it may no longer be needed (I'll leave that up to Volte to decide). However, this PR does update some stale/outdated info in those guidance files.

## Recommendation

- Add the Github `gh` CLI to your system to help automate Github updates/reviews when using an AI CLI coding tool.

## Changes

### New AI Commands

- `/review`: will perform a code review on your current branch/commit, based on the guidance from `.agents/code_review.md`

- `$gh-fix-ci`: an AI skill for GitHub Actions PR failures, including a helper script for check/log inspection.

- `$security-review`: a manually-invoked-only AI skill with GoMud-relevant Go, browser JavaScript, and jQuery security references.
