### PR TITLE
Gambling module

### DIFF
--- a/_datafiles/world/default/rooms/frostfang_slums/1005.yaml
+++ b/_datafiles/world/default/rooms/frostfang_slums/1005.yaml
@@ -1,0 +1,20 @@
+roomid: 1005
+zone: Frostfang Slums
+title: Casino Entrance
+description: The air here carries the mingled scent of pipe smoke, spilled wine, and
+  something sharper - the particular tension of people watching their fortunes turn.
+  Polished brass fixtures line the walls, their warm glow catching the faces of those
+  who linger near the entrance, some freshly arrived and bright-eyed, others wearing
+  the quieter expression of someone who has been here before. A velvet rope cordons
+  off the main floor beyond, though the rope is purely ceremonial; no one has been
+  turned away in living memory. From somewhere deeper inside comes the rhythmic clatter
+  of dice, the mechanical thunk of levers being pulled, and the occasional sharp cry
+  of someone whose luck has just changed - in one direction or the other.
+biome: city
+exits:
+  east:
+    roomid: 440
+  north:
+    roomid: 1006
+  west:
+    roomid: 1007

--- a/_datafiles/world/default/rooms/frostfang_slums/1006.yaml
+++ b/_datafiles/world/default/rooms/frostfang_slums/1006.yaml
@@ -1,0 +1,19 @@
+roomid: 1006
+zone: Frostfang Slums
+title: Casino North Wing
+description: The north wing operates at a different frequency than the rest of the
+  casino. The carpet here is a deeper red, the ceiling lower, the lighting more deliberate
+  - pools of it falling precisely over felt-covered tables where players sit in the
+  careful stillness of people who are thinking hard. Dealers move with the practiced
+  economy of those who have made the same gestures ten thousand times and found a
+  kind of peace in the repetition. Conversation, where it exists at all, is low and
+  clipped. The chips make a dry, clean sound when stacked. Someone at the far table
+  exhales slowly and turns a card. The room absorbs the result without comment. Whatever
+  happens here happens quietly, which somehow makes it feel more consequential than
+  the noise next door.
+biome: city
+exits:
+  south:
+    roomid: 1005
+tags:
+- claw machine

--- a/_datafiles/world/default/rooms/frostfang_slums/1007.yaml
+++ b/_datafiles/world/default/rooms/frostfang_slums/1007.yaml
@@ -1,0 +1,20 @@
+roomid: 1007
+zone: Frostfang Slums
+title: Casino West Wing
+description: The west wing hits you before you fully enter it. The noise arrives first
+  - a wall of sound built from the rhythmic clank of levers, the spinning whir of
+  reels, and the occasional eruption of celebration from somewhere across the room.
+  Rows of gleaming machines line the walls and march in columns down the center of
+  the floor, each one lit from within by a warm amber glow that gives the whole wing
+  the quality of perpetual late evening. The carpet underfoot is thick and patterned
+  in a design busy enough to hide a multitude of sins. Players sit hunched or perched
+  at their machines with the focused detachment of people who have temporarily excused
+  themselves from the rest of the world. Near the far wall, a claw machine stands
+  apart from the rest, its glass cabinet glowing a cool blue, prizes visible inside
+  like fish in an illuminated tank.
+biome: city
+exits:
+  east:
+    roomid: 1005
+tags:
+- slot machine

--- a/_datafiles/world/default/rooms/frostfang_slums/440.yaml
+++ b/_datafiles/world/default/rooms/frostfang_slums/440.yaml
@@ -15,3 +15,5 @@ exits:
     roomid: 439
   south:
     roomid: 441
+  west:
+    roomid: 1005

--- a/ai-context/global-summary.md
+++ b/ai-context/global-summary.md
@@ -60,10 +60,6 @@ internal/                  # Core engine packages (Go internal convention)
 └── [30+ other packages]  # Modular architecture with clear separation
 
 modules/                   # Plugin system for extending functionality
