### PR TITLE
[CI] Stabilize JavaScript linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,42 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  detect-changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      js_lint: >-
+        ${{ steps.filter.outputs.js_lint }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: filter
+        name: Detect JavaScript lint inputs
+        env:
+          BASE_REF: >-
+            ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_REF: ${{ github.sha }}
+        run: |
+          set -eu
+
+          if [ -z "${BASE_REF}" ] || \
+            [ "${BASE_REF}" = "0000000000000000000000000000000000000000" ]; then
+            BASE_REF="$(git rev-parse HEAD^)"
+          fi
+
+          changed_files="$(git diff --name-only "${BASE_REF}" "${HEAD_REF}")"
+          printf '%s\n' "${changed_files}"
+
+          if printf '%s\n' "${changed_files}" | \
+            grep -Eq '^(Makefile|\.jshintrc(\..*)?$|_datafiles/.*\.js$)'; then
+            echo "js_lint=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "js_lint=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  go-lint:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6.0.2
@@ -30,13 +65,23 @@ jobs:
 
       - uses: ./.github/actions/setup-go
 
+      - name: Run Go lint checks
+        run: make validate
+
+  js-lint:
+    runs-on: ubuntu-24.04
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.js_lint == 'true'
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '22'
-
-      - name: Run Go lint checks
-        run: make validate
 
       - name: Run JavaScript lint checks
         run: make js-lint

--- a/.jshintrc
+++ b/.jshintrc
@@ -3,6 +3,12 @@
   "browser": true,
   "devel": true,
   "sub": true,
+  "globals": {
+    "MP3Player": false,
+    "Terminal": false,
+    "FitAddon": false,
+    "WinBox": false
+  },
   "-W014": true,
   "-W083": true,
   "-W097": true

--- a/.jshintrc.webclient-windows
+++ b/.jshintrc.webclient-windows
@@ -1,0 +1,13 @@
+{
+  "extends": ".jshintrc",
+  "globals": {
+    "Client": false,
+    "FitAddon": false,
+    "injectStyles": false,
+    "ResizeObserver": false,
+    "Terminal": false,
+    "uiMenu": false,
+    "VirtualWindow": false,
+    "VirtualWindows": false
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ CI_LOCAL_GID ?= $(shell id -g)
 CI_LOCAL_DOCKER_SOCK_GID ?= $(shell stat -c '%g' /var/run/docker.sock 2>/dev/null || id -g)
 CI_LOCAL_HOME ?= /home/gomud
 CI_LOCAL_ACT_CACHE_DIR ?= $(PWD)/.git/.cache/act
+JSHINT_VERSION ?= 2.13.6
 JS_LINT_PATHS := $(shell find _datafiles -name '*.js' -print)
+WEBCLIENT_WINDOW_JS := $(shell find _datafiles/html/public/static/js/windows -name '*.js' -print)
+WEBCLIENT_BASE_JS := $(filter-out $(WEBCLIENT_WINDOW_JS),$(JS_LINT_PATHS))
 CI_LOCAL_RUN := docker run --rm \
 	--user "$(CI_LOCAL_UID):$(CI_LOCAL_GID)" \
 	--group-add "$(CI_LOCAL_DOCKER_SOCK_GID)" \
@@ -182,7 +185,9 @@ js-lint:  ### Run Javascript linter
 #   Grep filtering it to remove errors reported by docker image around npm packages
 #   if "### errors" is found in the output, exits with an error code of 1
 #   This should allow us to use it in CI/CD.
-	@docker run --rm -v "$(PWD)":/app -w /app node:22 npx jshint $(JS_LINT_PATHS) \
+	@docker run --rm -v "$(PWD)":/app -w /app node:22 sh -lc "\
+	  npx --yes jshint@$(JSHINT_VERSION) $(WEBCLIENT_BASE_JS) && \
+	  npx --yes jshint@$(JSHINT_VERSION) --config .jshintrc.webclient-windows $(WEBCLIENT_WINDOW_JS)" \
 	 2>&1 | grep -v "^npm " | tee /dev/stderr | grep -Eq "^[0-9]+ errors" && exit 1 || true
 
 #

--- a/_datafiles/html/public/static/js/webclient-core.js
+++ b/_datafiles/html/public/static/js/webclient-core.js
@@ -1,4 +1,4 @@
-/* global MP3Player, Triggers, WinBox */
+/* global Triggers */
 
 /**
  * webclient-core.js

--- a/_datafiles/html/public/static/js/windows/window-character.js
+++ b/_datafiles/html/public/static/js/windows/window-character.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
-
 /**
  * window-character.js
  *

--- a/_datafiles/html/public/static/js/windows/window-comm.js
+++ b/_datafiles/html/public/static/js/windows/window-comm.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
-
 /**
  * window-comm.js
  *

--- a/_datafiles/html/public/static/js/windows/window-gametime.js
+++ b/_datafiles/html/public/static/js/windows/window-gametime.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
-
 /**
  * window-gametime.js
  *

--- a/_datafiles/html/public/static/js/windows/window-gear.js
+++ b/_datafiles/html/public/static/js/windows/window-gear.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles, uiMenu */
-
 /**
  * window-gear.js
  *

--- a/_datafiles/html/public/static/js/windows/window-killstats.js
+++ b/_datafiles/html/public/static/js/windows/window-killstats.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
-
 /**
  * window-killstats.js
  *

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -1,5 +1,3 @@
-/* global Client, ResizeObserver, VirtualWindow, VirtualWindows, injectStyles, uiMenu */
-
 /**
  * window-map.js
  *

--- a/_datafiles/html/public/static/js/windows/window-modal.js
+++ b/_datafiles/html/public/static/js/windows/window-modal.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindows, injectStyles, Terminal, FitAddon */
-
 /**
  * window-modal.js
  *

--- a/_datafiles/html/public/static/js/windows/window-online.js
+++ b/_datafiles/html/public/static/js/windows/window-online.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
-
 /**
  * window-online.js
  *

--- a/_datafiles/html/public/static/js/windows/window-party.js
+++ b/_datafiles/html/public/static/js/windows/window-party.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
-
 /**
  * window-party.js
  *

--- a/_datafiles/html/public/static/js/windows/window-room.js
+++ b/_datafiles/html/public/static/js/windows/window-room.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles, uiMenu */
-
 /**
  * window-room.js
  *
@@ -422,7 +420,7 @@
         if (opts.locked) {
             const icon = document.createElement('span');
             icon.className   = 'rw-icon locked';
-            icon.textContent = '\u{1f512}';
+            icon.textContent = '\ud83d\udd12';
             icon.title       = opts.hasKey ? 'locked (have key)' : opts.hasCombo ? 'locked (have combo)' : 'locked';
             row.appendChild(icon);
         }

--- a/_datafiles/html/public/static/js/windows/window-status.js
+++ b/_datafiles/html/public/static/js/windows/window-status.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
-
 /**
  * window-status.js
  *

--- a/_datafiles/html/public/static/js/windows/window-vitals.js
+++ b/_datafiles/html/public/static/js/windows/window-vitals.js
@@ -1,5 +1,3 @@
-/* global Client, VirtualWindow, VirtualWindows, injectStyles */
-
 /**
  * window-vitals.js
  *


### PR DESCRIPTION
## Why
- repeated `/* global ... */` headers in the webclient window modules were lint-only noise
- JS lint failures were easy to misread because the `Lint` workflow mixed Go validation and JavaScript lint into one job
- unpinned `npx jshint` left CI behavior vulnerable to tool drift

## Changes
- pin JSHint in `make js-lint`
- centralize shared window-module globals in `.jshintrc.webclient-windows`
- remove the repeated globals headers from the window modules
- split `.github/workflows/lint.yml` into `go-lint` and `js-lint`
- only run `js-lint` when JS lint inputs change

## Validation
- `make js-lint`
- `actionlint .github/workflows/lint.yml`
- `yamllint .github/workflows/lint.yml`
