### PR TITLE
[CI] Fix release publish job

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -34,8 +34,8 @@ Recommended versioning for the next release line:
      - Run `go generate ./...`
      - Build per-platform binaries with `main.version` set from `main.go`
      - Create a generated prerelease tag like `pre-YYYYMMDDHHMMSS-<sha7>`
-     - Archive `_datafiles` as `go-mud-datafiles-pre-YYYYMMDDHHMMSS-<sha7>.zip`
-     - Generate `go-mud-pre-YYYYMMDDHHMMSS-<sha7>-SHA256SUMS.txt`
+     - Archive `_datafiles` as `gomud-ALL-datafiles-pre-YYYYMMDDHHMMSS-<sha7>.zip`
+     - Generate `gomud-pre-YYYYMMDDHHMMSS-<sha7>-SHA256SUMS.txt`
      - Publish a GitHub prerelease for that generated tag
      - Leave the release unmarked as `Latest`
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -119,7 +119,7 @@ jobs:
           -o bin/gomud-linux_arm5 .
 
       - name: Upload bin
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: bin-artifact
           path: bin/
@@ -139,7 +139,7 @@ jobs:
           persist-credentials: false
 
       - name: Download builds
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8.0.1
         with:
           name: bin-artifact
           path: bin/

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -134,8 +134,12 @@ jobs:
       DATAFILES_ARCHIVE: ${{ needs.prep.outputs.datafiles_archive }}
       CHECKSUMS_FILE: ${{ needs.prep.outputs.checksums_file }}
     steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Download builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bin-artifact
           path: bin/

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ci-local-inner: ### Run the local CI checks inside the CI tool image.
 		-e .github/act/pull_request.json \
 		-W .github/workflows/discord-notify.yml
 	act $(ACT_FLAGS) --dryrun push \
-		-e .github/act/push_tag.json \
+		-e .github/act/push_master.json \
 		-W .github/workflows/build-and-release.yml
 	act $(ACT_FLAGS) --dryrun push $(ACT_DRYRUN_SECRETS) \
 		-e .github/act/push_master.json \


### PR DESCRIPTION
## Summary
- fix the release job by checking out the repo before `gh release create`
- upgrade artifact actions to `actions/upload-artifact@v7.0.1` and `actions/download-artifact@v8.0.1`
- align local release dry-run validation with `push` to `master`
- sync release docs with the workflow's actual asset filenames

## Validation
- `actionlint .github/workflows/*.yml`
- `yamllint .github`
- `make validate`
- `act --pull=false -P ubuntu-24.04=catthehacker/ubuntu:act-latest --dryrun push -e .github/act/push_master.json -W .github/workflows/build-and-release.yml`
- `workflow_dispatch` release run completed successfully with published assets verified in GitHub Releases
