### PR TITLE
GMCP helpfiles

### DIFF
--- a/_datafiles/html/public/static/js/windows/window-comm.js
+++ b/_datafiles/html/public/static/js/windows/window-comm.js
@@ -63,6 +63,16 @@
             border-bottom: 2px solid #3ad4b8;
         }
 
+        @keyframes comm-tab-glow {
+            0%   { background: #0d2e28; color: #7ab8a0; }
+            50%  { background: #3ad4b8; color: #3ad4b8; }
+            100% { background: #0d2e28; color: #7ab8a0; }
+        }
+
+        #comm-output .tab-button.pending {
+            animation: comm-tab-glow 2s ease-in-out infinite;
+        }
+
         #comm-output .tab-contents {
             flex: 1;
             overflow: hidden;
@@ -160,6 +170,7 @@
                 panels.forEach(p => p.classList.remove('active'));
 
                 btn.classList.add('active');
+                btn.classList.remove('pending');
                 btn.dataset.unread = '0';
                 btn.textContent    = btn.dataset.label;
                 document.getElementById(target).classList.add('active');
@@ -211,6 +222,7 @@
         } else {
             tab.dataset.unread = String(parseInt(tab.dataset.unread) + 1);
             tab.textContent    = tab.dataset.label + '(' + tab.dataset.unread + ')';
+            tab.classList.add('pending');
         }
 
         const p = document.createElement('p');

--- a/_datafiles/world/default/items/consumables-30000/30012-phoenix_elixir.yaml
+++ b/_datafiles/world/default/items/consumables-30000/30012-phoenix_elixir.yaml
@@ -9,3 +9,4 @@ value: 92
 buffids: 
 - 14
 - 16
+- 35

--- a/modules/gmcp/files/data-overlays/keywords.yaml
+++ b/modules/gmcp/files/data-overlays/keywords.yaml
@@ -10,6 +10,7 @@ help:
       - mudletui
     integration:
       - discord
+      - gmcp
 
 # Aliases for keywords when typing: help <keyword>
 help-aliases:

--- a/modules/gmcp/files/datafiles/templates/help/gmcp-char.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp-char.template
@@ -1,0 +1,125 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp-char</ansi>
+
+The <ansi fg="white-bold">Char</ansi> GMCP payload delivers character state to the client. It is sent in full on login and updated incrementally as individual sub-payloads whenever the relevant data changes.
+
+Requesting <ansi fg="white-bold">Char</ansi> returns the complete payload. Individual sub-payloads can be requested or received independently.
+
+<ansi fg="yellow-bold">Char.Info</ansi>
+Sent on login and whenever core character attributes change.
+
+  <ansi fg="cyan">account</ansi>    <ansi fg="green">string</ansi>  - The player's account (login) username
+  <ansi fg="cyan">name</ansi>       <ansi fg="green">string</ansi>  - The character's in-game name
+  <ansi fg="cyan">class</ansi>      <ansi fg="green">string</ansi>  - Derived profession/class based on skill ranks
+  <ansi fg="cyan">race</ansi>       <ansi fg="green">string</ansi>  - Character race
+  <ansi fg="cyan">alignment</ansi>  <ansi fg="green">string</ansi>  - Moral alignment label (e.g. "Good", "Evil")
+  <ansi fg="cyan">level</ansi>      <ansi fg="yellow">number</ansi>  - Current character level
+  <ansi fg="cyan">role</ansi>       <ansi fg="green">string</ansi>  - Account role (e.g. "player", "admin")
+
+<ansi fg="yellow-bold">Char.Vitals</ansi>
+Sent whenever health or mana values change.
+
+  <ansi fg="cyan">hp</ansi>      <ansi fg="yellow">number</ansi>  - Current hit points
+  <ansi fg="cyan">hp_max</ansi>  <ansi fg="yellow">number</ansi>  - Maximum hit points
+  <ansi fg="cyan">sp</ansi>      <ansi fg="yellow">number</ansi>  - Current spell points (mana)
+  <ansi fg="cyan">sp_max</ansi>  <ansi fg="yellow">number</ansi>  - Maximum spell points
+
+<ansi fg="yellow-bold">Char.Stats</ansi>
+Sent when stats change (e.g. equipment changes, training).
+
+  <ansi fg="cyan">strength</ansi>      <ansi fg="yellow">number</ansi>  - Base strength value
+  <ansi fg="cyan">strengthmod</ansi>   <ansi fg="yellow">number</ansi>  - Modifier applied to strength (from buffs, gear, etc.)
+  <ansi fg="cyan">speed</ansi>         <ansi fg="yellow">number</ansi>  - Base speed value
+  <ansi fg="cyan">speedmod</ansi>      <ansi fg="yellow">number</ansi>  - Modifier applied to speed
+  <ansi fg="cyan">smarts</ansi>        <ansi fg="yellow">number</ansi>  - Base smarts (intelligence) value
+  <ansi fg="cyan">smartsmod</ansi>     <ansi fg="yellow">number</ansi>  - Modifier applied to smarts
+  <ansi fg="cyan">vitality</ansi>      <ansi fg="yellow">number</ansi>  - Base vitality (constitution) value
+  <ansi fg="cyan">vitalitymod</ansi>   <ansi fg="yellow">number</ansi>  - Modifier applied to vitality
+  <ansi fg="cyan">mysticism</ansi>     <ansi fg="yellow">number</ansi>  - Base mysticism (magic aptitude) value
+  <ansi fg="cyan">mysticismmod</ansi>  <ansi fg="yellow">number</ansi>  - Modifier applied to mysticism
+  <ansi fg="cyan">perception</ansi>    <ansi fg="yellow">number</ansi>  - Base perception value
+  <ansi fg="cyan">perceptionmod</ansi> <ansi fg="yellow">number</ansi>  - Modifier applied to perception
+
+<ansi fg="yellow-bold">Char.Worth</ansi>
+Sent when gold, experience, or spendable points change.
+
+  <ansi fg="cyan">gold_carry</ansi>      <ansi fg="yellow">number</ansi>  - Gold currently carried
+  <ansi fg="cyan">gold_bank</ansi>       <ansi fg="yellow">number</ansi>  - Gold stored in the bank
+  <ansi fg="cyan">skillpoints</ansi>     <ansi fg="yellow">number</ansi>  - Unspent skill points available for training
+  <ansi fg="cyan">trainingpoints</ansi>  <ansi fg="yellow">number</ansi>  - Unspent training points
+  <ansi fg="cyan">xp</ansi>              <ansi fg="yellow">number</ansi>  - Total experience points earned
+  <ansi fg="cyan">tnl</ansi>             <ansi fg="yellow">number</ansi>  - Experience points needed to reach the next level
+
+<ansi fg="yellow-bold">Char.Affects</ansi>
+Sent when active buffs or debuffs change. The payload is an object keyed by effect name.
+
+  Each entry contains:
+  <ansi fg="cyan">name</ansi>          <ansi fg="green">string</ansi>                        - Display name of the effect
+  <ansi fg="cyan">description</ansi>   <ansi fg="green">string</ansi>                        - Short description of what the effect does
+  <ansi fg="cyan">type</ansi>          <ansi fg="green">string</ansi>                        - Source category (e.g. "spell", "item", "unknown")
+  <ansi fg="cyan">duration_max</ansi>  <ansi fg="yellow">number</ansi>                        - Total duration in seconds (-1 if permanent)
+  <ansi fg="cyan">duration_cur</ansi>  <ansi fg="yellow">number</ansi>                        - Remaining duration in seconds (-1 if permanent)
+  <ansi fg="cyan">affects</ansi>       <ansi fg="blue-bold">object</ansi>(<ansi fg="green">string</ansi>-><ansi fg="yellow">number</ansi>)  - Map of stat names to their modifier values
+
+<ansi fg="yellow-bold">Char.Inventory</ansi>
+Sent when items are picked up, dropped, or equipped. Contains backpack and worn sub-objects.
+
+  <ansi fg="cyan">Backpack.Summary.count</ansi>  <ansi fg="yellow">number</ansi>  - Number of items currently carried
+  <ansi fg="cyan">Backpack.Summary.max</ansi>    <ansi fg="yellow">number</ansi>  - Maximum carry capacity
+  <ansi fg="cyan">Backpack.items</ansi>          <ansi fg="magenta">array</ansi>   - List of carried items (see item structure below)
+  <ansi fg="cyan">Worn</ansi>                    <ansi fg="blue-bold">object</ansi>  - Equipment slots: weapon, offhand, head, neck, body,
+                                   belt, gloves, ring, legs, feet
+
+  Each item (in backpack or worn slot) contains:
+  <ansi fg="cyan">id</ansi>       <ansi fg="green">string</ansi>  - Shorthand item identifier
+  <ansi fg="cyan">name</ansi>     <ansi fg="green">string</ansi>  - Display name
+  <ansi fg="cyan">type</ansi>     <ansi fg="green">string</ansi>  - Item category (e.g. "weapon", "armor", "food")
+  <ansi fg="cyan">subtype</ansi>  <ansi fg="green">string</ansi>  - Item sub-category (e.g. "sword", "chest", "potion")
+  <ansi fg="cyan">uses</ansi>     <ansi fg="yellow">number</ansi>  - Remaining uses (0 for items without charges)
+  <ansi fg="cyan">details</ansi>  <ansi fg="magenta">array</ansi>   - Flags such as "cursed", "quest", "2-handed"
+
+  <ansi fg="white-bold">Char.Inventory.Backpack</ansi> and <ansi fg="white-bold">Char.Inventory.Backpack.Summary</ansi> can be requested independently.
+
+<ansi fg="yellow-bold">Char.Enemies</ansi>
+Sent when the list of combatants in the room changes.
+
+  Each entry contains:
+  <ansi fg="cyan">id</ansi>        <ansi fg="green">string</ansi>  - Shorthand mob instance identifier
+  <ansi fg="cyan">name</ansi>      <ansi fg="green">string</ansi>  - Mob name
+  <ansi fg="cyan">level</ansi>     <ansi fg="yellow">number</ansi>  - Mob level
+  <ansi fg="cyan">hp</ansi>        <ansi fg="yellow">number</ansi>  - Current hit points
+  <ansi fg="cyan">hp_max</ansi>    <ansi fg="yellow">number</ansi>  - Maximum hit points
+  <ansi fg="cyan">engaged</ansi>   <ansi fg="red">bool</ansi>    - True if this mob is the one currently attacking the player
+
+<ansi fg="yellow-bold">Char.Quests</ansi>
+Sent when quest progress changes. Secret quests are excluded.
+
+  Each entry contains:
+  <ansi fg="cyan">name</ansi>         <ansi fg="green">string</ansi>  - Quest name
+  <ansi fg="cyan">description</ansi>  <ansi fg="green">string</ansi>  - Description of the current quest step
+  <ansi fg="cyan">completion</ansi>   <ansi fg="yellow">number</ansi>  - Percentage complete (0-100)
+
+<ansi fg="yellow-bold">Char.Skills</ansi>
+Sent when skills are gained or trained.
+
+  Each entry contains:
+  <ansi fg="cyan">name</ansi>     <ansi fg="green">string</ansi>  - Skill name
+  <ansi fg="cyan">level</ansi>    <ansi fg="yellow">number</ansi>  - Current skill rank (1-4)
+  <ansi fg="cyan">maximum</ansi>  <ansi fg="red">bool</ansi>    - True if the skill is at maximum rank
+
+<ansi fg="yellow-bold">Char.Jobs</ansi>
+Sent when profession progress changes. Jobs are derived from skill rank combinations.
+
+  Each entry contains:
+  <ansi fg="cyan">name</ansi>         <ansi fg="green">string</ansi>  - Profession name
+  <ansi fg="cyan">proficiency</ansi>  <ansi fg="green">string</ansi>  - Proficiency title (e.g. "Apprentice", "Master")
+  <ansi fg="cyan">completion</ansi>   <ansi fg="yellow">number</ansi>  - Percentage progress toward the next proficiency tier (0-100)
+
+<ansi fg="yellow-bold">Char.Pets</ansi>
+Sent when the player's pet status changes.
+
+  Each entry contains:
+  <ansi fg="cyan">name</ansi>    <ansi fg="green">string</ansi>  - Pet's name
+  <ansi fg="cyan">type</ansi>    <ansi fg="green">string</ansi>  - Pet species or type
+  <ansi fg="cyan">hunger</ansi>  <ansi fg="green">string</ansi>  - Hunger state (e.g. "full")
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help gmcp</ansi>, <ansi fg="command">help gmcp-room</ansi>, <ansi fg="command">help gmcp-party</ansi>

--- a/modules/gmcp/files/datafiles/templates/help/gmcp-comm.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp-comm.template
@@ -1,0 +1,17 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp-comm</ansi>
+
+The <ansi fg="white-bold">Comm.Channel</ansi> GMCP payload is sent whenever an in-game communication event occurs that the receiving player would normally see as text.
+
+<ansi fg="yellow-bold">Comm.Channel</ansi>
+Delivered to all players who would receive the message in-game.
+
+  <ansi fg="cyan">channel</ansi>  <ansi fg="green">string</ansi>  - The communication channel. One of:
+                   "say"       - Message spoken in the current room
+                   "party"     - Message sent to the player's party
+                   "broadcast" - Server-wide broadcast
+                   "whisper"   - Private message to a specific player
+  <ansi fg="cyan">sender</ansi>   <ansi fg="green">string</ansi>  - Name of the character or mob who sent the message
+  <ansi fg="cyan">source</ansi>   <ansi fg="green">string</ansi>  - Origin type: "player" or "mob"
+  <ansi fg="cyan">text</ansi>     <ansi fg="green">string</ansi>  - The message text, stripped of ANSI color codes
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help gmcp</ansi>, <ansi fg="command">help gmcp-char</ansi>

--- a/modules/gmcp/files/datafiles/templates/help/gmcp-game.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp-game.template
@@ -1,0 +1,17 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp-game</ansi>
+
+The <ansi fg="white-bold">Game</ansi> GMCP payload is sent to all online players whenever someone connects or disconnects. It combines server identity information with the current online player list into a single object.
+
+<ansi fg="yellow-bold">Game</ansi>
+
+  <ansi fg="cyan">Info.logintime</ansi>  <ansi fg="green">string</ansi>  - The time the receiving player logged in, formatted per the server's configured time format
+  <ansi fg="cyan">Info.name</ansi>       <ansi fg="green">string</ansi>  - The name of the MUD server
+
+  <ansi fg="cyan">Who.Players</ansi>     <ansi fg="magenta">array</ansi>   - List of currently online players
+
+  Each entry in <ansi fg="white-bold">Who.Players</ansi> contains:
+  <ansi fg="cyan">name</ansi>   <ansi fg="green">string</ansi>  - Character name
+  <ansi fg="cyan">level</ansi>  <ansi fg="yellow">number</ansi>  - Character level
+  <ansi fg="cyan">title</ansi>  <ansi fg="green">string</ansi>  - Account role or title (e.g. "player", "admin")
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help gmcp</ansi>, <ansi fg="command">help gmcp-gametime</ansi>

--- a/modules/gmcp/files/datafiles/templates/help/gmcp-gametime.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp-gametime.template
@@ -1,0 +1,20 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp-gametime</ansi>
+
+The <ansi fg="white-bold">Gametime</ansi> GMCP payload is sent to all online players every game round, providing the current in-game calendar date and time.
+
+<ansi fg="yellow-bold">Gametime</ansi>
+
+  <ansi fg="cyan">hour</ansi>         <ansi fg="yellow">number</ansi>  - Current in-game hour (12-hour format)
+  <ansi fg="cyan">hour24</ansi>       <ansi fg="yellow">number</ansi>  - Current in-game hour (24-hour format)
+  <ansi fg="cyan">minute</ansi>       <ansi fg="yellow">number</ansi>  - Current in-game minute
+  <ansi fg="cyan">ampm</ansi>         <ansi fg="green">string</ansi>  - "am" or "pm"
+  <ansi fg="cyan">day</ansi>          <ansi fg="yellow">number</ansi>  - Current day of the month
+  <ansi fg="cyan">month</ansi>        <ansi fg="yellow">number</ansi>  - Current month number
+  <ansi fg="cyan">month_name</ansi>   <ansi fg="green">string</ansi>  - Name of the current in-game month
+  <ansi fg="cyan">year</ansi>         <ansi fg="yellow">number</ansi>  - Current in-game year
+  <ansi fg="cyan">zodiac</ansi>       <ansi fg="green">string</ansi>  - Zodiac sign associated with the current year
+  <ansi fg="cyan">night</ansi>        <ansi fg="red">bool</ansi>    - True if it is currently nighttime in-game
+  <ansi fg="cyan">day_start</ansi>    <ansi fg="yellow">number</ansi>  - The hour (24h) at which daytime begins
+  <ansi fg="cyan">night_start</ansi>  <ansi fg="yellow">number</ansi>  - The hour (24h) at which nighttime begins
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help gmcp</ansi>, <ansi fg="command">help gmcp-game</ansi>

--- a/modules/gmcp/files/datafiles/templates/help/gmcp-help.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp-help.template
@@ -1,0 +1,18 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp-help</ansi>
+
+The <ansi fg="white-bold">Help</ansi> GMCP payload delivers help content directly to the client over GMCP rather than as terminal text. This is primarily used by the web client to display help in a dedicated UI panel.
+
+To request a help topic, send: <ansi fg="white-bold">!!GMCP(Help topic-name)</ansi>
+
+<ansi fg="yellow-bold">Help</ansi>
+
+  <ansi fg="cyan">title</ansi>   <ansi fg="green">string</ansi>  - The help topic name that was requested
+  <ansi fg="cyan">body</ansi>    <ansi fg="green">string</ansi>  - The rendered help content with ANSI escape sequences applied
+  <ansi fg="cyan">format</ansi>  <ansi fg="green">string</ansi>  - Content format descriptor. Currently always "terminal"
+
+<ansi fg="yellow-bold">Notes:</ansi>
+- If no help content is found for the requested topic, the body will contain a
+  "No help found" message.
+- The body text includes ANSI color codes suitable for terminal rendering.
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help gmcp</ansi>, <ansi fg="command">help client</ansi>

--- a/modules/gmcp/files/datafiles/templates/help/gmcp-party.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp-party.template
@@ -1,0 +1,28 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp-party</ansi>
+
+The <ansi fg="white-bold">Party</ansi> GMCP payload is sent to all party members whenever the party composition changes. The <ansi fg="white-bold">Party.Vitals</ansi> sub-payload is sent more frequently as members move or take damage.
+
+Players who are not in a party receive an empty <ansi fg="white-bold">Party</ansi> payload.
+
+<ansi fg="yellow-bold">Party</ansi>
+Full party state, sent on membership changes.
+
+  <ansi fg="cyan">Leader</ansi>   <ansi fg="green">string</ansi>  - Name of the party leader ("None" if no leader)
+  <ansi fg="cyan">Members</ansi>  <ansi fg="magenta">array</ansi>   - Players and charmed companions currently in the party
+  <ansi fg="cyan">Invited</ansi>  <ansi fg="magenta">array</ansi>   - Players who have been invited but have not yet joined
+  <ansi fg="cyan">Vitals</ansi>   <ansi fg="blue-bold">object</ansi>  - Keyed by character name (see Party.Vitals below)
+
+  Each entry in <ansi fg="white-bold">Members</ansi> and <ansi fg="white-bold">Invited</ansi> contains:
+  <ansi fg="cyan">name</ansi>      <ansi fg="green">string</ansi>  - Character or mob name
+  <ansi fg="cyan">status</ansi>    <ansi fg="green">string</ansi>  - Membership state: "In Party", "Invited", or a charm indicator
+  <ansi fg="cyan">position</ansi>  <ansi fg="green">string</ansi>  - Tactical rank in the party (e.g. "frontrank", "backrank") or "-" for charmed mobs
+
+<ansi fg="yellow-bold">Party.Vitals</ansi>
+Lightweight update sent whenever a member moves or their health changes. The payload is an object keyed by character name.
+
+  Each entry contains:
+  <ansi fg="cyan">level</ansi>     <ansi fg="yellow">number</ansi>  - Character or mob level
+  <ansi fg="cyan">health</ansi>    <ansi fg="yellow">number</ansi>  - Current health as a percentage (0-100)
+  <ansi fg="cyan">location</ansi>  <ansi fg="green">string</ansi>  - Title of the room the member is currently in
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help gmcp</ansi>, <ansi fg="command">help gmcp-char</ansi>

--- a/modules/gmcp/files/datafiles/templates/help/gmcp-room.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp-room.template
@@ -1,0 +1,71 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp-room</ansi>
+
+The <ansi fg="white-bold">Room.Info</ansi> GMCP payload is sent whenever the player enters a new room. Sub-payloads for room contents are updated independently as players, mobs, and items change.
+
+Requesting <ansi fg="white-bold">Room.Info</ansi> returns the complete payload. Sub-payloads such as <ansi fg="white-bold">Room.Info.Contents.Players</ansi> can be requested or received independently.
+
+<ansi fg="yellow-bold">Room.Info</ansi>
+Full room state, sent on room entry.
+
+  <ansi fg="cyan">num</ansi>          <ansi fg="yellow">number</ansi>  - Unique room ID
+  <ansi fg="cyan">name</ansi>         <ansi fg="green">string</ansi>  - Room title
+  <ansi fg="cyan">area</ansi>         <ansi fg="green">string</ansi>  - Zone/area name the room belongs to
+  <ansi fg="cyan">environment</ansi>  <ansi fg="green">string</ansi>  - Biome name (e.g. "Forest", "Cave", "City")
+  <ansi fg="cyan">coords</ansi>       <ansi fg="green">string</ansi>  - Comma-separated string: "ZoneName, x, y, z"
+  <ansi fg="cyan">mapsymbol</ansi>    <ansi fg="green">string</ansi>  - Single character used to represent this room on ASCII maps
+  <ansi fg="cyan">maplegend</ansi>    <ansi fg="green">string</ansi>  - Label describing the map symbol
+  <ansi fg="cyan">exits</ansi>        <ansi fg="blue-bold">object</ansi>  - Map of exit direction to destination room ID (number)
+  <ansi fg="cyan">exitsv2</ansi>      <ansi fg="blue-bold">object</ansi>  - Extended exit data keyed by direction (see below)
+  <ansi fg="cyan">details</ansi>      <ansi fg="magenta">array</ansi>   - Room feature flags. Possible values:
+                    "trainer"    - Room has a skill trainer
+                    "bank"       - Room contains a bank
+                    "storage"    - Room has player storage
+                    "character"  - Character creation/management room
+                    "pvp"        - PvP combat is enabled
+                    "ephemeral"  - Dynamically generated room (not persistent)
+                    "root"       - Entry room for the zone
+  <ansi fg="cyan">Contents</ansi>     <ansi fg="blue-bold">object</ansi>  - Players, NPCs, items, and containers present (see below)
+
+  Each entry in <ansi fg="white-bold">exitsv2</ansi> contains:
+  <ansi fg="cyan">num</ansi>      <ansi fg="yellow">number</ansi>  - Destination room ID
+  <ansi fg="cyan">dx</ansi>       <ansi fg="yellow">number</ansi>  - X-axis delta for mapping (-1, 0, or 1)
+  <ansi fg="cyan">dy</ansi>       <ansi fg="yellow">number</ansi>  - Y-axis delta for mapping (-1, 0, or 1)
+  <ansi fg="cyan">dz</ansi>       <ansi fg="yellow">number</ansi>  - Z-axis delta for mapping (-1, 0, or 1)
+  <ansi fg="cyan">details</ansi>  <ansi fg="magenta">array</ansi>   - Exit flags: "secret", "locked", "player_has_key", "player_has_pick_combo"
+
+<ansi fg="yellow-bold">Room.Info.Contents</ansi>
+Sent as part of Room.Info or independently when contents change.
+
+  <ansi fg="cyan">Players</ansi>     <ansi fg="magenta">array</ansi>  - Other players visible in the room (excludes the receiving player)
+  <ansi fg="cyan">Npcs</ansi>        <ansi fg="magenta">array</ansi>  - NPCs/mobs visible in the room
+  <ansi fg="cyan">Items</ansi>       <ansi fg="magenta">array</ansi>  - Items on the ground
+  <ansi fg="cyan">Containers</ansi>  <ansi fg="magenta">array</ansi>  - Containers present in the room
+
+  Each entry in <ansi fg="white-bold">Players</ansi> and <ansi fg="white-bold">Npcs</ansi> contains:
+  <ansi fg="cyan">id</ansi>          <ansi fg="green">string</ansi>  - Shorthand identifier for the character or mob instance
+  <ansi fg="cyan">name</ansi>        <ansi fg="green">string</ansi>  - Display name
+  <ansi fg="cyan">adjectives</ansi>  <ansi fg="magenta">array</ansi>   - Descriptive adjectives (e.g. race, size, condition)
+  <ansi fg="cyan">aggro</ansi>       <ansi fg="red">bool</ansi>    - True if currently engaged in combat
+  <ansi fg="cyan">quest_flag</ansi>  <ansi fg="red">bool</ansi>    - True if this NPC is relevant to one of the player's quests
+
+  Each entry in <ansi fg="white-bold">Items</ansi> contains:
+  <ansi fg="cyan">id</ansi>          <ansi fg="green">string</ansi>  - Shorthand item identifier
+  <ansi fg="cyan">name</ansi>        <ansi fg="green">string</ansi>  - Display name
+  <ansi fg="cyan">quest_flag</ansi>  <ansi fg="red">bool</ansi>    - True if this item is a quest item
+
+  Each entry in <ansi fg="white-bold">Containers</ansi> contains:
+  <ansi fg="cyan">name</ansi>           <ansi fg="green">string</ansi>  - Container name
+  <ansi fg="cyan">locked</ansi>         <ansi fg="red">bool</ansi>    - True if the container is locked
+  <ansi fg="cyan">haskey</ansi>         <ansi fg="red">bool</ansi>    - True if the player has a key for this container
+  <ansi fg="cyan">haspickcombo</ansi>   <ansi fg="red">bool</ansi>    - True if the player knows the pick combination for this lock
+  <ansi fg="cyan">usable</ansi>         <ansi fg="red">bool</ansi>    - True if the container can be used as a crafting station
+
+<ansi fg="yellow-bold">Notes:</ansi>
+- Hidden players and mobs are excluded from Contents.
+- Secret exits the player has not yet discovered are excluded from exits and exitsv2.
+- <ansi fg="white-bold">Room.Info.Contents.Players</ansi>, <ansi fg="white-bold">Room.Info.Contents.Npcs</ansi>, <ansi fg="white-bold">Room.Info.Contents.Items</ansi>,
+  and <ansi fg="white-bold">Room.Info.Contents.Containers</ansi> can each be requested independently.
+- When a player leaves a room, a bare <ansi fg="white-bold">Room.RemovePlayer "Name"</ansi> message is sent to
+  remaining players instead of a full Contents update.
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help gmcp</ansi>, <ansi fg="command">help gmcp-world</ansi>, <ansi fg="command">help gmcp-char</ansi>

--- a/modules/gmcp/files/datafiles/templates/help/gmcp-world.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp-world.template
@@ -1,0 +1,26 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp-world</ansi>
+
+The <ansi fg="white-bold">World.Map</ansi> GMCP payload is sent on request and delivers a snapshot of every room the player has previously visited, across all zones. It is intended for building a persistent client-side map.
+
+<ansi fg="yellow-bold">World.Map</ansi>
+An array of room entries. Each entry mirrors the structure of <ansi fg="white-bold">Room.Info</ansi> but omits live contents (players, NPCs, items).
+
+  <ansi fg="cyan">num</ansi>          <ansi fg="yellow">number</ansi>  - Unique room ID
+  <ansi fg="cyan">name</ansi>         <ansi fg="green">string</ansi>  - Room title
+  <ansi fg="cyan">area</ansi>         <ansi fg="green">string</ansi>  - Zone/area name the room belongs to
+  <ansi fg="cyan">environment</ansi>  <ansi fg="green">string</ansi>  - Biome name (e.g. "Forest", "Cave", "City")
+  <ansi fg="cyan">coords</ansi>       <ansi fg="green">string</ansi>  - Comma-separated string: "ZoneName, x, y, z"
+  <ansi fg="cyan">mapsymbol</ansi>    <ansi fg="green">string</ansi>  - Single character used to represent this room on ASCII maps
+  <ansi fg="cyan">maplegend</ansi>    <ansi fg="green">string</ansi>  - Label describing the map symbol
+  <ansi fg="cyan">exits</ansi>        <ansi fg="blue-bold">object</ansi>  - Map of exit direction to destination room ID (number)
+  <ansi fg="cyan">exitsv2</ansi>      <ansi fg="blue-bold">object</ansi>  - Extended exit data keyed by direction (see gmcp-room for structure)
+  <ansi fg="cyan">details</ansi>      <ansi fg="magenta">array</ansi>   - Room feature flags (same set as Room.Info)
+
+<ansi fg="yellow-bold">Notes:</ansi>
+- Only rooms the player has personally visited are included.
+- Exits to unvisited rooms are excluded.
+- Secret exits the player has not discovered are excluded.
+- This payload can be large for well-traveled characters. Clients should request it
+  only when building or refreshing a persistent map, not on every room change.
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help gmcp</ansi>, <ansi fg="command">help gmcp-room</ansi>

--- a/modules/gmcp/files/datafiles/templates/help/gmcp.template
+++ b/modules/gmcp/files/datafiles/templates/help/gmcp.template
@@ -1,0 +1,43 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gmcp</ansi>
+
+GMCP (Generic MUD Communication Protocol) is a telnet sub-negotiation protocol that allows the server to send structured JSON data to your client alongside normal text output. Clients that support GMCP can use this data to build custom UIs, maps, and status displays.
+
+The server sends GMCP data automatically as game state changes. Clients may also request specific payloads by name.
+
+<ansi fg="yellow-bold">Top-Level Payloads:</ansi>
+
+  <ansi fg="white-bold">Char</ansi>         - Character information, stats, inventory, and status
+                 See <ansi fg="command">help gmcp-char</ansi>
+
+  <ansi fg="white-bold">Comm.Channel</ansi> - In-game communication messages (say, party, broadcast, whisper)
+                 See <ansi fg="command">help gmcp-comm</ansi>
+
+  <ansi fg="white-bold">Game</ansi>         - Server information and online player list
+                 See <ansi fg="command">help gmcp-game</ansi>
+
+  <ansi fg="white-bold">Gametime</ansi>     - In-game calendar and time-of-day data
+                 See <ansi fg="command">help gmcp-gametime</ansi>
+
+  <ansi fg="white-bold">Party</ansi>        - Party membership, roles, and member vitals
+                 See <ansi fg="command">help gmcp-party</ansi>
+
+  <ansi fg="white-bold">Room.Info</ansi>    - Current room details, exits, and contents
+                 See <ansi fg="command">help gmcp-room</ansi>
+
+  <ansi fg="white-bold">World.Map</ansi>    - Snapshot of all rooms the player has visited
+                 See <ansi fg="command">help gmcp-world</ansi>
+
+  <ansi fg="white-bold">Help</ansi>         - Help content delivered over GMCP (used by the web client)
+                 See <ansi fg="command">help gmcp-help</ansi>
+
+  <ansi fg="white-bold">Client.GUI</ansi>   - Mudlet UI package installation and update instructions
+  <ansi fg="white-bold">Client.Map</ansi>   - Mudlet mapper package URL
+  <ansi fg="white-bold">External.Discord.Info</ansi>   - Discord Rich Presence application identity
+  <ansi fg="white-bold">External.Discord.Status</ansi> - Discord Rich Presence status update
+
+<ansi fg="yellow-bold">Notes:</ansi>
+- GMCP is negotiated automatically over telnet. Web client connections have GMCP enabled by default.
+- Clients declare which modules they support via <ansi fg="white-bold">Core.Supports.Set</ansi>.
+- All payloads are JSON objects unless otherwise noted.
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help client</ansi>, <ansi fg="command">help gmcp-char</ansi>, <ansi fg="command">help gmcp-room</ansi>, <ansi fg="command">help gmcp-party</ansi>

--- a/modules/webhelp/webhelp.go
+++ b/modules/webhelp/webhelp.go
@@ -106,6 +106,9 @@ func (w *WebHelpModule) getHelpCommand(r *http.Request) map[string]any {
 
 	searchTerm := r.URL.Query().Get("search")
 	searchTerm = strings.TrimSpace(searchTerm)
+	if strings.HasPrefix(strings.ToLower(searchTerm), "help ") {
+		searchTerm = strings.TrimSpace(searchTerm[5:])
+	}
 
 	data := map[string]any{}
 	data[`error`] = ``


### PR DESCRIPTION
# Description

This adds helpfiles for `gmcp` and related payloads (described within the `help gmcp` helpfile). This is intended to help developers find the gmcp structures and utilize them.

## Changes

- gmcp helpfiles added to gmcp module
- Added the death recovery buff to the phoenix elixer
- When a webclient "comm" message comes into a tab not currently selected, the tab glows to indicate a message is waiting.