-├── gmcp/                 # Generic MUD Communication Protocol
-├── auctions/             # Player auction system
-├── follow/               # Player following mechanics
-└── [other modules]       # Extensible module architecture
 
 provisioning/             # Docker deployment configuration
 ```

--- a/modules/context.md
+++ b/modules/context.md
@@ -38,61 +38,6 @@ The GoMud modules system provides a powerful plugin architecture that allows for
 - **File overlay system**: Plugin files can override core game files
 - **Data file integration**: Plugin data files are merged with core data files
 
-### Module Implementations (`modules/`)
-
-#### **GMCP Module** (`modules/gmcp/`)
-**Generic MUD Communication Protocol implementation**
-- **Multi-component architecture**: Separate components for Char, Comm, Game, Mudlet, Party, Room
-- **Real-time data sync**: Character stats, room information, party status to MUD clients
-- **Client integration**: Mudlet-specific features including mapping and UI components
-- **Telnet protocol handling**: IAC command processing for GMCP negotiation
-- **Discord integration**: Status updates and message bridging
-- **Event-driven updates**: Responds to character changes, room changes, party updates
-
-#### **Auctions Module** (`modules/auctions/`)
-**Player auction system**
-- **Auction management**: Start, bid, and end auction functionality
-- **Event-driven processing**: Uses NewRound events for auction timing
-- **Template system**: Custom templates for auction notifications
-- **State persistence**: Saves auction history and current auction state
-- **User command integration**: Adds `auction` command for player interaction
-- **Broadcast integration**: Auction updates sent to all players
-
-#### **Follow Module** (`modules/follow/`)
-**Player and mob following mechanics**
-- **Follow relationships**: Track who follows whom with limits and restrictions
-- **Event integration**: Responds to room changes, player/mob deaths, party updates
-- **AI integration**: Idle mob handlers for following behavior
-- **Scripting functions**: Exposes follow functions to JavaScript runtime
-- **State management**: Persistent follow relationships across server restarts
-- **Party integration**: Following behavior integrates with party system
-
-#### **Leaderboards Module** (`modules/leaderboards/`)
-**Player statistics and rankings**
-- **Web interface**: Custom web page showing player rankings
-- **Data collection**: Tracks various player statistics over time
-- **Periodic updates**: Uses NewRound events to update statistics
-- **Persistent storage**: Saves leaderboard data between server restarts
-- **Navigation integration**: Adds leaderboards link to web interface
-
-#### **Time Module** (`modules/time/`)
-**Game time display functionality**
-- **Simple command**: Adds `time` command to display current game time
-- **Template integration**: Uses help system for command documentation
-- **Minimal example**: Demonstrates basic plugin functionality
-
-#### **Cleanup Module** (`modules/cleanup/`)
-**World cleanup and maintenance**
-- **Cleanup commands**: `bury` and `trash` commands for removing items/corpses
-- **World maintenance**: Automated cleanup of abandoned items and corpses
-- **Configuration**: Configurable cleanup intervals and rules
-
-#### **Web Help Module** (`modules/webhelp/`)
-**Web-based help system**
-- **Help browser**: Web interface for browsing game help files
-- **Search functionality**: Search through help topics via web interface
-- **Template system**: Custom HTML templates for help display
-
 ## Event System Integration
 
 ### **Event-Driven Architecture**
@@ -323,6 +268,7 @@ The engine provides numerous hooks for module integration:
 - **GMCP**: Essential for modern MUD clients
 - **Auctions**: Player economy features
 - **Follow**: Social and AI mechanics
+- **Gambling**: Gambling items and room-based slot machines
 - **Leaderboards**: Player engagement and competition
 - **Time**: Basic utility functionality
 - **Cleanup**: World maintenance

--- a/modules/gambling/claw.go
+++ b/modules/gambling/claw.go
@@ -1,0 +1,245 @@
+package gambling
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+const defaultClawCost = 10
+const defaultClawWinChance = 10 // percent
+
+// clawPrize describes one prize slot in the claw machine.
+type clawPrize struct {
+	itemId    int
+	name      string
+	configKey string // config key for this prize's weight
+	defaultWt int    // weight used when config key is absent
+}
+
+// clawPrizes is the ordered list of prizes the claw machine can award.
+// Weights are relative: a prize with weight 20 is twice as likely as one with weight 10.
+// Set a prize's weight to 0 in config to remove it from the pool entirely.
+var clawPrizes = []clawPrize{
+	{dieItemId, `6-sided die`, `ClawPrizeDie`, 20},
+	{coinItemId, `lucky coin`, `ClawPrizeCoin`, 20},
+	{bottleItemId, `empty bottle`, `ClawPrizeBottle`, 20},
+	{cardsItemId, `deck of cards`, `ClawPrizeCards`, 15},
+	{eightItemId, `magic 8-ball`, `ClawPrize8Ball`, 15},
+	{tarotItemId, `tarot deck`, `ClawPrizeTarot`, 10},
+}
+
+// roomHasClaw returns true when the room carries a "claw machine" tag.
+func roomHasClaw(r *rooms.Room) bool {
+	for _, t := range r.Tags {
+		if strings.ToLower(t) == `claw machine` {
+			return true
+		}
+	}
+	return false
+}
+
+// clawPrizeWeight returns the configured weight for a prize, falling back to the default.
+func (g *GamblingModule) clawPrizeWeight(p clawPrize) int {
+	if v, ok := g.plug.Config.Get(p.configKey).(int); ok {
+		return v
+	}
+	return p.defaultWt
+}
+
+// pickClawPrize selects a prize using weighted random selection over the active pool.
+// Returns nil if the pool is empty (all weights zero).
+func (g *GamblingModule) pickClawPrize() *clawPrize {
+	total := 0
+	for i := range clawPrizes {
+		total += g.clawPrizeWeight(clawPrizes[i])
+	}
+	if total <= 0 {
+		return nil
+	}
+	roll := util.Rand(total)
+	cumulative := 0
+	for i := range clawPrizes {
+		cumulative += g.clawPrizeWeight(clawPrizes[i])
+		if roll < cumulative {
+			return &clawPrizes[i]
+		}
+	}
+	return &clawPrizes[len(clawPrizes)-1]
+}
+
+// onRoomLookClaw injects a claw machine alert when the room has the claw machine tag.
+func (g *GamblingModule) onRoomLookClaw(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
+	for _, t := range d.Tags {
+		if strings.ToLower(t) == `claw machine` {
+			d.RoomAlerts = append(d.RoomAlerts,
+				`There is a <ansi fg="cyan-bold">claw machine</ansi> here! You can <ansi fg="command">look</ansi> at or <ansi fg="command">play</ansi> it.`,
+			)
+			return d
+		}
+	}
+	return d
+}
+
+// playClaw executes one claw machine attempt for the user.
+func (g *GamblingModule) playClaw(user *users.UserRecord, room *rooms.Room) {
+
+	cost := defaultClawCost
+	if v, ok := g.plug.Config.Get(`ClawCost`).(int); ok && v > 0 {
+		cost = v
+	}
+
+	winChance := defaultClawWinChance
+	if v, ok := g.plug.Config.Get(`ClawWinChance`).(int); ok && v > 0 {
+		winChance = v
+	}
+
+	if user.Character.Gold < cost {
+		user.SendText(fmt.Sprintf(
+			`You need at least <ansi fg="gold">%d gold</ansi> to play the claw machine.`,
+			cost,
+		))
+		return
+	}
+
+	user.Character.Gold -= cost
+	events.AddToQueue(events.EquipmentChange{
+		UserId:     user.UserId,
+		GoldChange: -cost,
+	})
+
+	room.SendText(
+		fmt.Sprintf(`<ansi fg="username">%s</ansi> feeds coins into the claw machine and grips the joystick...`,
+			user.Character.Name),
+		user.UserId,
+	)
+
+	if util.Rand(100) >= winChance {
+		user.SendText(`<ansi fg="cyan">The claw descends...</ansi> hovers tantalizingly over a prize...`)
+		user.SendText(`<ansi fg="8">...and drops it at the last moment. Better luck next time!</ansi>`)
+		room.SendText(
+			fmt.Sprintf(`<ansi fg="8">The claw drops its prize just before the chute. <ansi fg="username">%s</ansi> walks away empty-handed.</ansi>`,
+				user.Character.Name),
+			user.UserId,
+		)
+		return
+	}
+
+	selected := g.pickClawPrize()
+	if selected == nil {
+		user.SendText(`<ansi fg="8">The claw machine whirs but the prize pool is empty. (All prize weights are zero.)</ansi>`)
+		return
+	}
+
+	prize := items.New(selected.itemId)
+	if !prize.IsValid() {
+		user.SendText(`<ansi fg="8">The claw machine whirs but produces nothing. (Something went wrong internally.)</ansi>`)
+		return
+	}
+
+	if !user.Character.StoreItem(prize) {
+		user.SendText(fmt.Sprintf(
+			`<ansi fg="cyan">The claw snatches up a <ansi fg="item">%s</ansi>!</ansi> <ansi fg="214">But your backpack is full — it tumbles back into the machine.</ansi>`,
+			selected.name,
+		))
+		return
+	}
+
+	events.AddToQueue(events.ItemOwnership{
+		UserId: user.UserId,
+		Item:   prize,
+		Gained: true,
+	})
+
+	user.SendText(`<ansi fg="cyan-bold">The claw descends with purpose...</ansi>`)
+	user.SendText(fmt.Sprintf(
+		`<ansi fg="green-bold">...and snatches up a <ansi fg="item">%s</ansi>!</ansi> It drops neatly into the prize chute. <ansi fg="yellow-bold">Congratulations!</ansi>`,
+		selected.name,
+	))
+	room.SendText(
+		fmt.Sprintf(`<ansi fg="cyan-bold">The claw machine rattles!</ansi> <ansi fg="username">%s</ansi> <ansi fg="green">wins a prize!</ansi>`,
+			user.Character.Name),
+		user.UserId,
+	)
+}
+
+// clawMachineNounDesc returns the noun description shown when a player types
+// "look claw machine" in a room with the claw machine tag.
+func (g *GamblingModule) clawMachineNounDesc(room *rooms.Room) string {
+	cost := defaultClawCost
+	if v, ok := g.plug.Config.Get(`ClawCost`).(int); ok && v > 0 {
+		cost = v
+	}
+	winChance := defaultClawWinChance
+	if v, ok := g.plug.Config.Get(`ClawWinChance`).(int); ok && v > 0 {
+		winChance = v
+	}
+	return fmt.Sprintf(
+		`A tall glass cabinet filled with prizes, lit from within by a warm glow. A mechanical claw hangs from a gantry inside. Cost to play: <ansi fg="gold">%d gold</ansi>. Chance to win: <ansi fg="cyan-bold">%d%%</ansi>. Type <ansi fg="command">play claw machine</ansi> to try your luck.`,
+		cost, winChance,
+	)
+}
+
+
+func (g *GamblingModule) lookClawMachine(user *users.UserRecord, room *rooms.Room) {
+
+	cost := defaultClawCost
+	if v, ok := g.plug.Config.Get(`ClawCost`).(int); ok && v > 0 {
+		cost = v
+	}
+
+	winChance := defaultClawWinChance
+	if v, ok := g.plug.Config.Get(`ClawWinChance`).(int); ok && v > 0 {
+		winChance = v
+	}
+
+	// Compute total weight for percentage display.
+	totalWeight := 0
+	for i := range clawPrizes {
+		totalWeight += g.clawPrizeWeight(clawPrizes[i])
+	}
+
+	user.SendText(``)
+	user.SendText(`<ansi fg="cyan">╔════════════════════════════════╗</ansi>`)
+	user.SendText(`<ansi fg="cyan">║</ansi>      <ansi fg="cyan-bold">C L A W  M A C H I N E</ansi>      <ansi fg="cyan">║</ansi>`)
+	user.SendText(`<ansi fg="cyan">╚════════════════════════════════╝</ansi>`)
+	user.SendText(``)
+	user.SendText(`A tall glass cabinet filled with small prizes, lit from within by a warm glow.`)
+	user.SendText(`A mechanical claw hangs from a gantry inside, waiting to be guided by a brave soul.`)
+	user.SendText(`A placard on the front reads:`)
+	user.SendText(``)
+	user.SendText(fmt.Sprintf(`    Cost to play:  <ansi fg="gold">%d gold</ansi>`, cost))
+	user.SendText(fmt.Sprintf(`    Chance to win: <ansi fg="cyan-bold">%d%%</ansi>`, winChance))
+	user.SendText(``)
+	user.SendText(`<ansi fg="cyan">Prizes</ansi> <ansi fg="8">(chance on win):</ansi>`)
+
+	for i := range clawPrizes {
+		p := clawPrizes[i]
+		wt := g.clawPrizeWeight(p)
+		if wt <= 0 {
+			continue
+		}
+		pct := 0
+		if totalWeight > 0 {
+			pct = wt * 100 / totalWeight
+		}
+		user.SendText(fmt.Sprintf(
+			`    <ansi fg="item">%-16s</ansi>  <ansi fg="cyan">%d%%</ansi>`,
+			p.name, pct,
+		))
+	}
+
+	user.SendText(``)
+	user.SendText(`Type <ansi fg="command">play claw machine</ansi> to try your luck.`)
+	user.SendText(``)
+
+	room.SendText(
+		fmt.Sprintf(`<ansi fg="username">%s</ansi> examines the claw machine.`, user.Character.Name),
+		user.UserId,
+	)
+}

--- a/modules/gambling/context.md
+++ b/modules/gambling/context.md
@@ -1,0 +1,159 @@
+# Gambling Module Context
+
+## Overview
+
+The `gambling` module is a self-contained plugin that adds gambling fixtures to the game world
+without any changes to the core engine. It provides gambling items with interactive scripts,
+a slot machine, and a claw machine. Rooms opt into each fixture via room tags.
+
+---
+
+## Room Tags
+
+Rooms can opt into gambling features by adding specific tags. Tags are set via the
+admin `room tag` command or by editing the room's YAML file directly:
+
+```yaml
+tags:
+  - slot machine
+```
+
+- A single room may carry both tags and have both machines present.
+- Tags are case-insensitive at the module level (`Slot Machine`, `slot machine`, and
+  `SLOT MACHINE` are all treated the same).
+- Machines are purely virtual; no item or mob needs to be placed in the room.
+
+---
+
+## Slot Machine
+
+**Tags:** `slots` or `slot machine` (either is accepted)
+
+Adds a slot machine to the room. Players interact with it using:
+
+- `play slots` - spend gold to spin the reels
+- `look slot machine` - view cost, current jackpot, and payout table
+
+**Configuration keys** (`Modules.gambling.*`):
+
+| Key | Default | Current | Description |
+|---|---|---|---|
+| `SlotCost` | `10` | `25` | Gold cost per spin |
+
+Half of every wager feeds the shared jackpot pool (`cost / 2` = 12 gold per spin at current cost). The jackpot persists across restarts.
+
+### Symbol Table
+
+Each reel has a total weight of **100**, so each symbol's weight is directly its per-reel
+percentage probability.
+
+| Symbol | Weight | Per-reel probability |
+|--------|--------|----------------------|
+| cherry | 30     | 30.00%               |
+| lemon  | 25     | 25.00%               |
+| orange | 20     | 20.00%               |
+| plum   | 15     | 15.00%               |
+| bell   |  7     |  7.00%               |
+| bar    |  2     |  2.00%               |
+| seven  |  1     |  1.00%               |
+
+All three reels are spun independently.
+
+### Outcome Evaluation Order
+
+`evaluate(a, b, c)` checks conditions in this exact order:
+
+1. All three identical → **triple** (special cases: seven = JACKPOT, bar = TRIPLE BAR 20x, bell = TRIPLE BELL 10x, all others = TRIPLE \<SYMBOL\> 5x)
+2. Any two identical → **PAIR** (2x)
+3. Two or more cherries → **CHERRIES** (2x) — **this branch is unreachable** (see note below)
+4. Default → **loss** (0x)
+
+> **Note on the CHERRIES branch:** Any combination of exactly two cherries is caught by the
+> PAIR check at step 2 before step 3 is reached. Triple cherry is caught at step 1. The
+> CHERRIES branch therefore can never fire with the current logic. It is dead code.
+
+### Probability and Combination Table
+
+Total possible weighted combinations: **100^3 = 1,000,000**
+
+| Outcome        | Payout | Combinations | Probability  | Approx. odds |
+|----------------|--------|-------------|--------------|--------------|
+| JACKPOT (777)  | jackpot pool | 1       | 0.0001%      | 1 in 1,000,000 |
+| TRIPLE BAR     | 20x    | 8           | 0.0008%      | 1 in 125,000 |
+| TRIPLE BELL    | 10x    | 343         | 0.0343%      | 1 in ~2,915  |
+| TRIPLE CHERRY  | 5x     | 27,000      | 2.7000%      | 1 in ~37     |
+| TRIPLE LEMON   | 5x     | 15,625      | 1.5625%      | 1 in 64      |
+| TRIPLE ORANGE  | 5x     | 8,000       | 0.8000%      | 1 in 125     |
+| TRIPLE PLUM    | 5x     | 3,375       | 0.3375%      | 1 in ~296    |
+| *All triples*  | *varies* | *54,352*  | *5.4352%*    | *1 in ~18*   |
+| PAIR (any)     | 2x     | 498,144     | 49.8144%     | ~1 in 2      |
+| CHERRIES       | 2x     | 0           | 0% (unreachable) | —        |
+| Loss           | 0x     | 447,504     | 44.7504%     | ~1 in 2.2    |
+
+Combination counts are computed as weighted counts out of 1,000,000 (since total weight = 100
+per reel, each weight unit equals one combination unit per reel).
+
+Pair combinations = 3 × Σ(w² × (100 − w)) over all symbols = 498,144.
+
+### Expected Return (Fixed Payouts Only)
+
+Excluding the jackpot (which is variable), the expected gold returned per 1 gold wagered from
+fixed-payout outcomes is:
+
+```
+E = (27000×5 + 15625×5 + 8000×5 + 3375×5 + 343×10 + 8×20 + 498144×2) / 1,000,000
+  = (135000 + 78125 + 40000 + 16875 + 3430 + 160 + 996288) / 1,000,000
+  = 1,269,878 / 1,000,000
+  ≈ 1.2699
+```
+
+**Fixed-payout RTP: ~127%** — the fixed payouts alone return more than the wager.
+
+### Jackpot Economics
+
+Half of every wager (`cost / 2`) is added to the shared jackpot pool, currently 12 gold per spin. The jackpot is won
+when three sevens land (probability 1 in 1,000,000 per spin). The pool resets to zero on
+a jackpot win and accumulates again from subsequent plays.
+
+Because the fixed-payout RTP already exceeds 100%, the jackpot pool effectively represents
+a bonus on top of already-positive expected returns for players.
+
+---
+
+## Claw Machine
+
+**Tag:** `claw machine`
+
+Adds a claw machine to the room. Players interact with it using:
+
+- `play claw machine` - spend gold for one claw attempt
+- `look claw machine` - view cost, win chance, and prize list
+
+**Configuration keys** (`Modules.gambling.*`):
+
+| Key | Default | Current | Description |
+|---|---|---|---|
+| `ClawCost` | `10` | `100` | Gold cost per attempt |
+| `ClawWinChance` | `10` | `10` | Percentage chance (1-100) of winning a prize |
+| `ClawPrizeDie` | `20` | `30` | Relative weight for the 6-sided die |
+| `ClawPrizeCoin` | `20` | `2` | Relative weight for the lucky coin |
+| `ClawPrizeBottle` | `20` | `8` | Relative weight for the empty bottle |
+| `ClawPrizeCards` | `15` | `20` | Relative weight for the deck of cards |
+| `ClawPrize8Ball` | `15` | `30` | Relative weight for the magic 8-ball |
+| `ClawPrizeTarot` | `10` | `10` | Relative weight for the tarot deck |
+
+Weights are relative to each other. The current weights sum to 100, so each weight is directly
+the percentage chance of that prize being selected on a win. Set a weight to `0` to remove
+that prize from the pool entirely. The `look claw machine` command shows each active prize
+with its calculated percentage chance based on current weights.
+
+**Current prize distribution (on a win):**
+
+| Prize | Weight | Chance on win |
+|---|---|---|
+| 6-sided die | 30 | 30% |
+| magic 8-ball | 30 | 30% |
+| deck of cards | 20 | 20% |
+| tarot deck | 10 | 10% |
+| empty bottle | 8 | 8% |
+| lucky coin | 2 | 2% |

--- a/modules/gambling/files/data-overlays/config.yaml
+++ b/modules/gambling/files/data-overlays/config.yaml
@@ -1,0 +1,43 @@
+################################################################################
+# If modified, these settings will be copied into your config overrides
+# folder under `Modules.gambling`:
+#
+# Modules:
+#   gambling:
+#     SlotCost: 25
+#     ClawCost: 100
+#     ClawWinChance: 10
+#     ClawPrizeCoin: 2
+#     ClawPrizeBottle: 8
+#     ClawPrizeTarot: 10
+#     ClawPrizeCards: 20
+#     ClawPrize8Ball: 30
+#     ClawPrizeDie: 30
+################################################################################
+# - SlotCost -
+#   The number of gold coins required to play the slot machine once.
+SlotCost: 25
+# - ClawCost -
+#   The number of gold coins required to play the claw machine once.
+ClawCost: 100
+# - ClawWinChance -
+#   The percentage chance (1-100) of winning a prize on the claw machine.
+ClawWinChance: 10
+# - ClawPrizeCoin -
+#   Relative weight for the lucky coin prize. Set to 0 to remove from the pool.
+ClawPrizeCoin: 2
+# - ClawPrizeBottle -
+#   Relative weight for the empty bottle prize. Set to 0 to remove from the pool.
+ClawPrizeBottle: 8
+# - ClawPrizeTarot -
+#   Relative weight for the tarot deck prize. Set to 0 to remove from the pool.
+ClawPrizeTarot: 10
+# - ClawPrizeCards -
+#   Relative weight for the deck of cards prize. Set to 0 to remove from the pool.
+ClawPrizeCards: 20
+# - ClawPrize8Ball -
+#   Relative weight for the magic 8-ball prize. Set to 0 to remove from the pool.
+ClawPrize8Ball: 30
+# - ClawPrizeDie -
+#   Relative weight for the 6-sided die prize. Set to 0 to remove from the pool.
+ClawPrizeDie: 30

--- a/modules/gambling/files/data-overlays/keywords.yaml
+++ b/modules/gambling/files/data-overlays/keywords.yaml
@@ -1,0 +1,2 @@
+help-aliases:
+  gambling: [slot machine, slots, claw machine, claw, claw game]

--- a/modules/gambling/files/datafiles/templates/help/gambling.template
+++ b/modules/gambling/files/datafiles/templates/help/gambling.template
@@ -1,0 +1,34 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">gambling</ansi>
+
+The <ansi fg="command">play</ansi> command lets you interact with gambling fixtures in the world.
+Currently supported: <ansi fg="cyan-bold">slot machines</ansi> and <ansi fg="cyan-bold">claw machines</ansi>.
+
+<ansi fg="yellow">Usage:</ansi>
+
+  <ansi fg="command">play slots</ansi>          - Pull the lever on the slot machine in this room.
+  <ansi fg="command">look slot machine</ansi>   - Examine the slot machine for cost and jackpot info.
+
+  <ansi fg="command">play claw machine</ansi>   - Operate the claw machine in this room.
+  <ansi fg="command">look claw machine</ansi>   - Examine the claw machine for cost, win chance, and prizes.
+
+<ansi fg="yellow">Slot Machine Rules:</ansi>
+
+  Each spin costs gold.
+  Half of each wager is added to the shared jackpot pool.
+
+  Payouts (multiples of the spin cost):
+    Three sevens    - JACKPOT (wins the entire jackpot pool)
+    Triple bar      - 20x
+    Triple bell     - 10x
+    Any other triple- 5x
+    Any pair        - 2x
+    Two cherries    - 2x
+    No match        - Loss
+
+<ansi fg="yellow">Claw Machine Rules:</ansi>
+
+  Each attempt costs gold
+  Prizes are items from the gambling collection:
+    <ansi fg="item">6-sided die</ansi>, <ansi fg="item">lucky coin</ansi>, <ansi fg="item">tarot deck</ansi>, <ansi fg="item">magic 8-ball</ansi>, <ansi fg="item">empty bottle</ansi>, <ansi fg="item">deck of cards</ansi>.
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help look</ansi>

--- a/modules/gambling/gambling.go
+++ b/modules/gambling/gambling.go
@@ -3,10 +3,16 @@ package gambling
 import (
 	"embed"
 	"io/fs"
+	"strings"
 
+	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/items"
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 var (
@@ -21,55 +27,163 @@ const eightItemId = 1040003
 const bottleItemId = 1040004
 const cardsItemId = 1040005
 
+const defaultCost = 10
+
 func init() {
 
-	plug := plugins.New(`gambling`, `1.0`)
+	g := &GamblingModule{
+		plug:  plugins.New(`gambling`, `1.0`),
+		state: SlotState{Jackpot: 0},
+	}
+	g.roomCache, _ = lru.New[int, struct{}](256)
 
-	if err := plug.AttachFileSystem(files); err != nil {
+	if err := g.plug.AttachFileSystem(files); err != nil {
 		panic(err)
 	}
 
-	// Read the die script from the embedded FS and register it so the
-	// scripting engine can find it without a corresponding file on disk.
-	scriptBytes, err := fs.ReadFile(files, `files/datafiles/items/1040000-6_sided_die.js`)
-	if err != nil {
-		mudlog.Error("gambling: failed to read die script", "error", err)
-	} else {
-		items.RegisterItemScript(dieItemId, string(scriptBytes))
+	// Register item scripts from embedded filesystem.
+	for itemId, path := range map[int]string{
+		dieItemId:    `files/datafiles/items/1040000-6_sided_die.js`,
+		coinItemId:   `files/datafiles/items/1040001-lucky_coin.js`,
+		tarotItemId:  `files/datafiles/items/1040002-tarot_deck.js`,
+		eightItemId:  `files/datafiles/items/1040003-magic_8_ball.js`,
+		bottleItemId: `files/datafiles/items/1040004-empty_bottle.js`,
+		cardsItemId:  `files/datafiles/items/1040005-deck_of_cards.js`,
+	} {
+		scriptBytes, err := fs.ReadFile(files, path)
+		if err != nil {
+			mudlog.Error("gambling: failed to read item script", "path", path, "error", err)
+			continue
+		}
+		items.RegisterItemScript(itemId, string(scriptBytes))
 	}
 
-	coinScript, err := fs.ReadFile(files, `files/datafiles/items/1040001-lucky_coin.js`)
-	if err != nil {
-		mudlog.Error("gambling: failed to read coin script", "error", err)
-	} else {
-		items.RegisterItemScript(coinItemId, string(coinScript))
+	// Register the "play" user command (handles both slots and claw machine).
+	g.plug.AddUserCommand(`play`, g.playCommand, false, false)
+
+	// Persist the jackpot across restarts.
+	g.plug.Callbacks.SetOnLoad(g.load)
+	g.plug.Callbacks.SetOnSave(g.save)
+
+	// Hook into room look to inject slot machine and claw machine alerts.
+	rooms.OnRoomLook.Register(g.onRoomLook)
+	rooms.OnRoomLook.Register(g.onRoomLookClaw)
+
+	// Inject gambling nouns when players enter or spawn in tagged rooms.
+	// This ensures "look slot machine" and "look claw machine" are resolved
+	// synchronously by the core look command rather than falling through to
+	// "Look at what???".
+	events.RegisterListener(events.RoomChange{}, g.onRoomChange)
+	events.RegisterListener(events.PlayerSpawn{}, g.onPlayerSpawn)
+}
+
+// ensureRoomNouns injects gambling fixture nouns into the room's Nouns map so
+// that "look slot machine", "look slots", and "look claw machine" are handled
+// synchronously by the core look command rather than falling through to
+// "Look at what???". Results are cached by room ID so the tag scan and map
+// writes only happen once per room per server session.
+func (g *GamblingModule) ensureRoomNouns(room *rooms.Room) {
+	if _, already := g.roomCache.Get(room.RoomId); already {
+		return
 	}
 
-	tarotScript, err := fs.ReadFile(files, `files/datafiles/items/1040002-tarot_deck.js`)
-	if err != nil {
-		mudlog.Error("gambling: failed to read tarot script", "error", err)
-	} else {
-		items.RegisterItemScript(tarotItemId, string(tarotScript))
+	if room.Nouns == nil {
+		room.Nouns = make(map[string]string)
 	}
 
-	eightScript, err := fs.ReadFile(files, `files/datafiles/items/1040003-magic_8_ball.js`)
-	if err != nil {
-		mudlog.Error("gambling: failed to read 8-ball script", "error", err)
-	} else {
-		items.RegisterItemScript(eightItemId, string(eightScript))
+	if roomHasSlots(room) {
+		room.Nouns[`slot machine`] = g.slotMachineNounDesc(room)
+		room.Nouns[`slots`] = `:slot machine`
 	}
 
-	bottleScript, err := fs.ReadFile(files, `files/datafiles/items/1040004-empty_bottle.js`)
-	if err != nil {
-		mudlog.Error("gambling: failed to read bottle script", "error", err)
-	} else {
-		items.RegisterItemScript(bottleItemId, string(bottleScript))
+	if roomHasClaw(room) {
+		room.Nouns[`claw machine`] = g.clawMachineNounDesc(room)
+		room.Nouns[`claw`] = `:claw machine`
 	}
 
-	cardsScript, err := fs.ReadFile(files, `files/datafiles/items/1040005-deck_of_cards.js`)
-	if err != nil {
-		mudlog.Error("gambling: failed to read cards script", "error", err)
-	} else {
-		items.RegisterItemScript(cardsItemId, string(cardsScript))
+	g.roomCache.Add(room.RoomId, struct{}{})
+}
+
+// onRoomChange injects gambling nouns whenever a player enters a tagged room.
+func (g *GamblingModule) onRoomChange(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.RoomChange)
+	if !ok || evt.UserId == 0 {
+		return events.Continue
 	}
+	if room := rooms.LoadRoom(evt.ToRoomId); room != nil {
+		g.ensureRoomNouns(room)
+	}
+	return events.Continue
+}
+
+// onPlayerSpawn injects gambling nouns for players who log in inside a tagged room.
+func (g *GamblingModule) onPlayerSpawn(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerSpawn)
+	if !ok {
+		return events.Continue
+	}
+	if room := rooms.LoadRoom(evt.RoomId); room != nil {
+		g.ensureRoomNouns(room)
+	}
+	return events.Continue
+}
+
+
+// GamblingModule holds module-level state for the gambling plugin.
+type GamblingModule struct {
+	plug      *plugins.Plugin
+	state     SlotState
+	// roomCache tracks room IDs whose gambling nouns have already been injected,
+	// so ensureRoomNouns skips work on every subsequent player movement through
+	// rooms that were already processed.
+	roomCache *lru.Cache[int, struct{}]
+}
+
+func (g *GamblingModule) load() {
+	g.plug.ReadIntoStruct(`slotstate`, &g.state)
+}
+
+func (g *GamblingModule) save() {
+	g.plug.WriteStruct(`slotstate`, g.state)
+}
+
+// onRoomLook injects a slot machine alert when the room has the slots tag.
+func (g *GamblingModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
+	for _, t := range d.Tags {
+		tl := strings.ToLower(t)
+		if tl == `slots` || tl == `slot machine` {
+			d.RoomAlerts = append(d.RoomAlerts,
+				`There is a <ansi fg="cyan-bold">slot machine</ansi> here! You can <ansi fg="command">look</ansi> at or <ansi fg="command">play</ansi> it.`,
+			)
+			return d
+		}
+	}
+	return d
+}
+
+// playCommand handles "play slots" / "play slot machine" / "play claw machine" / "play claw".
+func (g *GamblingModule) playCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+
+	arg := strings.TrimSpace(rest)
+
+	if m, c := util.FindMatchIn(arg, `slot machine`, `slots`, `slot`); m != `` || c != `` {
+		if !roomHasSlots(room) {
+			user.SendText(`There is no slot machine here.`)
+			return true, nil
+		}
+		g.playSlots(user, room)
+		return true, nil
+	}
+
+	if m, c := util.FindMatchIn(arg, `claw machine`, `claw`); m != `` || c != `` {
+		if !roomHasClaw(room) {
+			user.SendText(`There is no claw machine here.`)
+			return true, nil
+		}
+		g.playClaw(user, room)
+		return true, nil
+	}
+
+	user.SendText(`Play what? Try <ansi fg="command">play slots</ansi> or <ansi fg="command">play claw machine</ansi>.`)
+	return true, nil
 }

--- a/modules/gambling/slots.go
+++ b/modules/gambling/slots.go
@@ -1,0 +1,302 @@
+package gambling
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+// slotSymbol represents one reel symbol with a display glyph and relative weight.
+type slotSymbol struct {
+	glyph  string
+	weight int
+}
+
+// slotOutcome maps a result category to a payout multiplier (applied to the cost).
+// A multiplier of 0 means no payout (loss).
+type slotOutcome struct {
+	label      string
+	multiplier int // payout = cost * multiplier  (0 = lose, 1 = break-even, 2+ = win)
+}
+
+var (
+	reelSymbols = []slotSymbol{
+		{`cherry`, 30},
+		{`lemon`, 25},
+		{`orange`, 20},
+		{`plum`, 15},
+		{`bell`, 7},
+		{`bar`, 2},
+		{`seven`, 1},
+	}
+
+	// symbolColors maps each glyph to an ANSI fg color for reel display.
+	symbolColors = map[string]string{
+		`cherry`: `red-bold`,
+		`lemon`:  `yellow-bold`,
+		`orange`: `214`,
+		`plum`:   `magenta-bold`,
+		`bell`:   `cyan-bold`,
+		`bar`:    `white-bold`,
+		`seven`:  `220`,
+	}
+
+	// slotMu guards the jackpot state.
+	slotMu sync.Mutex
+)
+
+// SlotState holds the persistent jackpot pool.
+type SlotState struct {
+	Jackpot int `yaml:"Jackpot"`
+}
+
+// roomHasSlots returns true when the room carries a "slots" or "slot machine" tag.
+func roomHasSlots(r *rooms.Room) bool {
+	for _, t := range r.Tags {
+		tl := strings.ToLower(t)
+		if tl == `slots` || tl == `slot machine` {
+			return true
+		}
+	}
+	return false
+}
+
+// coloredGlyph wraps a symbol glyph in its designated ANSI color tag.
+func coloredGlyph(s slotSymbol) string {
+	color, ok := symbolColors[s.glyph]
+	if !ok {
+		color = `white`
+	}
+	return fmt.Sprintf(`<ansi fg="%s">%s</ansi>`, color, s.glyph)
+}
+
+// spinReel picks one symbol according to weighted random selection.
+func spinReel() slotSymbol {
+	total := 0
+	for _, s := range reelSymbols {
+		total += s.weight
+	}
+	roll := util.Rand(total)
+	cumulative := 0
+	for _, s := range reelSymbols {
+		cumulative += s.weight
+		if roll < cumulative {
+			return s
+		}
+	}
+	return reelSymbols[len(reelSymbols)-1]
+}
+
+// evaluate returns the outcome for a three-reel spin.
+func evaluate(a, b, c slotSymbol) slotOutcome {
+	if a.glyph == b.glyph && b.glyph == c.glyph {
+		switch a.glyph {
+		case `seven`:
+			return slotOutcome{`JACKPOT`, 0} // special: wins entire jackpot
+		case `bar`:
+			return slotOutcome{`TRIPLE BAR`, 20}
+		case `bell`:
+			return slotOutcome{`TRIPLE BELL`, 10}
+		default:
+			return slotOutcome{`TRIPLE ` + strings.ToUpper(a.glyph), 5}
+		}
+	}
+	if a.glyph == b.glyph || b.glyph == c.glyph || a.glyph == c.glyph {
+		return slotOutcome{`PAIR`, 2}
+	}
+	cherryCount := 0
+	for _, s := range []slotSymbol{a, b, c} {
+		if s.glyph == `cherry` {
+			cherryCount++
+		}
+	}
+	if cherryCount >= 2 {
+		return slotOutcome{`CHERRIES`, 2}
+	}
+	return slotOutcome{``, 0}
+}
+
+// jackpotBanner returns the festive multi-color JACKPOT banner line.
+func jackpotBanner() string {
+	// Each letter of JACKPOT cycles through festive bold colors.
+	colors := []string{`220`, `red-bold`, `green-bold`, `cyan-bold`, `magenta-bold`, `214`, `yellow-bold`}
+	letters := []string{`J`, `A`, `C`, `K`, `P`, `O`, `T`}
+	out := `<ansi fg="220">*** </ansi>`
+	for i, l := range letters {
+		out += fmt.Sprintf(`<ansi fg="%s">%s</ansi>`, colors[i%len(colors)], l)
+	}
+	out += `<ansi fg="220"> ***</ansi>`
+	return out
+}
+
+// playSlots executes one spin for the user, charging the cost and paying out
+// any winnings. It writes all output directly to the user and room.
+func (g *GamblingModule) playSlots(user *users.UserRecord, room *rooms.Room) {
+
+	cost := defaultCost
+	if v, ok := g.plug.Config.Get(`SlotCost`).(int); ok && v > 0 {
+		cost = v
+	}
+
+	if user.Character.Gold < cost {
+		user.SendText(fmt.Sprintf(
+			`You need at least <ansi fg="gold">%d gold</ansi> to play the slot machine.`,
+			cost,
+		))
+		return
+	}
+
+	// Deduct cost and add to jackpot pool.
+	user.Character.Gold -= cost
+
+	slotMu.Lock()
+	g.state.Jackpot += cost / 2 // half of each play feeds the jackpot
+	slotMu.Unlock()
+
+	events.AddToQueue(events.EquipmentChange{
+		UserId:     user.UserId,
+		GoldChange: -cost,
+	})
+
+	a, b, c := spinReel(), spinReel(), spinReel()
+
+	reelLine := fmt.Sprintf(
+		`<ansi fg="yellow">[ </ansi>%s <ansi fg="yellow">|</ansi> %s <ansi fg="yellow">|</ansi> %s<ansi fg="yellow"> ]</ansi>`,
+		coloredGlyph(a), coloredGlyph(b), coloredGlyph(c),
+	)
+
+	room.SendText(
+		fmt.Sprintf(`<ansi fg="username">%s</ansi> pulls the lever on the slot machine...`,
+			user.Character.Name),
+		user.UserId,
+	)
+
+	outcome := evaluate(a, b, c)
+
+	if outcome.label == `JACKPOT` {
+		slotMu.Lock()
+		prize := g.state.Jackpot
+		g.state.Jackpot = 0
+		slotMu.Unlock()
+
+		user.Character.Gold += prize
+		events.AddToQueue(events.EquipmentChange{
+			UserId:     user.UserId,
+			GoldChange: prize,
+		})
+
+		banner := jackpotBanner()
+		user.SendText(" ")
+		user.SendText(reelLine)
+		user.SendText(" ")
+		user.SendText(fmt.Sprintf(`%s <ansi fg="gold">You win %d gold!</ansi>`, banner, prize))
+		user.SendText(" ")
+		room.SendText(
+			fmt.Sprintf(`%s <ansi fg="username">%s</ansi> <ansi fg="yellow-bold">has hit the JACKPOT!!!</ansi>`,
+				banner, user.Character.Name),
+			user.UserId,
+		)
+		return
+	}
+
+	if outcome.multiplier > 0 {
+		prize := cost * outcome.multiplier
+
+		// Color the outcome label by tier.
+		var labelColor string
+		switch {
+		case outcome.multiplier >= 20:
+			labelColor = `gold`
+		case outcome.multiplier >= 10:
+			labelColor = `cyan-bold`
+		default:
+			labelColor = `green-bold`
+		}
+
+		user.Character.Gold += prize
+		events.AddToQueue(events.EquipmentChange{
+			UserId:     user.UserId,
+			GoldChange: prize,
+		})
+
+		user.SendText(reelLine)
+		user.SendText(" ")
+		user.SendText(fmt.Sprintf(
+			`<ansi fg="%s">%s!</ansi> You win <ansi fg="gold">%d gold</ansi>!`,
+			labelColor, outcome.label, prize,
+		))
+		user.SendText(" ")
+		room.SendText(
+			fmt.Sprintf(`<ansi fg="username">%s</ansi> <ansi fg="green">wins</ansi> on the slot machine!`, user.Character.Name),
+			user.UserId,
+		)
+		return
+	}
+
+	user.SendText(reelLine)
+	user.SendText(fmt.Sprintf(`<ansi fg="8">No luck this time. You lost <ansi fg="gold">%d gold</ansi>.</ansi>`, cost))
+	room.SendText(
+		fmt.Sprintf(`<ansi fg="username">%s</ansi> <ansi fg="8">loses on the slot machine.</ansi>`, user.Character.Name),
+		user.UserId,
+	)
+}
+
+// slotMachineNounDesc returns the noun description shown when a player types
+// "look slot machine" in a room with the slots tag.
+func (g *GamblingModule) slotMachineNounDesc(room *rooms.Room) string {
+	cost := defaultCost
+	if v, ok := g.plug.Config.Get(`SlotCost`).(int); ok && v > 0 {
+		cost = v
+	}
+	slotMu.Lock()
+	jackpot := g.state.Jackpot
+	slotMu.Unlock()
+	return fmt.Sprintf(
+		`A gleaming mechanical contraption adorned with spinning reels and flashing lights. A worn lever protrudes from its side. Cost to play: <ansi fg="gold">%d gold</ansi>. Current jackpot: <ansi fg="220">%d gold</ansi>. Type <ansi fg="command">play slots</ansi> to try your luck.`,
+		cost, jackpot,
+	)
+}
+
+
+func (g *GamblingModule) lookSlotMachine(user *users.UserRecord, room *rooms.Room) {
+
+	cost := defaultCost
+	if v, ok := g.plug.Config.Get(`SlotCost`).(int); ok && v > 0 {
+		cost = v
+	}
+
+	slotMu.Lock()
+	jackpot := g.state.Jackpot
+	slotMu.Unlock()
+
+	user.SendText(``)
+	user.SendText(`<ansi fg="220">╔════════════════════════════════╗</ansi>`)
+	user.SendText(`<ansi fg="220">║</ansi>     <ansi fg="yellow-bold">S L O T  M A C H I N E</ansi>     <ansi fg="220">║</ansi>`)
+	user.SendText(`<ansi fg="220">╚════════════════════════════════╝</ansi>`)
+	user.SendText(``)
+	user.SendText(`A gleaming mechanical contraption adorned with spinning reels and flashing lights.`)
+	user.SendText(`A worn lever protrudes from its side, inviting the bold and foolish alike.`)
+	user.SendText(`A placard on the front reads:`)
+	user.SendText(``)
+	user.SendText(fmt.Sprintf(
+		`    Cost to play:    <ansi fg="gold">%d gold</ansi>`,
+		cost,
+	))
+	user.SendText(fmt.Sprintf(
+		`    Current jackpot: <ansi fg="gold">%d gold</ansi>`,
+		jackpot,
+	))
+	user.SendText(``)
+	user.SendText(`Type <ansi fg="command">play slots</ansi> to try your luck.`)
+	user.SendText(``)
+
+	room.SendText(
+		fmt.Sprintf(`<ansi fg="username">%s</ansi> examines the slot machine.`, user.Character.Name),
+		user.UserId,
+	)
+}


### PR DESCRIPTION
# Description

This adds a "Gambling" module with two games to play: "slot machine" and "claw machine".
They are configurable. It also adds some prize items.

## Changes

Provide a bullet point list of noteworthy changes in this Pull Request:

- toy items added: `6-sided die`, `lucky coin`, `tarot deck`, `magic 8 ball`, `empty bottle` and `deck of cards`
- Slot machine added with jackpot tracking
- Claw machine added with toy items as prizes
- Costs/payout odds configurable
- Added a casino to the frostfang slums to demonstrate an implementation.
