### PR TITLE
SSH Connection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ _datafiles/**/plugin-data/*
 vendor/
 server.crt
 server.key
+ssh_host_key
+ssh_host_key.pub
 tmp-gomud.exe
 __debug*

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -212,6 +212,11 @@ FilePaths:
   #   Used to negotiate TLS/https requests
   HttpsCertFile: ""
   HttpsKeyFile: ""
+  # - SSHHostKeyFile -
+  #   Path to a PEM-encoded SSH host private key file.
+  #   Required when SSHPort is non-zero. Generate with:
+  #     ssh-keygen -t ed25519 -f ssh_host_key -N ""
+  SSHHostKeyFile: ""
 
 ################################################################################
 #
@@ -409,6 +414,14 @@ Network:
   #   If true, will send all http traffic to https with a redirect
   #   Requires both Http and Https to be working.
   HttpsRedirect: false
+  # - SSHPort -
+  #   The port the server listens on for SSH connections.
+  #   Requires SSHHostKeyFile to be set (See FilePaths).
+  #   0 (zero) means disabled.
+  SSHPort: 33332
+  # - MaxSSHConnections -
+  #   The maximum number of SSH connections the server will accept.
+  MaxSSHConnections: 100
   # - AfkSeconds -
   #   If this many seconds pass without player input, they are flagged as afk
   #   Set to zero to never mark anyone as AFK

--- a/_datafiles/html/public/index.html
+++ b/_datafiles/html/public/index.html
@@ -6,8 +6,16 @@
     </a>
   </div>
   <p>&nbsp;</p>
+  {{ $telnetPorts := activeTelnetPorts .CONFIG.Network.TelnetPort }}
+  {{ if gt (len $telnetPorts) 0 }}
   <div class="underlay">
-    <h3>Telnet Port{{ if gt (len .CONFIG.Network.TelnetPort) 1 }}s{{end}}: {{ join .CONFIG.Network.TelnetPort ", " }}</h3>
+    <h3>Telnet Port{{ if gt (len $telnetPorts) 1 }}s{{end}}: {{ join $telnetPorts ", " }}</h3>
   </div>
+  {{ end }}
+  {{ if sshEnabled .CONFIG }}
+  <div class="underlay">
+    <h3>SSH Port: {{ .CONFIG.Network.SSHPort }}</h3>
+  </div>
+  {{ end }}
 
 {{template "footer" .}}

--- a/_datafiles/html/public/online.html
+++ b/_datafiles/html/public/online.html
@@ -13,6 +13,7 @@
                 <th>Profession</th>
                 <th>Time Online</th>
                 <th>Role</th>
+                <th>Conn Type</th>
             </tr>
             {{range $index, $uInfo := .STATS.OnlineUsers}}
             <tr>
@@ -23,6 +24,7 @@
                 <td align="center">{{ $uInfo.Profession }}</td>
                 <td align="center">{{ $uInfo.OnlineTimeStr }}{{ if $uInfo.IsAFK }} (AFK){{end}}</td>
                 <td align="center">{{ $uInfo.Role }}</td>
+                <td align="center">{{ $uInfo.ConnType }}</td>
             </tr>
             {{end}}
         </table>

--- a/internal/configs/config.filepaths.go
+++ b/internal/configs/config.filepaths.go
@@ -8,6 +8,7 @@ type FilePaths struct {
 	AdminHtml        ConfigString `yaml:"AdminHtml"`
 	HttpsCertFile    ConfigString `yaml:"HttpsCertFile"`
 	HttpsKeyFile     ConfigString `yaml:"HttpsKeyFile"`
+	SSHHostKeyFile   ConfigString `yaml:"SSHHostKeyFile"`
 	CarefulSaveFiles ConfigBool   `yaml:"CarefulSaveFiles"`
 }
 

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -7,6 +7,8 @@ type Network struct {
 	HttpPort             ConfigInt         `yaml:"HttpPort"`             // Port used for web requests
 	HttpsPort            ConfigInt         `yaml:"HttpsPort"`            // Port used for web https requests
 	HttpsRedirect        ConfigBool        `yaml:"HttpsRedirect"`        // If true, http traffic will be redirected to https
+	SSHPort              ConfigInt         `yaml:"SSHPort"`              // Port used for SSH connections (0 to disable)
+	MaxSSHConnections    ConfigInt         `yaml:"MaxSSHConnections"`    // Maximum number of SSH connections to accept
 	AfkSeconds           ConfigInt         `yaml:"AfkSeconds"`           // How long until a player is marked as afk?
 	MaxIdleSeconds       ConfigInt         `yaml:"MaxIdleSeconds"`       // How many seconds a player can go without a command in game before being kicked.
 	TimeoutMods          ConfigBool        `yaml:"TimeoutMods"`          // Whether to kick admin/mods when idle too long.
@@ -22,6 +24,14 @@ func (n *Network) Validate() {
 
 	if n.MaxTelnetConnections < 1 {
 		n.MaxTelnetConnections = 50 // default
+	}
+
+	if n.SSHPort < 0 {
+		n.SSHPort = 0
+	}
+
+	if n.MaxSSHConnections < 1 {
+		n.MaxSSHConnections = 50 // default
 	}
 
 	if n.HttpPort < 0 {

--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/GoMud/internal/term"
 	"github.com/gorilla/websocket"
+	"golang.org/x/crypto/ssh"
 )
 
 type ConnectState uint32
@@ -118,6 +119,8 @@ type ConnectionDetails struct {
 	conn              net.Conn
 	wsConn            *websocket.Conn
 	wsLock            sync.Mutex
+	sshChannel        ssh.Channel
+	sshRemoteAddr     net.Addr
 	handlerMutex      sync.Mutex
 	inputHandlerNames []string
 	inputHandlers     []InputHandler
@@ -128,21 +131,22 @@ type ConnectionDetails struct {
 
 func (cd *ConnectionDetails) IsLocal() bool {
 
-	remoteAddrStr := ``
+	var remoteAddrStr string
 
-	if cd.wsConn == nil {
+	if cd.sshChannel != nil {
+		remoteAddrStr = cd.sshRemoteAddr.String()
+	} else if cd.wsConn != nil {
+		remoteAddrStr = cd.wsConn.RemoteAddr().String()
+	} else {
 		// Unix sockets are always local
 		if _, ok := cd.conn.(*net.UnixConn); ok {
 			return true
 		}
 		remoteAddrStr = cd.conn.RemoteAddr().String()
-	} else {
-		remoteAddrStr = cd.wsConn.RemoteAddr().String()
 	}
 
 	host, _, err := net.SplitHostPort(remoteAddrStr)
 	if err != nil {
-		// e.g. not “host:port” syntax
 		return false
 	}
 
@@ -155,6 +159,10 @@ func (cd *ConnectionDetails) IsLocal() bool {
 
 func (cd *ConnectionDetails) IsWebSocket() bool {
 	return cd.wsConn != nil
+}
+
+func (cd *ConnectionDetails) IsSSH() bool {
+	return cd.sshChannel != nil
 }
 
 // If HandleInput receives an error, we shouldn't pass input to the game logic
@@ -172,10 +180,6 @@ func (cd *ConnectionDetails) HandleInput(ci *ClientInput, handlerState map[strin
 	for i, inputHandler := range cd.inputHandlers {
 		lastHandler = cd.inputHandlerNames[i]
 		if runNextHandler := inputHandler(ci, handlerState); !runNextHandler {
-			// If it's the last one in the chain, ignore any aborts
-			// if i == handlerCt-1 {
-			// 	return false, lastHandler, nil
-			// }
 			return false, lastHandler, nil
 		}
 	}
@@ -221,12 +225,16 @@ func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
 		return 0, nil
 	}
 
+	if cd.sshChannel != nil {
+		return cd.sshChannel.Write(p)
+	}
+
 	if cd.wsConn != nil {
 		cd.wsLock.Lock()
 		defer cd.wsLock.Unlock()
 
 		// If this isn't caught and avoided, lots of stuff goes wrong.
-		// Websocket client complains, disconnects, error is rasised: close 1002 (protocol error): Invalid UTF-8 in text frame
+		// Websocket client complains, disconnects, error is raised: close 1002 (protocol error): Invalid UTF-8 in text frame
 		// Then a panic ensues as the server tries to write to a socket that's nil.
 		// TODO: Investigate cleaning up this condition better.
 		if p[0] == term.TELNET_IAC {
@@ -246,8 +254,11 @@ func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
 
 func (cd *ConnectionDetails) Read(p []byte) (n int, err error) {
 
+	if cd.sshChannel != nil {
+		return cd.sshChannel.Read(p)
+	}
+
 	if cd.wsConn != nil {
-		// read the bytes and then copy them into p
 		_, message, err := cd.wsConn.ReadMessage()
 		if err != nil {
 			return 0, err
@@ -264,6 +275,11 @@ func (cd *ConnectionDetails) Close() {
 		cd.heartbeat.stop()
 	}
 
+	if cd.sshChannel != nil {
+		cd.sshChannel.Close()
+		return
+	}
+
 	if cd.wsConn != nil {
 		cd.wsConn.Close()
 		return
@@ -272,6 +288,9 @@ func (cd *ConnectionDetails) Close() {
 }
 
 func (cd *ConnectionDetails) RemoteAddr() net.Addr {
+	if cd.sshChannel != nil {
+		return cd.sshRemoteAddr
+	}
 	if cd.wsConn != nil {
 		return cd.wsConn.RemoteAddr()
 	}
@@ -310,9 +329,8 @@ func NewConnectionDetails(connId ConnectionId, c net.Conn, wsC *websocket.Conn, 
 		conn:          c,
 		wsConn:        wsC,
 		wsLock:        sync.Mutex{},
-		// Track client settings
 		clientSettings: ClientSettings{
-			Display: DisplaySettings{ScreenWidth: 80, ScreenHeight: 40}, // Default to 80x40
+			Display: DisplaySettings{ScreenWidth: 80, ScreenHeight: 40},
 		},
 	}
 
@@ -325,4 +343,17 @@ func NewConnectionDetails(connId ConnectionId, c net.Conn, wsC *websocket.Conn, 
 	}
 
 	return cd
+}
+
+func NewSSHConnectionDetails(connId ConnectionId, ch ssh.Channel, remoteAddr net.Addr) *ConnectionDetails {
+	return &ConnectionDetails{
+		state:         Login,
+		connectionId:  connId,
+		inputDisabled: false,
+		sshChannel:    ch,
+		sshRemoteAddr: remoteAddr,
+		clientSettings: ClientSettings{
+			Display: DisplaySettings{ScreenWidth: 80, ScreenHeight: 40},
+		},
+	}
 }

--- a/internal/connections/connections.go
+++ b/internal/connections/connections.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/gorilla/websocket"
+	"golang.org/x/crypto/ssh"
 )
 
 const ReadBufferSize = 1024
@@ -52,12 +53,29 @@ func Add(conn net.Conn, wsConn *websocket.Conn) *ConnectionDetails {
 		connectCounter,
 		conn,
 		wsConn,
-		nil, // use default settings for now TODO: add into overall config pattern?
+		nil,
 	)
 
 	netConnections[connDetails.ConnectionId()] = connDetails
 
-	// return the unique ID to find this connection later
+	return connDetails
+}
+
+func AddSSH(ch ssh.Channel, remoteAddr net.Addr) *ConnectionDetails {
+
+	lock.Lock()
+	defer lock.Unlock()
+
+	connectCounter++
+
+	connDetails := NewSSHConnectionDetails(
+		connectCounter,
+		ch,
+		remoteAddr,
+	)
+
+	netConnections[connDetails.ConnectionId()] = connDetails
+
 	return connDetails
 }
 

--- a/internal/integrations/discord/listeners.go
+++ b/internal/integrations/discord/listeners.go
@@ -34,6 +34,10 @@ func HandlePlayerSpawn(e events.Event) events.ListenerReturn {
 
 	if connDetails.IsWebSocket() {
 		message += ` (via websocket)`
+	} else if connDetails.IsSSH() {
+		message += ` (via ssh)`
+	} else {
+		message += ` (via telnet)`
 	}
 
 	SendRichMessage(message, Green)

--- a/internal/usercommands/online.go
+++ b/internal/usercommands/online.go
@@ -24,7 +24,7 @@ func Online(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 
 	if user.Role != users.RoleUser {
 		headers = append([]string{language.T(`UserId`)}, headers...)
-		headers = append(headers, []string{language.T(`Zone`), language.T(`RoomId`)}...)
+		headers = append(headers, []string{language.T(`Zone`), language.T(`RoomId`), language.T(`Conn Type`)}...)
 	}
 
 	allFormatting := [][]string{}
@@ -76,10 +76,10 @@ func Online(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 
 			if user.Role != users.RoleUser {
 				row = append([]string{strconv.Itoa(u.UserId)}, row...)
-				row = append(row, []string{u.Character.Zone, strconv.Itoa(u.Character.RoomId)}...)
+				row = append(row, []string{u.Character.Zone, strconv.Itoa(u.Character.RoomId), onlineInfo.ConnType}...)
 
 				formatting = append([]string{`<ansi fg="userid">%s</ansi>`}, formatting...)
-				formatting = append(formatting, []string{`<ansi fg="zone">%s</ansi>`, `<ansi fg="1">%s</ansi>`}...)
+				formatting = append(formatting, []string{`<ansi fg="zone">%s</ansi>`, `<ansi fg="1">%s</ansi>`, `<ansi fg="white">%s</ansi>`}...)
 			}
 
 			allFormatting = append(allFormatting, formatting)

--- a/internal/users/onlineinfo.go
+++ b/internal/users/onlineinfo.go
@@ -10,4 +10,5 @@ type OnlineInfo struct {
 	OnlineTimeStr string
 	IsAFK         bool
 	Role          string
+	ConnType      string
 }

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -643,6 +643,15 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 		isAfk = true
 	}
 
+	connType := `telnet`
+	if cd := connections.Get(u.connectionId); cd != nil {
+		if cd.IsWebSocket() {
+			connType = `websocket`
+		} else if cd.IsSSH() {
+			connType = `ssh`
+		}
+	}
+
 	return OnlineInfo{
 		u.Username,
 		u.Character.Name,
@@ -653,6 +662,7 @@ func (u *UserRecord) GetOnlineInfo() OnlineInfo {
 		timeStr,
 		isAfk,
 		u.Role,
+		connType,
 	}
 }
 

--- a/internal/web/template_func.go
+++ b/internal/web/template_func.go
@@ -3,6 +3,7 @@ package web
 import (
 	"fmt"
 	"html"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -77,6 +78,15 @@ var (
 			return stringIn + strings.Repeat(padString, paddingLength)
 		},
 		"join": func(items []string, sep string) string { return strings.Join(items, sep) },
+		"activeTelnetPorts": func(ports []string) []string {
+			active := make([]string, 0, len(ports))
+			for _, p := range ports {
+				if n, err := strconv.Atoi(p); err == nil && n > 0 {
+					active = append(active, p)
+				}
+			}
+			return active
+		},
 		"lte":  func(a, b int) bool { return a <= b },
 		"gte":  func(a, b int) bool { return a >= b },
 		"lt":   func(a, b int) bool { return a < b },
@@ -101,6 +111,9 @@ var (
 			return strings.ToLower(str)
 		},
 		"now": func() int64 { return time.Now().UnixMilli() },
+		"sshEnabled": func(c configs.Config) bool {
+			return int(c.Network.SSHPort) > 0 && c.FilePaths.SSHHostKeyFile != ``
+		},
 		"getconfig": func() configs.Config {
 			return configs.GetConfig()
 		},

--- a/internal/web/template_func.go
+++ b/internal/web/template_func.go
@@ -87,9 +87,9 @@ var (
 			}
 			return active
 		},
-		"lte":  func(a, b int) bool { return a <= b },
-		"gte":  func(a, b int) bool { return a >= b },
-		"lt":   func(a, b int) bool { return a < b },
+		"lte": func(a, b int) bool { return a <= b },
+		"gte": func(a, b int) bool { return a >= b },
+		"lt":  func(a, b int) bool { return a < b },
 		//"gt":   func(a, b int) bool { return a > b },
 		"uc":  func(s string) string { return strings.Title(s) },
 		"lc":  func(s string) string { return strings.ToLower(s) },

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/usercommands"
 	"github.com/GoMudEngine/GoMud/internal/version"
 	"github.com/gorilla/websocket"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/GoMudEngine/GoMud/internal/mapper"
 	"github.com/GoMudEngine/GoMud/internal/mobs"
@@ -294,7 +295,7 @@ func main() {
 
 	allServerListeners := make([]net.Listener, 0, len(c.Network.TelnetPort))
 	for _, port := range c.Network.TelnetPort {
-		if p, err := strconv.Atoi(port); err == nil {
+		if p, err := strconv.Atoi(port); err == nil && p > 0 {
 			if s := TelnetListenOnPort(``, p, &wg, int(c.Network.MaxTelnetConnections)); s != nil {
 				allServerListeners = append(allServerListeners, s)
 			}
@@ -303,6 +304,31 @@ func main() {
 
 	if c.Network.LocalPort > 0 {
 		TelnetListenOnPort(`127.0.0.1`, int(c.Network.LocalPort), &wg, 0)
+	}
+
+	if sshPort := int(c.Network.SSHPort); sshPort > 0 {
+		hostKeyPath := c.FilePaths.SSHHostKeyFile.String()
+		if hostKeyPath == `` {
+			mudlog.Error("SSH", "error", "SSHPort is set but SSHHostKeyFile is not configured; SSH disabled")
+		} else {
+			hostKeyBytes, err := os.ReadFile(hostKeyPath)
+			if err != nil {
+				mudlog.Error("SSH", "error", "failed to read SSH host key", "path", hostKeyPath, "details", err)
+			} else {
+				signer, err := ssh.ParsePrivateKey(hostKeyBytes)
+				if err != nil {
+					mudlog.Error("SSH", "error", "failed to parse SSH host key", "details", err)
+				} else {
+					sshConfig := &ssh.ServerConfig{
+						NoClientAuth: true,
+					}
+					sshConfig.AddHostKey(signer)
+					if s := SSHListenOnPort(sshPort, sshConfig, &wg, int(c.Network.MaxSSHConnections)); s != nil {
+						allServerListeners = append(allServerListeners, s)
+					}
+				}
+			}
+		}
 	}
 
 	go worldManager.InputWorker(workerShutdownChan, &wg)
@@ -1169,6 +1195,333 @@ func TelnetListenOnPort(hostname string, portNum int, wg *sync.WaitGroup, maxCon
 	}()
 
 	return server
+}
+
+func SSHListenOnPort(portNum int, sshConfig *ssh.ServerConfig, wg *sync.WaitGroup, maxConnections int) net.Listener {
+
+	server, err := net.Listen("tcp", fmt.Sprintf(":%d", portNum))
+	if err != nil {
+		mudlog.Error("Error creating SSH server", "error", err)
+		return nil
+	}
+
+	mudlog.Info("SSH", "status", "listening", "port", portNum)
+
+	go func() {
+		for {
+			conn, err := server.Accept()
+
+			if !serverAlive.Load() {
+				mudlog.Warn("SSH connections disabled.")
+				return
+			}
+
+			if err != nil {
+				mudlog.Warn("SSH connection error", "error", err)
+				continue
+			}
+
+			if maxConnections > 0 {
+				if connections.ActiveConnectionCount() >= maxConnections {
+					conn.Write([]byte("\n\n\n!!! Server is full. Try again later. !!!\n\n\n"))
+					conn.Close()
+					continue
+				}
+			}
+
+			wg.Add(1)
+			go handleSSHHandshake(conn, sshConfig, wg)
+		}
+	}()
+
+	return server
+}
+
+func handleSSHHandshake(conn net.Conn, sshConfig *ssh.ServerConfig, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	sshConn, chans, reqs, err := ssh.NewServerConn(conn, sshConfig)
+	if err != nil {
+		mudlog.Warn("SSH handshake failed", "remoteAddr", conn.RemoteAddr().String(), "error", err)
+		return
+	}
+	defer sshConn.Close()
+
+	// Discard all out-of-band requests (keepalive, etc.)
+	go ssh.DiscardRequests(reqs)
+
+	for newChan := range chans {
+		if newChan.ChannelType() != "session" {
+			newChan.Reject(ssh.UnknownChannelType, "unsupported channel type")
+			continue
+		}
+
+		ch, chanReqs, err := newChan.Accept()
+		if err != nil {
+			mudlog.Warn("SSH channel accept failed", "error", err)
+			return
+		}
+
+		wg.Add(1)
+		go handleSSHConnection(connections.AddSSH(ch, sshConn.RemoteAddr()), chanReqs, wg)
+	}
+}
+
+func handleSSHConnection(connDetails *connections.ConnectionDetails, reqs <-chan *ssh.Request, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	mudlog.Info("New SSH Connection", "connectionID", connDetails.ConnectionId(), "remoteAddr", connDetails.RemoteAddr().String())
+
+	// Handle SSH channel requests (pty-req, window-change, shell, exec, etc.)
+	// We run this in a goroutine so the read loop below can start immediately.
+	go func() {
+		for req := range reqs {
+			switch req.Type {
+			case "pty-req":
+				// Parse terminal dimensions from the pty-req payload.
+				// Payload: string term, uint32 cols, uint32 rows, uint32 width-px, uint32 height-px, string modes
+				if len(req.Payload) >= 12 {
+					// Skip the terminal name string: 4-byte length prefix + string bytes
+					nameLen := int(req.Payload[0])<<24 | int(req.Payload[1])<<16 | int(req.Payload[2])<<8 | int(req.Payload[3])
+					offset := 4 + nameLen
+					if offset+8 <= len(req.Payload) {
+						cols := uint32(req.Payload[offset])<<24 | uint32(req.Payload[offset+1])<<16 | uint32(req.Payload[offset+2])<<8 | uint32(req.Payload[offset+3])
+						rows := uint32(req.Payload[offset+4])<<24 | uint32(req.Payload[offset+5])<<16 | uint32(req.Payload[offset+6])<<8 | uint32(req.Payload[offset+7])
+						if cols > 0 && rows > 0 {
+							cs := connections.GetClientSettings(connDetails.ConnectionId())
+							cs.Display.ScreenWidth = cols
+							cs.Display.ScreenHeight = rows
+							connections.OverwriteClientSettings(connDetails.ConnectionId(), cs)
+						}
+					}
+				}
+				if req.WantReply {
+					req.Reply(true, nil)
+				}
+			case "window-change":
+				// Payload: uint32 cols, uint32 rows, uint32 width-px, uint32 height-px
+				if len(req.Payload) >= 8 {
+					cols := uint32(req.Payload[0])<<24 | uint32(req.Payload[1])<<16 | uint32(req.Payload[2])<<8 | uint32(req.Payload[3])
+					rows := uint32(req.Payload[4])<<24 | uint32(req.Payload[5])<<16 | uint32(req.Payload[6])<<8 | uint32(req.Payload[7])
+					if cols > 0 && rows > 0 {
+						cs := connections.GetClientSettings(connDetails.ConnectionId())
+						cs.Display.ScreenWidth = cols
+						cs.Display.ScreenHeight = rows
+						connections.OverwriteClientSettings(connDetails.ConnectionId(), cs)
+					}
+				}
+				if req.WantReply {
+					req.Reply(true, nil)
+				}
+			case "shell", "exec":
+				if req.WantReply {
+					req.Reply(true, nil)
+				}
+			default:
+				if req.WantReply {
+					req.Reply(false, nil)
+				}
+			}
+		}
+	}()
+
+	var sharedState map[string]any = make(map[string]any)
+
+	connDetails.AddInputHandler("AnsiHandler", inputhandlers.AnsiHandler)
+	connDetails.AddInputHandler("CleanserInputHandler", inputhandlers.CleanserInputHandler)
+	connDetails.AddInputHandler("TextPrefixHandler", inputhandlers.TextPrefixHandler)
+
+	loginHandler := inputhandlers.GetLoginPromptHandler()
+	connDetails.AddInputHandler("LoginPromptHandler", loginHandler)
+
+	plugins.OnNetConnect(connDetails)
+
+	if audioConfig := audio.GetFile(`intro`); audioConfig.FilePath != `` {
+		v := 100
+		if audioConfig.Volume > 0 && audioConfig.Volume <= 100 {
+			v = audioConfig.Volume
+		}
+		connections.SendTo(
+			term.MspCommand.BytesWithPayload([]byte("!!MUSIC("+audioConfig.FilePath+" V="+strconv.Itoa(v)+" L=-1 C=1)")),
+			connDetails.ConnectionId(),
+		)
+	}
+
+	splashTxt, _ := templates.Process("login/connect-splash", nil)
+	connections.SendTo([]byte(templates.AnsiParse(splashTxt)), connDetails.ConnectionId())
+
+	initialTriggerInput := &connections.ClientInput{
+		ConnectionId: connDetails.ConnectionId(),
+	}
+	loginHandler(initialTriggerInput, sharedState)
+
+	var userObject *users.UserRecord
+	var sug suggestions.Suggestions
+	lastInput := time.Now()
+	c := configs.GetConfig()
+
+	inputBuffer := make([]byte, connections.ReadBufferSize)
+	clientInput := &connections.ClientInput{
+		ConnectionId: connDetails.ConnectionId(),
+		DataIn:       []byte{},
+		Buffer:       make([]byte, 0, connections.ReadBufferSize),
+		EnterPressed: false,
+		Clipboard:    []byte{},
+		History:      connections.InputHistory{},
+	}
+
+	for {
+		clientInput.EnterPressed = false
+		clientInput.TabPressed = false
+		clientInput.BSPressed = false
+
+		n, err := connDetails.Read(inputBuffer)
+		if err != nil {
+			if userObject != nil {
+				userObject.EventLog.Add(`conn`, `Disconnected`)
+				if c.Network.ZombieSeconds > 0 {
+					connDetails.SetState(connections.Zombie)
+					worldManager.SendSetZombie(userObject.UserId, true)
+				} else {
+					worldManager.SendLeaveWorld(userObject.UserId)
+					worldManager.SendLogoutConnectionId(connDetails.ConnectionId())
+				}
+			}
+			mudlog.Warn("SSH", "connectionID", connDetails.ConnectionId(), "error", err)
+			connections.Remove(connDetails.ConnectionId())
+			break
+		}
+
+		if connDetails.InputDisabled() {
+			continue
+		}
+
+		clientInput.DataIn = inputBuffer[:n]
+		okContinue, lastHandlerName, err := connDetails.HandleInput(clientInput, sharedState)
+		if err != nil {
+			mudlog.Warn("InputHandler Error", "handler", lastHandlerName, "error", err)
+			continue
+		}
+
+		if !okContinue {
+			if userObject == nil {
+				continue
+			}
+
+			_, suggested := userObject.GetUnsentText()
+			redrawPrompt := false
+
+			if clientInput.TabPressed {
+				if sug.Count() < 1 {
+					sug.Set(worldManager.GetAutoComplete(userObject.UserId, string(clientInput.Buffer)))
+				}
+				if sug.Count() > 0 {
+					suggested = sug.Next()
+					userObject.SetUnsentText(string(clientInput.Buffer), suggested)
+					redrawPrompt = true
+				}
+			} else if clientInput.BSPressed {
+				userObject.SetUnsentText(string(clientInput.Buffer), ``)
+				if suggested != `` {
+					suggested = ``
+					sug.Clear()
+					redrawPrompt = true
+				}
+			} else {
+				if suggested != `` {
+					if len(clientInput.Buffer) > 0 && clientInput.Buffer[len(clientInput.Buffer)-1] == term.ASCII_SPACE {
+						clientInput.Buffer = append(clientInput.Buffer[0:len(clientInput.Buffer)-1], []byte(suggested)...)
+						clientInput.Buffer = append(clientInput.Buffer[0:len(clientInput.Buffer)], []byte(` `)...)
+						redrawPrompt = true
+						userObject.SetUnsentText(string(clientInput.Buffer), ``)
+						sug.Clear()
+					} else {
+						suggested = ``
+						sug.Clear()
+						userObject.SetUnsentText(string(clientInput.Buffer), suggested)
+						redrawPrompt = true
+					}
+				}
+				userObject.SetUnsentText(string(clientInput.Buffer), suggested)
+			}
+
+			if redrawPrompt {
+				pTxt := userObject.GetCommandPrompt()
+				connections.SendTo([]byte(templates.AnsiParse(pTxt)), clientInput.ConnectionId)
+			}
+			continue
+		}
+
+		if okContinue && lastHandlerName == "LoginPromptHandler" {
+			connections.SendTo(
+				term.MspCommand.BytesWithPayload([]byte("!!MUSIC(Off)")),
+				clientInput.ConnectionId,
+			)
+
+			if uo, exists := sharedState["UserObject"]; exists {
+				var ok bool
+				userObject, ok = uo.(*users.UserRecord)
+				if !ok {
+					mudlog.Error("UserObject type assertion failed", "connectionId", clientInput.ConnectionId)
+					connections.Remove(clientInput.ConnectionId)
+					break
+				}
+				delete(sharedState, "UserObject")
+			} else {
+				mudlog.Error("Login process completed but UserObject not found in sharedState", "connectionId", clientInput.ConnectionId)
+				connections.Remove(clientInput.ConnectionId)
+				break
+			}
+
+			connDetails.RemoveInputHandler("LoginPromptHandler")
+			connDetails.AddInputHandler("EchoInputHandler", inputhandlers.EchoInputHandler)
+			connDetails.AddInputHandler("HistoryInputHandler", inputhandlers.HistoryInputHandler)
+
+			if userObject.Role == users.RoleAdmin {
+				connDetails.AddInputHandler("SystemCommandInputHandler", inputhandlers.SystemCommandInputHandler)
+			}
+
+			connDetails.AddInputHandler("SignalHandler", inputhandlers.SignalHandler, "AnsiHandler")
+			connDetails.SetState(connections.LoggedIn)
+			worldManager.SendEnterWorld(userObject.UserId, userObject.Character.RoomId)
+			clientInput.Reset()
+			continue
+		}
+
+		if !okContinue {
+			if userObject == nil {
+				continue
+			}
+		}
+
+		if clientInput.EnterPressed {
+			c = configs.GetConfig()
+
+			if time.Since(lastInput) < time.Duration(c.Timing.TurnMs)*time.Millisecond {
+				clientInput.Reset()
+				userObject.SetUnsentText(``, ``)
+			} else {
+				_, suggested := userObject.GetUnsentText()
+				if len(suggested) > 0 {
+					clientInput.Buffer = append(clientInput.Buffer, []byte(suggested)...)
+					sug.Clear()
+					userObject.SetUnsentText(string(clientInput.Buffer), ``)
+					connections.SendTo([]byte(templates.AnsiParse(userObject.GetCommandPrompt())), clientInput.ConnectionId)
+				}
+
+				wi := WorldInput{
+					FromId:    userObject.UserId,
+					InputText: string(clientInput.Buffer),
+				}
+				worldManager.SendInput(wi)
+				clientInput.Reset()
+				userObject.SetUnsentText(``, ``)
+				lastInput = time.Now()
+			}
+
+			time.Sleep(time.Duration(10) * time.Millisecond)
+		}
+	}
 }
 
 func loadAllDataFiles(isReload bool) {


### PR DESCRIPTION
# Description

This adds another type of connection: SSH.
Users can connect to the mud and interact using SSH instead of Telnet.

## Changes

- Added third connection type "SSH"
- If enabled, ports are displayed on front page
- New config values to support it
- "online" status reflects connection type now
