### PR TITLE
Zombie mode

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -435,10 +435,10 @@ Network:
   #   Whether Admin/Mod users get timed out when reaching MaxIdleSeconds
   #   If set to false, Admins & Mods never get force disconnected.
   TimeoutMods: false
-  # - ZombieSeconds -
+  # - LinkDeadSeconds -
   #   How many seconds a character stays active/in game after a network connection
   #   is lost. Set to 0 to instantly log out characters (exploitable).
-  ZombieSeconds: 60
+  LinkDeadSeconds: 60
   # - LogoutRounds -
   #   How many rounds of meditation a player must complete before they are
   #   logged out. If interrupted, they must start over.

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -435,7 +435,7 @@ Network:
   #   Whether Admin/Mod users get timed out when reaching MaxIdleSeconds
   #   If set to false, Admins & Mods never get force disconnected.
   TimeoutMods: false
-    # - ZombieSeconds -
+  # - ZombieSeconds -
   #   How many seconds a character stays active/in game after a network connection
   #   is lost. Set to 0 to instantly log out characters (exploitable).
   ZombieSeconds: 60

--- a/ai-context/network-summary.md
+++ b/ai-context/network-summary.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The GoMud network layer provides a sophisticated, multi-protocol networking system that supports both traditional MUD clients via telnet and modern web-based clients via WebSocket. The architecture is designed for high concurrency, robust protocol handling, and extensive customization through a plugin system.
+The GoMud network layer provides a sophisticated, multi-protocol networking system that supports traditional MUD clients via telnet, modern web-based clients via WebSocket, and terminal clients via SSH. The architecture is designed for high concurrency, robust protocol handling, and extensive customization through a plugin system.
 
 ## Network Architecture
 
@@ -12,12 +12,12 @@ The GoMud network layer provides a sophisticated, multi-protocol networking syst
 - Primary network initialization and server startup
 - Manages multiple concurrent network listeners
 - Handles graceful shutdown and connection cleanup
-- Coordinates between telnet and WebSocket protocols
+- Coordinates between telnet, WebSocket, and SSH protocols
 
 **Connection Management (`internal/connections`)**
 - Thread-safe connection tracking with unique IDs
-- Dual protocol support (telnet and WebSocket)
-- Connection state management (Login, LoggedIn, Zombie)
+- Triple protocol support: telnet (`net.Conn`), WebSocket (`*websocket.Conn`), SSH (`ssh.Channel`)
+- Connection state management (Login, LoggedIn, LinkDead)
 - Heartbeat monitoring for WebSocket connections
 - Input processing pipeline with chainable handlers
 
@@ -75,7 +75,8 @@ The GoMud network layer provides a sophisticated, multi-protocol networking syst
   - `window-change` handling: live terminal resize updates to client settings
   - Out-of-band requests (keepalive, etc.) silently discarded
   - Same input handler chain and game integration as telnet
-  - Connection type reported as `ssh` in online info and Discord notifications
+  - Connection type reported as `ssh` in `OnlineInfo` and Discord notifications
+  - Tracked via `NewSSHConnectionDetails` with `ssh.Channel` and remote `net.Addr`
 
 ### HTTP/HTTPS Server
 - **HTTP Port**: 80 (configurable, 0 to disable)
@@ -101,7 +102,7 @@ The GoMud network layer provides a sophisticated, multi-protocol networking syst
 **Connection States**:
 - **Login**: Initial state before authentication
 - **LoggedIn**: Authenticated and active
-- **Zombie**: Disconnected but not yet cleaned up (configurable timeout)
+- **LinkDead**: Disconnected but not yet cleaned up (configurable timeout)
 
 **Connection Tracking**:
 - Thread-safe connection registry with RWMutex
@@ -117,7 +118,7 @@ The GoMud network layer provides a sophisticated, multi-protocol networking syst
 - Shared state map for handler communication
 - Handler-specific error handling and recovery
 
-**Standard Handler Chain** (Telnet and SSH):
+**Standard Handler Chain (Telnet and SSH)**:
 1. **TelnetIACHandler**: Telnet protocol command processing
 2. **AnsiHandler**: ANSI escape sequence processing
 3. **CleanserInputHandler**: Input sanitization
@@ -143,7 +144,7 @@ The GoMud network layer provides a sophisticated, multi-protocol networking syst
 
 ### Multi-Step Authentication
 - **Username Validation**: Existence checking and format validation
-- **Password Authentication**: Secure password verification
+- **Password Authentication**: Secure bcrypt password verification
 - **Account Creation**: New user registration workflow
 - **Duplicate Login Handling**: Detection and management of concurrent sessions
 
@@ -173,7 +174,7 @@ Network:
   HttpsRedirect: false          # Auto-redirect HTTP to HTTPS
   SSHPort: 0                    # SSH port (0 = disabled)
   MaxSSHConnections: 50         # Max SSH connections
-  ZombieSeconds: 60             # Zombie connection timeout
+  LinkDeadSeconds: 60           # Link-dead connection timeout
   AfkSeconds: 1800              # AFK timeout
   TimeoutMods: false            # Timeout moderators/admins
 ```
@@ -200,10 +201,11 @@ FilePaths:
 - **Thread Safety**: Goroutine-safe ping/pong handling
 
 ### Client Settings Management
-- **Screen Dimensions**: Width/height tracking (default 80x24)
+- **Screen Dimensions**: Width/height tracking (default 80x40)
 - **Protocol Capabilities**: MSP support detection
 - **Display Preferences**: Color and formatting support
 - **Terminal Type**: Client terminal identification
+- **Connection Type**: Tracked as `telnet`, `websocket`, or `ssh` in `OnlineInfo`
 
 ### Command History
 - **History Size**: 10 commands maximum
@@ -249,13 +251,12 @@ FilePaths:
 - **Connection Tracking**: Total connections and disconnections
 - **Active Connections**: Real-time active connection count
 - **Error Logging**: Comprehensive error tracking and reporting
-- **Performance Metrics**: Connection timing and throughput monitoring
 
 ## Error Handling and Recovery
 
 ### Connection Error Management
 - **Graceful Degradation**: Automatic handling of connection failures
-- **Zombie State**: Temporary preservation of disconnected users
+- **LinkDead State**: Temporary preservation of disconnected users
 - **Automatic Cleanup**: Failed connection removal and resource cleanup
 - **Error Logging**: Detailed error reporting with context
 
@@ -272,6 +273,7 @@ FilePaths:
 - **Session Management**: Connection association with user accounts
 - **Character Loading**: Automatic character data loading on login
 - **Duplicate Detection**: Prevention of multiple concurrent logins
+- **Connection Type**: SSH/WebSocket/telnet type exposed via `UserRecord.GetOnlineInfo()`
 
 ### Event System Integration
 - **Connection Events**: Login/logout event generation
@@ -283,81 +285,16 @@ FilePaths:
 - **Input Processing**: User command forwarding to game engine
 - **Output Handling**: Game output formatting and transmission
 - **State Synchronization**: Connection state with game state
-- **Zombie Management**: Temporary character preservation
-
-## Security Considerations
-
-### Network Security
-- **Input Validation**: Comprehensive input sanitization
-- **Protocol Security**: Safe telnet and WebSocket handling
-- **Connection Limits**: DoS protection through connection limiting
-- **Authentication**: Secure multi-step authentication process
-
-### Administrative Security
-- **Role Verification**: Admin command access control
-- **Audit Logging**: Complete administrative action logging
-- **Session Management**: Secure admin session handling
-- **Command Validation**: Strict system command syntax validation
-
-## Deployment and Operations
-
-### Server Startup Process
-1. **Configuration Loading**: Network settings validation
-2. **Port Binding**: Telnet, SSH, and HTTP/HTTPS server startup
-3. **Worker Initialization**: Input and main worker goroutines
-4. **Plugin Loading**: Network plugin initialization
-5. **Signal Handling**: Graceful shutdown signal registration
-
-### Graceful Shutdown
-1. **Connection Notification**: Broadcast shutdown message
-2. **New Connection Blocking**: Prevent new connections
-3. **Connection Cleanup**: Close all active connections
-4. **Resource Cleanup**: Release network resources
-5. **Worker Synchronization**: Wait for worker completion
-
-### Monitoring and Maintenance
-- **Connection Statistics**: Real-time connection monitoring
-- **Error Tracking**: Network error logging and analysis
-- **Performance Monitoring**: Connection timing and throughput
-- **Resource Usage**: Memory and CPU utilization tracking
+- **LinkDead Management**: Temporary character preservation
 
 ## User Input Processing Flow
-
-### Input Processing Architecture
-
-GoMud implements a sophisticated multi-stage input processing system that handles user commands through a series of channels, workers, and event processing stages. This design provides excellent separation of concerns, scalability, and extensibility.
 
 ### Input Flow Stages
 
 #### Stage 1: Network Input Reception
-**Location**: Connection handlers in `main.go`
-
-**Telnet Flow**:
-1. Raw bytes received from telnet connection
-2. Input handler chain processes the data:
-   - `TelnetIACHandler`: Processes telnet protocol commands
-   - `AnsiHandler`: Handles ANSI escape sequences
-   - `CleanserInputHandler`: Sanitizes input
-   - `LoginPromptHandler`: Manages authentication (pre-login)
-   - `EchoInputHandler`: Handles terminal echo (post-login)
-   - `HistoryInputHandler`: Manages command history
-   - `SystemCommandInputHandler`: Processes system commands (admin only)
-   - `SignalHandler`: Handles terminal signals
-
-**SSH Flow**:
-1. TCP connection accepted; SSH handshake performed via `golang.org/x/crypto/ssh`
-2. Only `session` channels accepted
-3. `pty-req` and `window-change` channel requests handled for terminal sizing
-4. Same full input handler chain as telnet
-5. Reads/writes on `ssh.Channel`; connection tracked via `NewSSHConnectionDetails`
-
-**WebSocket Flow**:
-1. WebSocket message received
-2. Simplified handler chain (no telnet/ANSI processing)
-3. Direct conversion to input event
+Raw bytes received from the connection and passed through the input handler chain (see Handler Chain above).
 
 #### Stage 2: World Input Channel
-**Structure**: `WorldInput` struct
 ```go
 type WorldInput struct {
     FromId    int     // User ID
@@ -365,35 +302,15 @@ type WorldInput struct {
     ReadyTurn uint64  // Turn number when ready to process
 }
 ```
-
-**Channel**: `worldInput chan WorldInput`
-- **Blocking Channel**: Synchronous communication between network and game layers
-- **Thread Safety**: Single writer (network), single reader (InputWorker)
-- **Backpressure**: Network connections block if game processing falls behind
+- **Channel**: `worldInput chan WorldInput`
+- Synchronous communication between network and game layers
 
 #### Stage 3: Input Worker Processing
-**Worker**: `InputWorker` goroutine in `world.go`
-
-**Responsibilities**:
-1. Receives `WorldInput` from network layer
-2. Converts to `events.Input` event
-3. Adds to event queue with current turn number
-4. Provides isolation between network and game logic
-
-**Code Flow**:
-```go
-case wi := <-w.worldInput:
-    events.AddToQueue(events.Input{
-        UserId:    wi.FromId,
-        InputText: wi.InputText,
-        ReadyTurn: util.GetTurnCount(),
-    })
-```
+- Receives `WorldInput` from network layer
+- Converts to `events.Input` event
+- Adds to event queue with current turn number
 
 #### Stage 4: Event System Processing
-**Event Type**: `events.Input`
-
-**Event Structure**:
 ```go
 type Input struct {
     UserId        int
@@ -404,151 +321,52 @@ type Input struct {
     Flags         EventFlag
 }
 ```
+- Turn-based queuing: commands wait until their `ReadyTurn`
+- One command per user per turn
+- Commands not ready are requeued
 
-**Processing Logic**:
-1. **Turn-Based Queuing**: Commands wait until their `ReadyTurn` is reached
-2. **Input Blocking**: Commands can block further input with `CmdBlockInput` flag
-3. **One Command Per Turn**: Only one command per user per turn processed
-4. **Requeuing**: Commands not ready are requeued for later processing
-
-#### Stage 5: Command Execution
-**Function**: `processInput()` in `world.go`
-
-**Processing Steps**:
-1. **User Validation**: Verify user exists and is active
-2. **Prompt Handling**: Process any active command prompts
-3. **Macro Expansion**: Expand user-defined macros into multiple commands
-4. **Command Parsing**: Split input into command and arguments
-5. **Command Execution**: Try to execute via `usercommands.TryCommand()`
-6. **Error Handling**: Track unrecognized commands and provide feedback
+#### Stage 5: Command Execution (`processInput()` in `world.go`)
+1. User validation
+2. Prompt handling
+3. Macro expansion
+4. Command parsing
+5. Execution via `usercommands.TryCommand()`
 
 ### Channel Architecture
 
-#### Primary Channels
+| Channel | Type | Purpose |
+|---------|------|---------|
+| World Input | `chan WorldInput` | User commands from network layer |
+| Enter World | `chan [2]int` | User login completion (userId, roomId) |
+| Leave World | `chan int` | User logout/disconnect (userId) |
+| Logout Connection | `chan connections.ConnectionId` | Connection-specific logout |
+| LinkDead Flag | `chan [2]int` | LinkDead state management |
 
-**World Input Channel**:
-- **Type**: `chan WorldInput`
-- **Purpose**: User command input from network layer
-- **Flow**: Network → InputWorker → Event System
+### Worker Goroutines
 
-**Enter World Channel**:
-- **Type**: `chan [2]int` (userId, roomId)
-- **Purpose**: User login completion
-- **Flow**: Authentication → MainWorker → Game World
+**InputWorker**: Converts network input to game events. Single goroutine, no shared state.
 
-**Leave World Channel**:
-- **Type**: `chan int` (userId)
-- **Purpose**: User logout/disconnect
-- **Flow**: Network/System → MainWorker → Game World
-
-**Logout Connection Channel**:
-- **Type**: `chan connections.ConnectionId`
-- **Purpose**: Connection-specific logout
-- **Flow**: Network → MainWorker → User Management
-
-**Zombie Flag Channel**:
-- **Type**: `chan [2]int` (userId, flag)
-- **Purpose**: Zombie state management
-- **Flow**: Network/System → MainWorker → User Management
-
-#### Worker Goroutines
-
-**InputWorker**:
-- **Purpose**: Convert network input to game events
-- **Channels Read**: `worldInput`, `shutdown`
-- **Thread Safety**: Single goroutine, no shared state
-- **Lifecycle**: Started at server startup, stopped on shutdown
-
-**MainWorker**:
-- **Purpose**: Game state management and event processing
-- **Channels Read**: Multiple management channels, timers
-- **Responsibilities**:
-  - Event loop processing
-  - Turn/round timing
-  - User lifecycle management
-  - Room maintenance
-  - Statistics updates
+**MainWorker**: Game state management and event processing. Handles event loop, turn/round timing, user lifecycle, room maintenance.
 
 ### Input Processing Features
 
-#### Turn-Based Processing
-- **Turn Counter**: Global turn counter incremented every `TurnMs` milliseconds
-- **Command Queuing**: Commands wait for their designated turn
-- **Fairness**: One command per user per turn prevents command flooding
-- **Timing Control**: Commands can specify future turn execution
-
-#### Input Blocking and Flow Control
-- **Block Input Flag**: Commands can block further user input
-- **Unblock Input Flag**: Commands can unblock previously blocked input
-- **Ignore Map**: Tracks users with blocked input by turn number
-- **Zombie Handling**: Special processing for disconnected users
-
-#### Macro System
-- **Macro Expansion**: Two-character macros expand to command sequences
-- **Sequential Execution**: Macro commands executed in order with turn delays
-- **Delimiter Support**: Semicolon-separated command sequences
-- **Turn Scheduling**: Each macro command gets its own turn
-
-#### Command Processing
+- **Turn-Based Processing**: Global turn counter; one command per user per turn
+- **Input Blocking**: Commands can block/unblock further user input via `CmdBlockInput` flag
+- **Macro System**: Two-character macros expand to semicolon-delimited command sequences
 - **Alias Resolution**: Commands resolved through keyword alias system
-- **Shortcut Support**: Gossip shortcuts (`, .`) expanded automatically
-- **Command Parsing**: Intelligent command/argument separation
-- **Error Tracking**: Bad commands tracked for analytics
 
-### Performance Characteristics
+## Deployment and Operations
 
-#### Scalability Features
-- **Asynchronous Processing**: Network and game processing decoupled
-- **Backpressure Handling**: Network blocks if game processing falls behind
-- **Event Batching**: Multiple events processed per event loop iteration
-- **Efficient Queuing**: Minimal memory allocation for event processing
+### Server Startup Process
+1. Configuration loading and network settings validation
+2. Port binding: Telnet, SSH, and HTTP/HTTPS server startup
+3. Worker initialization: InputWorker and MainWorker goroutines
+4. Plugin loading and network plugin initialization
+5. Signal handling for graceful shutdown
 
-#### Concurrency Safety
-- **Channel Communication**: Thread-safe communication between layers
-- **Single Writers**: Each channel has single writer goroutine
-- **Game State Locking**: MUD state locked during processing
-- **Atomic Operations**: Turn counters use atomic operations
-
-#### Resource Management
-- **Event Requeuing**: Efficient requeuing of delayed events
-- **Memory Cleanup**: Event trackers cleared each turn
-- **Connection Cleanup**: Failed connections automatically removed
-- **Graceful Shutdown**: All workers synchronized on shutdown
-
-### Integration Points
-
-#### Network Layer Integration
-- **Protocol Abstraction**: Same input flow for telnet, SSH, and WebSocket
-- **Handler Flexibility**: Configurable input handler chains
-- **Error Propagation**: Network errors propagated to game layer
-- **Connection State**: Input processing aware of connection state
-
-#### Event System Integration
-- **Event Priority**: Input events processed with appropriate priority
-- **Event Flags**: Rich flag system for command behavior control
-- **Event Requeuing**: Seamless requeuing of delayed commands
-- **Event Tracking**: Per-user event tracking prevents command flooding
-
-#### Game System Integration
-- **User Management**: Direct integration with user authentication
-- **Command System**: Seamless integration with command processing
-- **Prompt System**: Interactive prompt handling
-- **Statistics**: Input processing statistics and monitoring
-
-This sophisticated input processing architecture provides excellent performance, scalability, and maintainability while ensuring fair command processing and robust error handling across all network protocols.
-
-## Future Enhancements
-
-### Protocol Extensions
-- **Modern Protocols**: Enhanced WebSocket features
-- **Compression**: Network traffic compression
-- **Encryption**: Enhanced security protocols
-- **Binary Protocols**: Efficient binary communication
-
-### Performance Improvements
-- **Connection Pooling**: Advanced connection management
-- **Load Balancing**: Multi-server connection distribution
-- **Caching**: Network operation caching
-- **Optimization**: Protocol-specific optimizations
-
-This comprehensive network layer provides a robust foundation for MUD server networking with excellent scalability, security, and extensibility through its plugin architecture. The dual-protocol support ensures compatibility with both traditional MUD clients and modern web-based interfaces while maintaining high performance and reliability.
+### Graceful Shutdown
+1. Broadcast shutdown message to all connections
+2. Block new connections
+3. Close all active connections
+4. Release network resources
+5. Wait for worker completion

--- a/internal/buffs/context.md
+++ b/internal/buffs/context.md
@@ -144,51 +144,10 @@ const (
 ### Flag Usage Patterns
 ```go
 // Check for specific behavioral flags
-func (bs *Buffs) HasFlag(action Flag, expire bool) bool {
-    if action != All {
-        if _, ok := bs.buffFlags[action]; !ok {
-            return false
-        }
-    }
-    
-    found := false
-    for index, b := range bs.List {
-        if b.Expired() {
-            continue
-        }
-        
-        bSpec := GetBuffSpec(b.BuffId)
-        for _, flag := range bSpec.Flags {
-            if flag == action || action == All {
-                found = true
-                
-                // Optionally expire the buff when checked
-                if expire {
-                    if b.BuffId == 0 { // Special buff 0 handling
-                        bs.List = append(bs.List[:index], bs.List[index+1:]...)
-                    } else {
-                        b.TriggersLeft = TriggersLeftExpired
-                        bs.List[index] = b
-                    }
-                    break
-                }
-                
-                return found
-            }
-        }
-    }
-    
-    return found
-}
+func (bs *Buffs) HasFlag(action Flag, expire bool) bool
 
 // Get all buff IDs with specific flag
-func (bs *Buffs) GetBuffIdsWithFlag(action Flag) []int {
-    buffIds := []int{}
-    for _, idx := range bs.buffFlags[action] {
-        buffIds = append(buffIds, bs.List[idx].BuffId)
-    }
-    return buffIds
-}
+func (bs *Buffs) GetBuffIdsWithFlag(action Flag) []int
 ```
 
 ## Timing and Trigger System
@@ -196,86 +155,22 @@ func (bs *Buffs) GetBuffIdsWithFlag(action Flag) []int {
 ### Round-Based Triggers
 ```go
 // Trigger buffs based on round intervals
-func (bs *Buffs) Trigger(buffId ...int) (triggeredBuffs []*Buff) {
-    for idx, b := range bs.List {
-        // Handle specific buff triggering if requested
-        if len(buffId) > 0 {
-            found := false
-            for _, id := range buffId {
-                if b.BuffId == id {
-                    found = true
-                    break
-                }
-            }
-            if !found {
-                continue
-            }
-        }
-        
-        if buffInfo := GetBuffSpec(b.BuffId); buffInfo != nil {
-            if b.TriggersLeft > 0 {
-                b.RoundCounter++
-                
-                // Check if it's time to trigger
-                if b.RoundCounter%buffInfo.RoundInterval == 0 {
-                    triggeredBuffs = append(triggeredBuffs, b)
-                    
-                    // Decrement triggers unless unlimited
-                    if b.TriggersLeft != TriggersLeftUnlimited {
-                        b.TriggersLeft--
-                    } else {
-                        // Reset counter to prevent overflow
-                        b.RoundCounter = 0
-                    }
-                }
-                
-                bs.List[idx] = b
-            }
-        }
-    }
-    
-    return triggeredBuffs
-}
+func (bs *Buffs) Trigger(buffId ...int) (triggeredBuffs []*Buff)
 ```
 
 ### Duration Calculations
 ```go
 // Calculate remaining and total duration
-func GetDurations(buff *Buff, spec *BuffSpec) (roundsLeft int, totalRounds int) {
-    totalRounds = spec.TriggerCount * spec.RoundInterval
-    roundsLeft = totalRounds - buff.RoundCounter
-    return roundsLeft, totalRounds
-}
+func GetDurations(buff *Buff, spec *BuffSpec) (roundsLeft int, totalRounds int)
 
 // Check if buff has expired
-func (b *Buff) Expired() bool {
-    return b.TriggersLeft <= TriggersLeftExpired
-}
+func (b *Buff) Expired() bool
 ```
 
 ### Time String Processing
 ```go
 // Validate and convert time strings to round intervals
-func (b *BuffSpec) Validate() error {
-    // Special handling for logout/meditation buff
-    if b.BuffId == 0 {
-        b.TriggerCount = int(configs.GetNetworkConfig().LogoutRounds)
-    }
-    
-    // Convert time string to round interval using game time system
-    b.RoundInterval = int(validationCalculator.AddPeriod(b.TriggerRate) - validationRound)
-    
-    if b.TriggerCount < 1 {
-        return fmt.Errorf("buffId %d (%s) has TriggerCount < 1", b.BuffId, b.Name)
-    }
-    
-    if b.RoundInterval < 1 {
-        return fmt.Errorf("buffId %d (%s) has RoundInterval < 1. Is %s valid?", 
-                         b.BuffId, b.Name, b.TriggerRate)
-    }
-    
-    return nil
-}
+func (b *BuffSpec) Validate() error
 ```
 
 ## Stat Modification System
@@ -283,56 +178,19 @@ func (b *BuffSpec) Validate() error {
 ### Individual Buff Stat Modifications
 ```go
 // Get stat modification from single buff
-func (b *Buff) StatMod(statName string) int {
-    if b.Expired() {
-        return 0
-    }
-    
-    if buffInfo := GetBuffSpec(b.BuffId); buffInfo != nil {
-        return buffInfo.StatMods.Get(statName)
-    }
-    
-    return 0
-}
+func (b *Buff) StatMod(statName string) int
 ```
 
 ### Cumulative Stat Modifications
 ```go
 // Calculate total stat modification from all active buffs
-func (bs *Buffs) StatMod(statName string) int {
-    buffAmt := 0
-    for _, b := range bs.List {
-        buffAmt += b.StatMod(statName)
-    }
-    return buffAmt
-}
+func (bs *Buffs) StatMod(statName string) int
 ```
 
 ### Buff Value Calculation
 ```go
 // Calculate relative power/value of a buff for balance
-func (b *BuffSpec) GetValue() int {
-    val := 0
-    
-    // Sum absolute values of all stat modifications
-    for _, v := range b.StatMods {
-        val += int(math.Abs(float64(v)))
-    }
-    
-    // Add value for frequency (more frequent = more valuable)
-    freqVal := max(5-b.RoundInterval, 0)
-    val += freqVal
-    
-    // Add value for flags (5 points per flag)
-    val += len(b.Flags) * 5
-    
-    // Multiply by trigger count for total effect
-    if b.TriggerCount > 0 {
-        val *= b.TriggerCount
-    }
-    
-    return val
-}
+func (b *BuffSpec) GetValue() int
 ```
 
 ## Buff Management Operations
@@ -340,102 +198,22 @@ func (b *BuffSpec) GetValue() int {
 ### Adding Buffs
 ```go
 // Add new buff or refresh existing buff
-func (bs *Buffs) AddBuff(buffId int, isPermanent bool) bool {
-    if buffInfo := GetBuffSpec(buffId); buffInfo != nil {
-        newBuff := Buff{
-            BuffId:       buffInfo.BuffId,
-            RoundCounter: 0,
-            PermaBuff:    false,
-            TriggersLeft: buffInfo.TriggerCount,
-        }
-        
-        // Handle permanent buffs (from equipment/race)
-        if isPermanent {
-            newBuff.TriggersLeft = TriggersLeftUnlimited
-            newBuff.PermaBuff = true
-        }
-        
-        // Check if buff already exists
-        if idx, ok := bs.buffIds[buffId]; ok {
-            // Refresh existing buff
-            bs.List[idx].TriggersLeft = newBuff.TriggersLeft
-            bs.List[idx].PermaBuff = newBuff.PermaBuff
-            return true
-        }
-        
-        // Add new buff
-        bs.List = append(bs.List, &newBuff)
-        listIndex := len(bs.List) - 1
-        bs.buffIds[buffId] = listIndex
-        
-        // Update flag indexes
-        for _, flag := range buffInfo.Flags {
-            if _, ok := bs.buffFlags[flag]; !ok {
-                bs.buffFlags[flag] = []int{}
-            }
-            bs.buffFlags[flag] = append(bs.buffFlags[flag], listIndex)
-        }
-        
-        return true
-    }
-    
-    return false
-}
+func (bs *Buffs) AddBuff(buffId int, isPermanent bool) bool
 ```
 
 ### Removing Buffs
 ```go
 // Remove specific buff by ID
-func (bs *Buffs) RemoveBuff(buffId int) bool {
-    if index, ok := bs.buffIds[buffId]; ok {
-        bs.List[index].TriggersLeft = TriggersLeftExpired
-        return true
-    }
-    return false
-}
+func (bs *Buffs) RemoveBuff(buffId int) bool
 
 // Mark buff as started (no longer waiting for start event)
-func (bs *Buffs) Started(buffId int) {
-    if idx, ok := bs.buffIds[buffId]; ok {
-        bs.List[idx].OnStartWaiting = false
-    }
-}
+func (bs *Buffs) Started(buffId int)
 ```
 
 ### Pruning Expired Buffs
 ```go
 // Remove all expired buffs and rebuild indexes
-func (bs *Buffs) Prune() (prunedBuffs []*Buff) {
-    if len(bs.List) == 0 {
-        return prunedBuffs
-    }
-    
-    didPrune := false
-    
-    // Iterate backwards to safely remove items
-    for i := len(bs.List) - 1; i >= 0; i-- {
-        b := bs.List[i]
-        prune := false
-        
-        buffInfo := GetBuffSpec(b.BuffId)
-        if buffInfo == nil || b.Expired() {
-            prune = true
-        }
-        
-        if prune {
-            prunedBuffs = append(prunedBuffs, b)
-            bs.List = append(bs.List[:i], bs.List[i+1:]...)
-            didPrune = true
-        }
-    }
-    
-    // Rebuild lookup indexes if any buffs were pruned
-    if didPrune {
-        bs.Validate(true)
-    }
-    
-    return prunedBuffs
-}
+func (bs *Buffs) Prune() (prunedBuffs []*Buff)
 ```
 
 ## Collection Validation and Indexing
@@ -443,80 +221,19 @@ func (bs *Buffs) Prune() (prunedBuffs []*Buff) {
 ### Index Management
 ```go
 // Validate and rebuild internal indexes
-func (bs *Buffs) Validate(forceRebuild ...bool) {
-    if bs.buffFlags == nil {
-        bs.buffFlags = make(map[Flag][]int)
-    }
-    if bs.buffIds == nil {
-        bs.buffIds = make(map[int]int)
-    }
-    
-    // Rebuild if size mismatch or forced
-    if (len(bs.List) != len(bs.buffIds)) || (len(forceRebuild) > 0 && forceRebuild[0]) {
-        bs.buffIds = make(map[int]int)
-        bs.buffFlags = make(map[Flag][]int)
-        
-        // Rebuild all indexes
-        for idx, b := range bs.List {
-            bs.buffIds[b.BuffId] = idx
-            
-            bSpec := GetBuffSpec(b.BuffId)
-            if bSpec == nil {
-                mudlog.Warn("buffs.Validate()", "buffId", b.BuffId, "error", "invalid buffId")
-                continue
-            }
-            
-            // Index all flags for this buff
-            for _, flag := range bSpec.Flags {
-                if _, ok := bs.buffFlags[flag]; !ok {
-                    bs.buffFlags[flag] = []int{}
-                }
-                bs.buffFlags[flag] = append(bs.buffFlags[flag], idx)
-            }
-        }
-    }
-}
+func (bs *Buffs) Validate(forceRebuild ...bool)
 ```
 
 ### Query Operations
 ```go
 // Check if specific buff exists
-func (bs *Buffs) HasBuff(buffId int) bool {
-    if _, ok := bs.buffIds[buffId]; ok {
-        return true
-    }
-    return false
-}
+func (bs *Buffs) HasBuff(buffId int) bool
 
 // Get remaining triggers for buff
-func (bs *Buffs) TriggersLeft(buffId int) int {
-    if idx, ok := bs.buffIds[buffId]; ok {
-        return bs.List[idx].TriggersLeft
-    }
-    return 0
-}
+func (bs *Buffs) TriggersLeft(buffId int) int
 
 // Get all active buffs (optionally filtered by ID)
-func (bs *Buffs) GetBuffs(buffId ...int) []*Buff {
-    retBuffs := []*Buff{}
-    for _, b := range bs.List {
-        if !b.Expired() {
-            if len(buffId) > 0 {
-                // Filter by specific buff IDs
-                for _, id := range buffId {
-                    if b.BuffId == id {
-                        retBuffs = append(retBuffs, b)
-                        break
-                    }
-                }
-            } else {
-                // Return all active buffs
-                retBuffs = append(retBuffs, b)
-            }
-        }
-    }
-    return retBuffs
-}
+func (bs *Buffs) GetBuffs(buffId ...int) []*Buff
 ```
 
 ## Scripting Integration
@@ -524,48 +241,19 @@ func (bs *Buffs) GetBuffs(buffId ...int) []*Buff {
 ### Script System Support
 ```go
 // Get buff script content
-func (b *BuffSpec) GetScript() string {
-    scriptPath := b.GetScriptPath()
-    if _, err := os.Stat(scriptPath); err == nil {
-        if bytes, err := os.ReadFile(scriptPath); err == nil {
-            return string(bytes)
-        }
-    }
-    return ""
-}
+func (b *BuffSpec) GetScript() string
 
 // Generate script file path
-func (b *BuffSpec) GetScriptPath() string {
-    buffFilePath := b.Filename()
-    scriptFilePath := strings.Replace(buffFilePath, ".yaml", ".js", 1)
-    
-    fullScriptPath := strings.Replace(
-        string(configs.GetFilePathsConfig().DataFiles)+"/buffs/"+b.Filepath(),
-        buffFilePath,
-        scriptFilePath,
-        1)
-    
-    return util.FilePath(fullScriptPath)
-}
+func (b *BuffSpec) GetScriptPath() string
 ```
 
 ### Display and Visibility
 ```go
 // Get visible name and description (handles secret buffs)
-func (b *BuffSpec) VisibleNameDesc() (name, description string) {
-    if b.Secret {
-        return "Mysterious Affliction", "Unknown"
-    }
-    return b.Name, b.Description
-}
+func (b *BuffSpec) VisibleNameDesc() (name, description string)
 
 // Get buff display name
-func (bs *Buff) Name() string {
-    if sp := GetBuffSpec(bs.BuffId); sp != nil {
-        return sp.Name
-    }
-    return ""
-}
+func (bs *Buff) Name() string
 ```
 
 ## Data Management and Search
@@ -573,55 +261,19 @@ func (bs *Buff) Name() string {
 ### Buff Discovery
 ```go
 // Search buffs by name or description
-func SearchBuffs(searchTerm string) []int {
-    searchTerm = strings.TrimSpace(strings.ToLower(searchTerm))
-    results := make([]int, 0, 2)
-    
-    for _, buff := range buffs {
-        if strings.Contains(strings.ToLower(buff.Name), searchTerm) ||
-           strings.Contains(strings.ToLower(buff.Description), searchTerm) {
-            results = append(results, buff.BuffId)
-        }
-    }
-    
-    return results
-}
+func SearchBuffs(searchTerm string) []int
 
 // Get all available buff IDs
-func GetAllBuffIds() []int {
-    results := make([]int, 0, len(buffs))
-    for _, buff := range buffs {
-        results = append(results, buff.BuffId)
-    }
-    return results
-}
+func GetAllBuffIds() []int
 ```
 
 ### File Management
 ```go
 // Generate filename for buff specification
-func (b *BuffSpec) Filename() string {
-    filename := util.ConvertForFilename(b.Name)
-    return fmt.Sprintf("%d-%s.yaml", b.BuffId, filename)
-}
+func (b *BuffSpec) Filename() string
 
 // Load all buff specifications from files
-func LoadDataFiles() {
-    start := time.Now()
-    
-    tmpBuffs, err := fileloader.LoadAllFlatFiles[int, *BuffSpec](
-        string(configs.GetFilePathsConfig().DataFiles) + "/buffs"
-    )
-    if err != nil {
-        panic(err)
-    }
-    
-    buffs = tmpBuffs
-    
-    mudlog.Info("buffSpec.LoadDataFiles()", 
-        "loadedCount", len(buffs), 
-        "Time Taken", time.Since(start))
-}
+func LoadDataFiles()
 ```
 
 ## Integration Patterns

--- a/internal/characters/formattedname.go
+++ b/internal/characters/formattedname.go
@@ -24,8 +24,8 @@ var (
 		`hidden`:   {`hidden`, `?`, `gray`},      // Are they hiding?
 		`lit`:      {`☀️Lit`, `☀️`, `lit`},       // Does light come from this character?
 		`sleeping`: {`asleep`, `zZz`, `gray`},    // Are they hiding?
-		`zombie`:   {`zOmBie`, `z`, `zombie`},    // Have they disconnected and are zombie status?
-		`poisoned`: {`☠poisoned`, `☠`, `purple`}, // Have they disconnected and are zombie status?
+		`zombie`:   {`zOmBie`, `z`, `zombie`},    // Have they disconnected and/or zombie status?
+		`poisoned`: {`☠poisoned`, `☠`, `purple`}, // Have they disconnected and/or zombie status?
 		`shop`:     {`shop`, `$`, `gold`},        // Do they sell stuff?
 	}
 

--- a/internal/combat/context.md
+++ b/internal/combat/context.md
@@ -94,214 +94,48 @@ const (
 ### Player vs Mob Combat
 ```go
 // Main combat function for player attacking mob
-func AttackPlayerVsMob(user *users.UserRecord, mob *mobs.Mob) AttackResult {
-    attackResult := calculateCombat(*user.Character, mob.Character, User, Mob)
-    
-    // Apply damage to attacker if any
-    if attackResult.DamageToSource != 0 {
-        user.Character.ApplyHealthChange(attackResult.DamageToSource * -1)
-        user.WimpyCheck() // Check if player should flee
-    }
-    
-    // Apply damage to target
-    mob.Character.ApplyHealthChange(attackResult.DamageToTarget * -1)
-    
-    // Track damage for loot distribution
-    mob.Character.TrackPlayerDamage(user.UserId, attackResult.DamageToTarget)
-    
-    // Play appropriate sound effects
-    if attackResult.Hit {
-        user.PlaySound("hit-other", "combat")
-    } else {
-        user.PlaySound("miss", "combat")
-    }
-    
-    return attackResult
-}
+func AttackPlayerVsMob(user *users.UserRecord, mob *mobs.Mob) AttackResult
 ```
 
 ### Player vs Player Combat
 ```go
 // PvP combat with alignment consequences
-func AttackPlayerVsPlayer(userAtk *users.UserRecord, userDef *users.UserRecord) AttackResult {
-    attackResult := calculateCombat(*userAtk.Character, *userDef.Character, User, User)
-    
-    // Apply damage to both participants
-    if attackResult.DamageToSource != 0 {
-        userAtk.Character.ApplyHealthChange(attackResult.DamageToSource * -1)
-        userAtk.WimpyCheck()
-    }
-    
-    if attackResult.DamageToTarget != 0 {
-        userDef.Character.ApplyHealthChange(attackResult.DamageToTarget * -1)
-        userDef.WimpyCheck()
-    }
-    
-    // Play sound effects for both players
-    if attackResult.Hit {
-        userAtk.PlaySound("hit-other", "combat")
-        userDef.PlaySound("hit-self", "combat")
-    } else {
-        userAtk.PlaySound("miss", "combat")
-    }
-    
-    return attackResult
-}
+func AttackPlayerVsPlayer(userAtk *users.UserRecord, userDef *users.UserRecord) AttackResult
 ```
 
 ### Mob vs Player Combat
 ```go
 // NPC attacking player with AI integration
-func AttackMobVsPlayer(mob *mobs.Mob, user *users.UserRecord) AttackResult {
-    attackResult := calculateCombat(mob.Character, *user.Character, Mob, User)
-    
-    // Apply damage to mob (rare, usually from weapon effects)
-    mob.Character.ApplyHealthChange(attackResult.DamageToSource * -1)
-    
-    // Apply damage to player
-    if attackResult.DamageToTarget != 0 {
-        user.Character.ApplyHealthChange(attackResult.DamageToTarget * -1)
-        user.WimpyCheck()
-    }
-    
-    // Player hears when they're hit
-    if attackResult.Hit {
-        user.PlaySound("hit-self", "combat")
-    }
-    
-    return attackResult
-}
+func AttackMobVsPlayer(mob *mobs.Mob, user *users.UserRecord) AttackResult
 ```
 
 ### Mob vs Mob Combat
 ```go
 // NPC vs NPC combat with charm attribution
-func AttackMobVsMob(mobAtk *mobs.Mob, mobDef *mobs.Mob) AttackResult {
-    attackResult := calculateCombat(mobAtk.Character, mobDef.Character, Mob, User)
-    
-    // Apply damage to both mobs
-    mobAtk.Character.ApplyHealthChange(attackResult.DamageToSource * -1)
-    mobDef.Character.ApplyHealthChange(attackResult.DamageToTarget * -1)
-    
-    // If attacking mob is charmed, attribute damage to controlling player
-    if charmedUserId := mobAtk.Character.GetCharmedUserId(); charmedUserId > 0 {
-        mobDef.Character.TrackPlayerDamage(charmedUserId, attackResult.DamageToTarget)
-    }
-    
-    return attackResult
-}
+func AttackMobVsMob(mobAtk *mobs.Mob, mobDef *mobs.Mob) AttackResult
 ```
 
 ## Combat Calculation Engine
 
 ### Main Combat Resolution
 ```go
-func calculateCombat(sourceChar characters.Character, targetChar characters.Character, 
-                    sourceType SourceTarget, targetType SourceTarget) AttackResult {
-    
-    attackResult := AttackResult{}
-    
-    // Calculate number of attacks based on speed differential
-    attackCount := int(math.Ceil(float64(sourceChar.Stats.Speed.ValueAdj-targetChar.Stats.Speed.ValueAdj) / 25))
-    if attackCount < 1 {
-        attackCount = 1
-    }
-    
-    // Add stat modification bonuses
-    statModDBonus := sourceChar.StatMod("damage")
-    attackCount += sourceChar.StatMod("attacks")
-    
-    // Process each attack
-    for i := 0; i < attackCount; i++ {
-        // Determine weapons to use
-        attackWeapons := getAttackWeapons(sourceChar)
-        
-        // Handle backstab mechanics
-        if sourceChar.Aggro.Type == characters.BackStab {
-            attackResult.Crit = true
-            attackMessagePrefix = "<ansi fg=\"magenta-bold\">*[BACKSTAB]*</ansi> "
-            sourceChar.SetAggro(sourceChar.Aggro.UserId, sourceChar.Aggro.MobInstanceId, characters.DefaultAttack)
-        }
-        
-        // Process each weapon attack
-        for _, weapon := range attackWeapons {
-            processWeaponAttack(weapon, &attackResult, sourceChar, targetChar, sourceType, targetType)
-        }
-        
-        // Pet participation (20% chance)
-        if util.RollDice(1, 5) == 1 && sourceChar.Pet.Exists() {
-            processPetAttack(sourceChar, targetChar, &attackResult, sourceType, targetType)
-        }
-    }
-    
-    return attackResult
-}
+func calculateCombat(sourceChar characters.Character, targetChar characters.Character,
+                    sourceType SourceTarget, targetType SourceTarget) AttackResult
 ```
 
 ### Hit Calculation System
 ```go
 // Calculate hit chance based on speed statistics
-func hitChance(attackSpd, defendSpd int) int {
-    atkPlusDef := float64(attackSpd + defendSpd)
-    if atkPlusDef < 1 {
-        atkPlusDef = 1
-    }
-    return 30 + int(float64(attackSpd)/atkPlusDef*70) // 30-100% base hit chance
-}
+func hitChance(attackSpd, defendSpd int) int
 
 // Determine if attack hits with modifiers
-func Hits(attackSpd, defendSpd, hitModifier int) bool {
-    toHit := hitChance(attackSpd, defendSpd)
-    if hitModifier != 0 {
-        toHit += hitModifier
-    }
-    
-    // Clamp hit chance between 5% and 95%
-    if toHit < 5 {
-        toHit = 5
-    }
-    if toHit > 95 {
-        toHit = 95
-    }
-    
-    hitRoll := util.Rand(100)
-    util.LogRoll("Hits", hitRoll, toHit)
-    
-    return hitRoll < toHit
-}
+func Hits(attackSpd, defendSpd, hitModifier int) bool
 ```
 
 ### Critical Hit System
 ```go
 // Calculate critical hit probability
-func Crits(sourceChar characters.Character, targetChar characters.Character) bool {
-    levelDiff := sourceChar.Level - targetChar.Level
-    if levelDiff < 1 {
-        levelDiff = 1
-    }
-    
-    // Base crit chance: 5% + (strength + speed) / level difference
-    critChance := 5 + int(math.Round(float64(sourceChar.Stats.Strength.ValueAdj+sourceChar.Stats.Speed.ValueAdj)/float64(levelDiff)))
-    
-    // Buff modifications
-    if sourceChar.HasBuffFlag(buffs.Accuracy) {
-        critChance *= 2 // Double crit chance with Accuracy buff
-    }
-    
-    if targetChar.HasBuffFlag(buffs.Blink) {
-        critChance /= 2 // Half crit chance against Blink buff
-    }
-    
-    // Minimum 5% crit chance
-    if critChance < 5 {
-        critChance = 5
-    }
-    
-    critRoll := util.Rand(100)
-    util.LogRoll("Crits", critRoll, critChance)
-    
-    return critRoll < critChance
-}
+func Crits(sourceChar characters.Character, targetChar characters.Character) bool
 ```
 
 ## Dual Wielding System
@@ -309,67 +143,10 @@ func Crits(sourceChar characters.Character, targetChar characters.Character) boo
 ### Weapon Selection and Penalties
 ```go
 // Determine weapons available for attack
-func getAttackWeapons(sourceChar characters.Character) []items.Item {
-    attackWeapons := []items.Item{}
-    dualWieldLevel := sourceChar.GetSkillLevel(skills.DualWield)
-    
-    // Add primary weapon
-    if sourceChar.Equipment.Weapon.ItemId > 0 {
-        attackWeapons = append(attackWeapons, sourceChar.Equipment.Weapon)
-    }
-    
-    // Add offhand weapon if it's a weapon type
-    if sourceChar.Equipment.Offhand.ItemId > 0 && 
-       sourceChar.Equipment.Offhand.GetSpec().Type == items.Weapon {
-        attackWeapons = append(attackWeapons, sourceChar.Equipment.Offhand)
-    }
-    
-    // Default to unarmed if no weapons
-    if len(attackWeapons) == 0 {
-        attackWeapons = append(attackWeapons, items.Item{ItemId: 0})
-    }
-    
-    // Apply dual wield skill restrictions
-    if len(attackWeapons) > 1 {
-        maxWeapons := 1
-        
-        if dualWieldLevel == 2 {
-            // 50% chance to use both weapons at level 2
-            if util.Rand(100) < 50 {
-                maxWeapons = 2
-            }
-        } else if dualWieldLevel >= 3 {
-            maxWeapons = 2 // Always dual wield at level 3+
-        }
-        
-        // Special case: martial weapons (claws) can always dual wield
-        if sourceChar.Equipment.Weapon.GetSpec().Subtype == items.Claws && 
-           sourceChar.Equipment.Offhand.GetSpec().Subtype == items.Claws {
-            maxWeapons = 2
-        }
-        
-        // Remove excess weapons randomly
-        for len(attackWeapons) > maxWeapons {
-            rnd := util.Rand(len(attackWeapons))
-            attackWeapons = append(attackWeapons[:rnd], attackWeapons[rnd+1:]...)
-        }
-    }
-    
-    return attackWeapons
-}
+func getAttackWeapons(sourceChar characters.Character) []items.Item
 
 // Calculate dual wield penalty
-func getDualWieldPenalty(weaponCount int, dualWieldLevel int) int {
-    penalty := 0
-    if weaponCount > 1 {
-        if dualWieldLevel < 4 {
-            penalty = 35 // 35% penalty to hit
-        } else {
-            penalty = 25 // 25% penalty to hit at mastery level
-        }
-    }
-    return penalty
-}
+func getDualWieldPenalty(weaponCount int, dualWieldLevel int) int
 ```
 
 ## Combat Messaging System
@@ -377,81 +154,20 @@ func getDualWieldPenalty(weaponCount int, dualWieldLevel int) int {
 ### Message Token System
 ```go
 // Token replacement for dynamic combat messages
-func buildTokenReplacements(sourceChar, targetChar characters.Character, 
-                          sourceType, targetType SourceTarget, 
-                          weaponName string, damage int) map[items.TokenName]string {
-    
-    tokenReplacements := map[items.TokenName]string{
-        items.TokenItemName:     weaponName,
-        items.TokenSource:       sourceChar.Name,
-        items.TokenSourceType:   string(sourceType) + "name",
-        items.TokenTarget:       targetChar.Name,
-        items.TokenTargetType:   string(targetType) + "name",
-        items.TokenDamage:       strconv.Itoa(damage),
-        items.TokenEntranceName: "unknown",
-        items.TokenExitName:     "unknown",
-    }
-    
-    // Use mob display names for NPCs
-    if sourceType == Mob {
-        tokenReplacements[items.TokenSource] = sourceChar.GetMobName(0).String()
-    }
-    
-    if targetType == Mob {
-        tokenReplacements[items.TokenTarget] = targetChar.GetMobName(0).String()
-    }
-    
-    return tokenReplacements
-}
+func buildTokenReplacements(sourceChar, targetChar characters.Character,
+                          sourceType, targetType SourceTarget,
+                          weaponName string, damage int) map[items.TokenName]string
 ```
 
 ### Cross-Room Combat Messaging
 ```go
 // Handle messaging for cross-room combat
-func handleCrossRoomMessages(sourceChar, targetChar characters.Character, 
-                           attackResult *AttackResult, msgs items.AttackMessages) {
-    
-    if sourceChar.RoomId == targetChar.RoomId {
-        // Same room combat
-        attackResult.SendToSource(string(msgs.Together.ToAttacker))
-        attackResult.SendToTarget(string(msgs.Together.ToDefender))
-        attackResult.SendToSourceRoom(string(msgs.Together.ToRoom))
-    } else {
-        // Cross-room combat with directional information
-        attackResult.SendToSource(string(msgs.Separate.ToAttacker))
-        attackResult.SendToTarget(string(msgs.Separate.ToDefender))
-        attackResult.SendToSourceRoom(string(msgs.Separate.ToAttackerRoom))
-        attackResult.SendToTargetRoom(string(msgs.Separate.ToDefenderRoom))
-        
-        // Add directional information
-        addDirectionalTokens(sourceChar, targetChar, tokenReplacements)
-    }
-}
+func handleCrossRoomMessages(sourceChar, targetChar characters.Character,
+                           attackResult *AttackResult, msgs items.AttackMessages)
 
 // Add exit/entrance direction tokens for cross-room combat
-func addDirectionalTokens(sourceChar, targetChar characters.Character, 
-                         tokens map[items.TokenName]string) {
-    
-    // Find exit from source to target
-    if atkRoom := rooms.LoadRoom(sourceChar.RoomId); atkRoom != nil {
-        for exitName, exit := range atkRoom.Exits {
-            if exit.RoomId == targetChar.RoomId {
-                tokens[items.TokenExitName] = exitName
-                break
-            }
-        }
-    }
-    
-    // Find entrance from target to source
-    if defRoom := rooms.LoadRoom(targetChar.RoomId); defRoom != nil {
-        for exitName, exit := range defRoom.Exits {
-            if exit.RoomId == sourceChar.RoomId {
-                tokens[items.TokenEntranceName] = exitName
-                break
-            }
-        }
-    }
-}
+func addDirectionalTokens(sourceChar, targetChar characters.Character,
+                         tokens map[items.TokenName]string)
 ```
 
 ## Combat Calculations and Utilities
@@ -477,120 +193,13 @@ func CombatOdds(atkChar characters.Character, defChar characters.Character) floa
 ### Taming Mechanics
 ```go
 // Calculate chance to tame a mob
-func ChanceToTame(s *users.UserRecord, t *mobs.Mob) int {
-    const (
-        MOD_SKILL_MIN    = 1    // Minimum base tame ability
-        MOD_SKILL_MAX    = 100  // Maximum base tame ability
-        MOD_SIZE_SMALL   = 0    // Modifier for small creatures
-        MOD_SIZE_MEDIUM  = -10  // Modifier for medium creatures
-        MOD_SIZE_LARGE   = -25  // Modifier for large creatures
-        MOD_LEVELDIFF_MIN = -25 // Lowest level delta modifier
-        MOD_LEVELDIFF_MAX = 25  // Highest level delta modifier
-        MOD_HEALTHPERCENT_MAX = 50.0 // Max bonus for reduced target HP
-        FACTOR_IS_AGGRO  = 0.50 // Reduction if target is aggressive
-    )
-    
-    // Base proficiency with this mob type
-    proficiencyModifier := s.Character.MobMastery.GetTame(int(t.MobId))
-    proficiencyModifier = clamp(proficiencyModifier, MOD_SKILL_MIN, MOD_SKILL_MAX)
-    
-    // Size-based difficulty
-    raceInfo := races.GetRace(s.Character.RaceId)
-    sizeModifier := 0
-    switch raceInfo.Size {
-    case races.Large:
-        sizeModifier = MOD_SIZE_LARGE
-    case races.Small:
-        sizeModifier = MOD_SIZE_SMALL
-    default: // Medium
-        sizeModifier = MOD_SIZE_MEDIUM
-    }
-    
-    // Level difference bonus/penalty
-    levelDiff := s.Character.Level - t.Character.Level
-    levelDiff = clamp(levelDiff, MOD_LEVELDIFF_MIN, MOD_LEVELDIFF_MAX)
-    
-    // Health-based bonus (lower health = easier to tame)
-    healthModifier := MOD_HEALTHPERCENT_MAX - 
-        math.Ceil(float64(s.Character.Health)/float64(s.Character.HealthMax.Value)*MOD_HEALTHPERCENT_MAX)
-    
-    // Aggro penalty
-    aggroModifier := 1.0
-    if t.Character.IsAggro(s.UserId, 0) {
-        aggroModifier = FACTOR_IS_AGGRO
-    }
-    
-    // Calculate final tame chance
-    baseChance := float64(proficiencyModifier) + float64(levelDiff) + healthModifier + float64(sizeModifier)
-    return int(math.Ceil(baseChance * aggroModifier))
-}
+func ChanceToTame(s *users.UserRecord, t *mobs.Mob) int
 ```
 
 ### Alignment Change System
 ```go
 // Calculate alignment change from PvP combat
-func AlignmentChange(killerAlignment int8, killedAlignment int8) int {
-    isKillerGood := killerAlignment > characters.AlignmentNeutralHigh
-    isKillerEvil := killerAlignment < characters.AlignmentNeutralLow
-    isKillerNeutral := killerAlignment >= characters.AlignmentNeutralLow && 
-                       killerAlignment <= characters.AlignmentNeutralHigh
-    
-    isKilledGood := killedAlignment > characters.AlignmentNeutralHigh
-    isKilledEvil := killedAlignment < characters.AlignmentNeutralLow
-    isKilledNeutral := killedAlignment >= characters.AlignmentNeutralLow && 
-                       killedAlignment <= characters.AlignmentNeutralHigh
-    
-    // Calculate alignment delta (0-100 scale)
-    deltaAbs := math.Abs(math.Max(float64(killerAlignment), float64(killedAlignment)) - 
-                        math.Min(float64(killerAlignment), float64(killedAlignment))) * 0.5
-    
-    // Determine change magnitude based on alignment difference
-    changeAmt := 0
-    if deltaAbs <= 10 {
-        changeAmt = 0
-    } else if deltaAbs <= 30 {
-        changeAmt = 1
-    } else if deltaAbs <= 60 {
-        changeAmt = 2
-    } else if deltaAbs <= 80 {
-        changeAmt = 3
-    } else {
-        changeAmt = 4
-    }
-    
-    // Calculate direction factor
-    factor := 0
-    
-    if isKillerGood {
-        if isKilledGood { // Good vs Good = especially evil
-            factor = -2
-            changeAmt = int(math.Max(float64(changeAmt), 1))
-        } else if isKilledEvil { // Good vs Evil = good act
-            factor = 1
-        } else if isKilledNeutral { // Good vs Neutral = evil act
-            factor = -1
-        }
-    } else if isKillerEvil {
-        if isKilledGood { // Evil vs Good = evil act
-            factor = -1
-        } else if isKilledEvil { // Evil vs Evil = especially good
-            factor = 2
-            changeAmt = int(math.Max(float64(changeAmt), 1))
-        } else if isKilledNeutral { // Evil vs Neutral = evil act
-            factor = -1
-        }
-    } else if isKillerNeutral {
-        if isKilledGood { // Neutral vs Good = evil act
-            factor = -1
-        } else if isKilledEvil { // Neutral vs Evil = good act
-            factor = 1
-        } else if isKilledNeutral { // Neutral vs Neutral = no change
-            factor = 0
-        }
-    }
-    
-    return factor * changeAmt
-}
+func AlignmentChange(killerAlignment int8, killedAlignment int8) int
 ```
 
 ## Pet Combat System
@@ -598,39 +207,8 @@ func AlignmentChange(killerAlignment int8, killedAlignment int8) int {
 ### Pet Participation
 ```go
 // Handle pet joining combat (20% chance per round)
-func processPetAttack(sourceChar characters.Character, targetChar characters.Character, 
-                     attackResult *AttackResult, sourceType, targetType SourceTarget) {
-    
-    if sourceChar.RoomId != targetChar.RoomId {
-        return // Pets only fight in same room
-    }
-    
-    if !sourceChar.Pet.Exists() || sourceChar.Pet.Damage.DiceRoll == "" {
-        return // No pet or pet has no combat ability
-    }
-    
-    attacks, dCount, dSides, dBonus, _ := sourceChar.Pet.GetDiceRoll()
-    
-    for i := 0; i < attacks; i++ {
-        attackTargetDamage := util.RollDice(dCount, dSides) + dBonus
-        attackResult.DamageToTarget += attackTargetDamage
-        
-        // Send pet attack messages
-        petName := sourceChar.Pet.DisplayName()
-        
-        toAttackerMsg := fmt.Sprintf("%s jumps into the fray and deals <ansi fg=\"damage\">%d damage</ansi> to <ansi fg=\"%sname\">%s</ansi>!", 
-                                   petName, attackTargetDamage, string(targetType), targetChar.Name)
-        attackResult.SendToSource(toAttackerMsg)
-        
-        toDefenderMsg := fmt.Sprintf("%s jumps into the fray and deals <ansi fg=\"damage\">%d damage</ansi> to you!", 
-                                   petName, attackTargetDamage)
-        attackResult.SendToTarget(toDefenderMsg)
-        
-        toRoomMsg := fmt.Sprintf("%s jumps into the fray and deals <ansi fg=\"damage\">%d damage</ansi> to <ansi fg=\"%sname\">%s</ansi>!", 
-                               petName, attackTargetDamage, string(targetType), targetChar.Name)
-        attackResult.SendToTargetRoom(toRoomMsg)
-    }
-}
+func processPetAttack(sourceChar characters.Character, targetChar characters.Character,
+                     attackResult *AttackResult, sourceType, targetType SourceTarget)
 ```
 
 ## Integration Patterns

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -12,7 +12,7 @@ type Network struct {
 	AfkSeconds           ConfigInt         `yaml:"AfkSeconds"`           // How long until a player is marked as afk?
 	MaxIdleSeconds       ConfigInt         `yaml:"MaxIdleSeconds"`       // How many seconds a player can go without a command in game before being kicked.
 	TimeoutMods          ConfigBool        `yaml:"TimeoutMods"`          // Whether to kick admin/mods when idle too long.
-	ZombieSeconds        ConfigInt         `yaml:"ZombieSeconds"`        // How many seconds a player will be a zombie allowing them to reconnect.
+	LinkDeadSeconds      ConfigInt         `yaml:"LinkDeadSeconds"`      // How many seconds a player will be link-dead allowing them to reconnect.
 	LogoutRounds         ConfigInt         `yaml:"LogoutRounds"`         // How many rounds of uninterrupted meditation must be completed to log out.
 }
 
@@ -50,8 +50,8 @@ func (n *Network) Validate() {
 		n.MaxIdleSeconds = 0
 	}
 
-	if n.ZombieSeconds < 0 {
-		n.ZombieSeconds = 0
+	if n.LinkDeadSeconds < 0 {
+		n.LinkDeadSeconds = 0
 	}
 
 	if n.LogoutRounds < 0 {

--- a/internal/configs/context.md
+++ b/internal/configs/context.md
@@ -11,7 +11,7 @@ The configuration system is built around a centralized `Config` struct with seve
 ### Core Components
 
 **Configuration Structure:**
-- Hierarchical configuration organized into logical subsections (Server, Network, GamePlay, etc.)
+- Hierarchical configuration organized into logical subsections
 - Type-safe configuration values using custom types (`ConfigString`, `ConfigInt`, `ConfigBool`, etc.)
 - Automatic validation and default value enforcement
 - Thread-safe access with read-write mutex protection
@@ -19,435 +19,270 @@ The configuration system is built around a centralized `Config` struct with seve
 **Override System:**
 - Runtime configuration overrides stored separately from base configuration
 - Dot-notation path support for nested configuration access
-- Persistent override storage in YAML format
+- Persistent override storage in YAML format (path: `{DataFiles}/config-overrides.yaml` or `$CONFIG_PATH`)
 - Automatic path correction and fuzzy matching for configuration keys
 
 **Type System:**
 - Custom configuration types with string conversion and validation
-- Special `ConfigSecret` type that redacts sensitive values in output
-- Automatic type inference and conversion from string values
+- Special `ConfigSecret` type that redacts sensitive values in output (`*** REDACTED ***`)
+- Automatic type inference and conversion from string values via `StringToConfigValue`
 - Support for complex types including slices and nested structures
 
 **Validation Framework:**
-- Per-subsection validation with range checking and defaults
+- Per-subsection `Validate()` methods with range checking and defaults
 - Locked configuration properties that cannot be changed at runtime
 - Banned name patterns for user input validation
 - Environment variable integration with automatic assignment
 
-## Key Features
+## Config Struct
 
-### 1. **Type-Safe Configuration**
-- Custom configuration types prevent type errors and provide consistent interfaces
-- Automatic validation and range checking for all configuration values
-- Support for integers, floats, booleans, strings, slices, and secret values
-- Type inference from string input for dynamic configuration updates
-
-### 2. **Hierarchical Structure**
-- Logical organization into subsections (Server, Network, GamePlay, FilePaths, etc.)
-- Dot-notation access for nested configuration properties
-- Automatic path resolution and correction for typos or partial matches
-- Flattening and unflattening of nested structures for override management
-
-### 3. **Runtime Configuration Management**
-- Live configuration updates without server restart
-- Persistent override storage separate from base configuration
-- Thread-safe configuration access with mutex protection
-- Configuration change validation and rollback on errors
-
-### 4. **Security Features**
-- `ConfigSecret` type automatically redacts sensitive values in logs and output
-- Environment variable support for secure credential injection
-- Locked configuration properties to prevent unauthorized changes
-- Validation of user input against banned patterns
-
-### 5. **Override System**
-- Dot-notation configuration overrides (e.g., `Server.MaxCPUCores`)
-- Persistent storage of overrides in separate YAML file
-- Automatic path correction and fuzzy matching
-- Override precedence over base configuration values
+```go
+type Config struct {
+    Server       Server
+    Memory       Memory
+    LootGoblin   LootGoblin
+    Timing       Timing
+    FilePaths    FilePaths
+    GamePlay     GamePlay
+    Integrations Integrations
+    TextFormats  TextFormats
+    Translation  Translation
+    Network      Network
+    Scripting    Scripting
+    SpecialRooms SpecialRooms
+    Validation   Validation
+    Roles        Roles
+    Modules      Modules
+}
+```
 
 ## Configuration Subsections
 
 ### Server Configuration
-```yaml
-Server:
-  MudName: "My MUD Server"
-  CurrentVersion: "1.0.0"
-  Seed: "random-seed-value"        # ConfigSecret type
-  MaxCPUCores: 4
-  OnLoginCommands: ["look", "who"]
-  Motd: "Welcome to the game!"
-  NextRoomId: 1000
-  Locked: ["Seed"]                 # Locked properties
+```go
+type Server struct {
+    MudName         ConfigString      // Name of the MUD
+    CurrentVersion  ConfigString      // Current version string
+    Seed            ConfigSecret      // Seed for content generation (redacted in output)
+    MaxCPUCores     ConfigInt         // CPU cores for multi-core operations
+    OnLoginCommands ConfigSliceString // Commands run on user login
+    Motd            ConfigString      // Message of the day
+    NextRoomId      ConfigInt         // Next room ID for room creation
+    Locked          ConfigSliceString // Config properties locked from runtime changes
+}
 ```
 
 ### Network Configuration
-```yaml
-Network:
-  MaxTelnetConnections: 50
-  TelnetPort: ["4000", "4001"]
-  LocalPort: 4002
-  HttpPort: 80
-  HttpsPort: 443
-  HttpsRedirect: true
-  AfkSeconds: 300
-  MaxIdleSeconds: 1800
-  TimeoutMods: false
-  ZombieSeconds: 60
-  LogoutRounds: 10
+```go
+type Network struct {
+    MaxTelnetConnections ConfigInt         // Max telnet connections (default 50)
+    TelnetPort           ConfigSliceString // One or more telnet ports
+    LocalPort            ConfigInt         // Localhost-only admin port
+    HttpPort             ConfigInt         // HTTP port (0 to disable)
+    HttpsPort            ConfigInt         // HTTPS port (0 to disable)
+    HttpsRedirect        ConfigBool        // Redirect HTTP to HTTPS
+    SSHPort              ConfigInt         // SSH port (0 to disable)
+    MaxSSHConnections    ConfigInt         // Max SSH connections (default 50)
+    AfkSeconds           ConfigInt         // Seconds until AFK
+    MaxIdleSeconds       ConfigInt         // Seconds before idle kick
+    TimeoutMods          ConfigBool        // Whether to timeout admins/mods
+    LinkDeadSeconds      ConfigInt         // Link-dead reconnect window
+    LogoutRounds         ConfigInt         // Rounds of meditation required to log out
+}
 ```
 
 ### GamePlay Configuration
-```yaml
-GamePlay:
-  AllowItemBuffRemoval: true
-  Death:
-    PermaDeath: false
-    CorpseDecayRounds: 100
-  LivesStart: 3
-  LivesMax: 10
-  LivesOnLevelUp: 1
-  PricePerLife: 1000
-  ShopRestockRate: "1h"
-  ContainerSizeMax: 50
-  MaxAltCharacters: 5
-  ConsistentAttackMessages: true
-  PVP: "limited"                   # enabled, disabled, limited, off
-  PVPMinimumLevel: 10
-  XPScale: 100.0
-  MobConverseChance: 25
+```go
+type GamePlay struct {
+    AllowItemBuffRemoval     ConfigBool
+    Death                    GameplayDeath
+    Party                    GameplayParty
+    LivesStart               ConfigInt    // Starting permadeath lives
+    LivesMax                 ConfigInt    // Maximum permadeath lives
+    LivesOnLevelUp           ConfigInt    // Lives gained on level up
+    PricePerLife             ConfigInt    // Gold cost to buy a life
+    ShopRestockRate          ConfigString // Default shop restock duration (e.g. "6 hours")
+    ContainerSizeMax         ConfigInt    // Max items in a container
+    MaxAltCharacters         ConfigInt    // Max alt characters per account
+    ConsistentAttackMessages ConfigBool
+    PVP                      ConfigString // "enabled", "disabled", "limited"
+    PVPMinimumLevel          ConfigInt
+    XPScale                  ConfigFloat  // XP difficulty multiplier (default 100)
+    MobConverseChance        ConfigInt    // 0-100 chance of mob conversing when idle
+}
+
+type GameplayDeath struct {
+    EquipmentDropChance ConfigFloat  // 0.0-1.0 chance to drop equipment on death
+    AlwaysDropBackpack  ConfigBool
+    XPPenalty           ConfigString // "none", "level", "10%", "25%", etc.
+    ProtectionLevels    ConfigInt    // Levels protected from death penalties
+    PermaDeath          ConfigBool
+    CorpsesEnabled      ConfigBool
+    CorpseDecayTime     ConfigString // Duration string (e.g. "1 hour")
+}
+
+type GameplayParty struct {
+    MaxPlayerCount ConfigInt  // 0 = unlimited
+    SameRoomOnly   ConfigBool
+}
 ```
 
 ### File Paths Configuration
-```yaml
-FilePaths:
-  DataFiles: "_datafiles"
-  PublicHtml: "_datafiles/html/public"
-  AdminHtml: "_datafiles/html/admin"
-  HttpsCertFile: "cert.pem"
-  HttpsKeyFile: "key.pem"
-  WebCDNLocation: "/static"
-  CarefulSaveFiles: true
+```go
+type FilePaths struct {
+    WebDomain        ConfigString // Web domain name
+    WebCDNLocation   ConfigString // Optional CDN for static files
+    DataFiles        ConfigString // Path to data files (default "_datafiles/world/default")
+    PublicHtml       ConfigString // Public HTML directory
+    AdminHtml        ConfigString // Admin HTML directory
+    HttpsCertFile    ConfigString // TLS certificate path
+    HttpsKeyFile     ConfigString // TLS private key path
+    SSHHostKeyFile   ConfigString // SSH host private key (required for SSH)
+    CarefulSaveFiles ConfigBool   // Write to .new file then rename
+}
+```
+
+### Timing Configuration
+```go
+type Timing struct {
+    TurnMs            ConfigInt // Milliseconds per turn (default 100, min 10)
+    RoundSeconds      ConfigInt // Seconds per round (default 4)
+    RoundsPerAutoSave ConfigInt // Rounds between auto-saves (default 900)
+    RoundsPerDay      ConfigInt // Rounds per in-game day (default 20)
+    NightHours        ConfigInt // Hours of night (0-24)
+}
+
+// Helper methods (calculated and cached on Validate):
+func (e Timing) TurnsPerRound() int
+func (e Timing) TurnsPerAutoSave() int
+func (e Timing) TurnsPerSecond() int
+func (e Timing) SecondsToRounds(seconds int) int
+func (e Timing) SecondsToTurns(seconds int) int
+func (e Timing) MinutesToRounds(minutes int) int
+func (e Timing) MinutesToTurns(minutes int) int
+func (e Timing) RoundsToSeconds(rounds int) int
+```
+
+### Validation Configuration
+```go
+type Validation struct {
+    NameSizeMin      ConfigInt         // Min name length
+    NameSizeMax      ConfigInt         // Max name length (max 80)
+    PasswordSizeMin  ConfigInt         // Min password length
+    PasswordSizeMax  ConfigInt         // Max password length
+    NameRejectRegex  ConfigString      // Regex names must match
+    NameRejectReason ConfigString      // Reason shown when name rejected
+    EmailOnJoin      ConfigString      // "required", "optional", or "none"
+    BannedNames      ConfigSliceString // Wildcard patterns for banned names
+}
 ```
 
 ## Configuration Types
 
-### Basic Types
 ```go
-type ConfigInt int           // Integer values with validation
-type ConfigUInt64 uint64     // Unsigned 64-bit integers
-type ConfigString string     // String values
-type ConfigSecret string     // Automatically redacted strings
-type ConfigFloat float64     // Floating-point values
-type ConfigBool bool         // Boolean values
-type ConfigSliceString []string  // String arrays
-```
+type ConfigInt         int
+type ConfigUInt64      uint64
+type ConfigString      string
+type ConfigSecret      string     // String() returns "*** REDACTED ***"
+type ConfigFloat       float64
+type ConfigBool        bool
+type ConfigSliceString []string
 
-### Type Interface
-```go
 type ConfigValue interface {
-    String() string    // String representation
-    Set(string) error  // Set value from string
+    String() string
+    Set(string) error
 }
 ```
 
-### Secret Type Behavior
-```go
-// ConfigSecret automatically redacts in output
-func (c ConfigSecret) String() string {
-    return `*** REDACTED ***`
-}
-
-// Access actual value through helper function
-func GetSecret(v ConfigSecret) string {
-    return string(v)
-}
-```
+`ConfigSecret` hides its value in all string representations. Use `configs.GetSecret(v ConfigSecret) string` to access the raw value.
 
 ## Configuration Access Patterns
 
 ### Reading Configuration
 ```go
-// Get complete configuration
 config := configs.GetConfig()
-
-// Access subsections
-serverConfig := configs.GetServerConfig()
+serverConfig  := configs.GetServerConfig()
 networkConfig := configs.GetNetworkConfig()
 gameplayConfig := configs.GetGamePlayConfig()
-
-// Access specific values
-mudName := config.Server.MudName.String()
-maxConnections := int(config.Network.MaxTelnetConnections)
-pvpEnabled := config.GamePlay.PVP.String() == "enabled"
+timingConfig  := configs.GetTimingConfig()
+filePathsConfig := configs.GetFilePathsConfig()
+validationConfig := configs.GetValidationConfig()
+rolesConfig   := configs.GetRolesConfig()
 ```
 
 ### Setting Configuration Values
 ```go
-// Set configuration value by dot path
-err := configs.SetVal("Server.MudName", "New Server Name")
+// Set by dot-path; validates, persists to override file, and reloads
+err := configs.SetVal("Server.MudName", "New Name")
 err := configs.SetVal("Network.HttpPort", "8080")
 err := configs.SetVal("GamePlay.PVP", "enabled")
-
-// Configuration is automatically validated and saved
-if err != nil {
-    log.Printf("Configuration error: %v", err)
-}
 ```
 
-### Environment Variable Integration
+### Dot-Notation and Path Resolution
 ```go
-// Configuration fields can be populated from environment variables
-type Server struct {
-    DatabaseURL ConfigSecret `yaml:"DatabaseURL" env:"DATABASE_URL"`
-    APIKey      ConfigSecret `yaml:"APIKey" env:"API_KEY"`
-}
-
-// Values are automatically loaded from environment on startup
-```
-
-## Override System
-
-### Override File Format
-```yaml
-# config-overrides.yaml
-Server:
-  MudName: "Development Server"
-  MaxCPUCores: 8
-Network:
-  HttpPort: 8080
-  HttpsPort: 8443
-GamePlay:
-  PVP: "enabled"
-  XPScale: 150.0
-```
-
-### Dot-Notation Access
-```go
-// All configuration paths support dot notation
+// All config paths support dot notation
 allConfig := config.AllConfigData()
-// Returns map with keys like:
-// "Server.MudName" -> "My MUD Server"
-// "Network.HttpPort" -> 80
-// "GamePlay.PVP" -> "limited"
+// Returns map with keys like "Server.MudName", "Network.HttpPort", etc.
 
-// Set values using dot notation
-configs.SetVal("Server.MudName", "New Name")
-configs.SetVal("GamePlay.Death.PermaDeath", "true")
-```
-
-### Path Resolution and Correction
-```go
-// Automatic path correction for typos
+// Fuzzy path lookup (case-insensitive, partial match)
 fullPath, typeName := configs.FindFullPath("mudname")
 // Returns: "Server.MudName", "configs.ConfigString"
-
-fullPath, typeName := configs.FindFullPath("httpport")
-// Returns: "Network.HttpPort", "configs.ConfigInt"
-
-// Supports partial matches and case-insensitive lookup
 ```
+
+### Override System
+```go
+// Programmatically add overrides (e.g. from module config)
+err := configs.AddOverlayOverrides(map[string]any{
+    "Server.MudName": configs.ConfigString("Dev Server"),
+})
+
+// Get current overrides
+overrides := configs.GetOverrides()
+
+// Flatten/unflatten helpers
+flat := configs.Flatten(nestedMap)
+```
+
+### Reload Configuration
+```go
+err := configs.ReloadConfig()
+```
+
+Reads `_datafiles/config.yaml`, applies overrides from `{DataFiles}/config-overrides.yaml` (or `$CONFIG_PATH`), applies environment variables, and validates.
 
 ## Validation System
 
-### Per-Subsection Validation
-```go
-func (s *Server) Validate() {
-    if s.Seed == `` {
-        s.Seed = `Mud` // default value
-    }
-    
-    if s.MaxCPUCores < 0 {
-        s.MaxCPUCores = 0 // enforce minimum
-    }
-}
-
-func (n *Network) Validate() {
-    if n.MaxTelnetConnections < 1 {
-        n.MaxTelnetConnections = 50 // default
-    }
-    
-    if n.HttpPort < 0 {
-        n.HttpPort = 0 // disable if negative
-    }
-}
-```
+Each subsection has a `Validate()` method enforcing defaults and ranges. The top-level `Config.Validate()` calls all subsection validators and caches computed values (e.g. `seedInt`, timing calculations).
 
 ### Banned Name Validation
 ```go
-// Check if a name matches banned patterns
 bannedPattern, isBanned := config.IsBannedName("testname")
-if isBanned {
-    return fmt.Errorf("Name matches banned pattern: %s", bannedPattern)
-}
 ```
+Uses wildcard matching against `Validation.BannedNames`.
 
 ### Locked Configuration Properties
 ```go
-// Some properties cannot be changed at runtime
-func isEditAllowed(configPath string) bool {
-    serverConfig := configs.GetServerConfig()
-    for _, lockedPath := range serverConfig.Locked {
-        if configPath == lockedPath {
-            return false
-        }
-    }
-    return true
-}
+// Properties listed in Server.Locked cannot be changed via SetVal at runtime
+Server:
+  Locked: ["Seed"]
 ```
 
-## Configuration Loading and Persistence
-
-### Startup Process
-1. **Load Base Configuration**: Read `_datafiles/config.yaml`
-2. **Load Overrides**: Read `config-overrides.yaml` if it exists
-3. **Apply Environment Variables**: Set values from environment
-4. **Validate Configuration**: Run all validation functions
-5. **Build Lookup Tables**: Create path and type lookup maps
-
-### Runtime Updates
+## PVP Constants
 ```go
-// Configuration changes are immediately persisted
-err := configs.SetVal("Server.MudName", "New Name")
-// This automatically:
-// 1. Validates the new value
-// 2. Updates the override file
-// 3. Reloads the configuration
-// 4. Validates the complete configuration
-```
-
-### Configuration Reload
-```go
-// Reload configuration from files
-err := configs.ReloadConfig()
-if err != nil {
-    log.Printf("Failed to reload config: %v", err)
-}
-```
-
-## Integration Examples
-
-### User Command Integration
-```go
-// Server configuration command
-func server_Config(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
-    args := util.SplitButRespectQuotes(rest)
-    
-    if len(args) >= 2 {
-        configName := strings.ToLower(args[0])
-        configValue := strings.Join(args[1:], ` `)
-        
-        if err := configs.SetVal(configName, configValue); err != nil {
-            user.SendText(fmt.Sprintf("Config error: %s=%s (%s)", configName, configValue, err))
-            return true, nil
-        }
-        
-        user.SendText(fmt.Sprintf("Configuration updated: %s=%s", configName, configValue))
-        return true, nil
-    }
-    
-    // Show current configuration
-    allConfigData := configs.GetConfig().AllConfigData()
-    // Display configuration options...
-}
-```
-
-### Web Interface Integration
-```go
-// Template access to configuration
-templateData := map[string]any{
-    "CONFIG": configs.GetConfig(),
-    "STATS":  GetStats(),
-}
-
-// In templates:
-// {{.CONFIG.Server.MudName}}
-// {{.CONFIG.Network.HttpPort}}
-// {{.CONFIG.GamePlay.PVP}}
-```
-
-### Plugin Configuration
-```go
-// Plugin-specific configuration
-func (p *PluginConfig) Set(name string, val any) {
-    configs.SetVal(fmt.Sprintf(`Modules.%s.%s`, p.pluginName, name), fmt.Sprintf(`%v`, val))
-}
-
-func (p *PluginConfig) Get(name string) any {
-    m := configs.Flatten(configs.GetModulesConfig())
-    return m[fmt.Sprintf(`%s.%s`, p.pluginName, name)]
-}
+const (
+    PVPEnabled  = "enabled"
+    PVPDisabled = "disabled"
+    PVPOff      = "off"      // normalized to "disabled" on Validate
+    PVPLimited  = "limited"
+)
 ```
 
 ## Performance Considerations
 
-### Configuration Caching
-- Configuration is cached in memory with read-write mutex protection
-- Changes trigger validation and persistence but don't require full reload
-- Lookup tables provide O(1) access to configuration paths and types
-
-### Thread Safety
-```go
-var configDataLock sync.RWMutex
-
-func GetConfig() Config {
-    configDataLock.RLock()
-    defer configDataLock.RUnlock()
-    
-    if !configData.validated {
-        configData.Validate()
-    }
-    return configData
-}
-```
-
-### Validation Optimization
-- Validation only runs when configuration changes
-- Cached validation state prevents redundant validation calls
-- Subsection validation allows targeted updates
-
-## Security Features
-
-### Secret Management
-```go
-// Secrets are automatically redacted in logs and output
-type Server struct {
-    DatabasePassword ConfigSecret `yaml:"DatabasePassword" env:"DB_PASSWORD"`
-    APIKey          ConfigSecret `yaml:"APIKey" env:"API_KEY"`
-}
-
-// Access actual values securely
-dbPassword := configs.GetSecret(config.Server.DatabasePassword)
-```
-
-### Configuration Locking
-```go
-// Prevent runtime changes to sensitive configuration
-Server:
-  Locked: ["Seed", "DatabasePassword", "APIKey"]
-```
-
-### Input Validation
-```go
-// Validate user input against banned patterns
-Validation:
-  BannedNames: ["admin*", "root", "system", "*test*"]
-```
-
-## Error Handling and Logging
-
-### Configuration Errors
-- Type conversion errors with detailed messages
-- Path resolution errors with suggestions for correct paths
-- Validation errors with specific constraint information
-- File I/O errors with full context
-
-### Logging Integration
-```go
-// Configuration changes are logged
-mudlog.Info("SetVal", "path", propertyPath, "value", newVal, "success", true)
-mudlog.Error("SetVal", "path", propertyPath, "error", err)
-```
+- Configuration is cached in memory with `sync.RWMutex` protection
+- `validated` flag prevents redundant validation calls
+- Key/type lookup tables (`keyLookups`, `typeLookups`) provide O(1) path resolution after initial build
+- Timing helper values (`turnsPerRound`, etc.) are pre-calculated and cached on `Validate()`
 
 ## Dependencies
 
@@ -457,47 +292,3 @@ mudlog.Error("SetVal", "path", propertyPath, "error", err)
 - `sync` - Thread-safe access control
 - `reflect` - Dynamic configuration introspection
 - `os` - Environment variable access and file operations
-
-## Usage Examples
-
-### Dynamic Configuration Updates
-```go
-// Update server settings at runtime
-configs.SetVal("Server.MudName", "Production Server")
-configs.SetVal("Network.MaxTelnetConnections", "100")
-configs.SetVal("GamePlay.XPScale", "75.0")
-
-// Changes are immediately validated and persisted
-```
-
-### Configuration Validation
-```go
-// Custom validation in subsections
-func (g *GamePlay) Validate() {
-    if g.XPScale <= 0 {
-        g.XPScale = 100.0 // default
-    }
-    
-    if g.PVP != "enabled" && g.PVP != "disabled" && g.PVP != "limited" {
-        g.PVP = "limited" // default
-    }
-    
-    if g.MaxAltCharacters < 0 {
-        g.MaxAltCharacters = 5 // default
-    }
-}
-```
-
-### Environment Variable Integration
-```go
-// Automatic environment variable loading
-os.Setenv("DATABASE_URL", "postgres://localhost/muddb")
-os.Setenv("API_KEY", "secret-api-key")
-
-// Configuration automatically loads these values
-config := configs.GetConfig()
-dbURL := configs.GetSecret(config.Server.DatabaseURL)
-apiKey := configs.GetSecret(config.Server.APIKey)
-```
-
-This configuration system provides a robust foundation for managing all aspects of GoMud server configuration with type safety, validation, security, and runtime flexibility.

--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -19,7 +19,7 @@ type ConnectState uint32
 const (
 	Login ConnectState = iota
 	LoggedIn
-	Zombie
+	LinkDead
 	MaxHistory = 10
 )
 

--- a/internal/connections/context.md
+++ b/internal/connections/context.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The GoMud connections system provides comprehensive network connection management with support for both traditional telnet and WebSocket connections. It features connection lifecycle management, input handling with history, heartbeat monitoring for WebSocket connections, client settings management, and thread-safe connection operations with graceful shutdown support.
+The GoMud connections system provides comprehensive network connection management with support for telnet, WebSocket, and SSH connections. It features connection lifecycle management, input handling with history, heartbeat monitoring for WebSocket connections, client settings management, and thread-safe connection operations with graceful shutdown support.
 
 ## Architecture
 
@@ -12,8 +12,8 @@ The connections system is built around several key components:
 
 **Connection Management:**
 - Thread-safe connection tracking with unique IDs
-- Dual protocol support (telnet and WebSocket)
-- Connection state management (Login, LoggedIn, Zombie)
+- Triple protocol support: telnet (`net.Conn`), WebSocket (`*websocket.Conn`), and SSH (`ssh.Channel`)
+- Connection state management (Login, LoggedIn, LinkDead)
 - Automatic connection cleanup and resource management
 
 **Input Processing:**
@@ -36,11 +36,12 @@ The connections system is built around several key components:
 
 ## Key Features
 
-### 1. **Dual Protocol Support**
+### 1. **Triple Protocol Support**
 - **Telnet Connections**: Traditional MUD protocol with full terminal control
 - **WebSocket Connections**: Modern web-based connections with heartbeat monitoring
+- **SSH Connections**: Full SSH channel support via `golang.org/x/crypto/ssh`
 - **Unix Socket Support**: Local connections for development and administration
-- **Protocol Detection**: Automatic handling based connection type
+- **Protocol Detection**: `IsWebSocket()` and `IsSSH()` methods on `ConnectionDetails`
 
 ### 2. **Advanced Input Management**
 - **Handler Chaining**: Multiple input processors with configurable order
@@ -51,7 +52,7 @@ The connections system is built around several key components:
 ### 3. **Connection State Management**
 - **Login State**: Initial connection before authentication
 - **LoggedIn State**: Authenticated and active connections
-- **Zombie State**: Disconnected but not yet cleaned up
+- **LinkDead State**: Disconnected but not yet cleaned up
 - **Thread-Safe Operations**: All connection operations are mutex-protected
 
 ### 4. **Robust Heartbeat System**
@@ -62,15 +63,17 @@ The connections system is built around several key components:
 
 ## Connection Structure
 
-### Connection Details Structure
+### ConnectionDetails Structure
 ```go
 type ConnectionDetails struct {
     connectionId      ConnectionId    // Unique connection identifier
     state             ConnectState    // Current connection state
     lastInputTime     time.Time       // Last input received timestamp
-    conn              net.Conn        // Raw network connection
+    conn              net.Conn        // Raw network connection (telnet/unix)
     wsConn            *websocket.Conn // WebSocket connection (if applicable)
     wsLock            sync.Mutex      // WebSocket write synchronization
+    sshChannel        ssh.Channel     // SSH channel (if applicable)
+    sshRemoteAddr     net.Addr        // SSH remote address
     handlerMutex      sync.Mutex      // Input handler synchronization
     inputHandlerNames []string        // Handler names for management
     inputHandlers     []InputHandler  // Handler function chain
@@ -78,6 +81,15 @@ type ConnectionDetails struct {
     clientSettings    ClientSettings  // Client configuration
     heartbeat         *heartbeatManager // WebSocket heartbeat manager
 }
+```
+
+### Construction
+```go
+// Create a telnet or WebSocket connection (heartbeat auto-started for WebSocket)
+func NewConnectionDetails(connId ConnectionId, c net.Conn, wsC *websocket.Conn, config *HeartbeatConfig) *ConnectionDetails
+
+// Create an SSH connection
+func NewSSHConnectionDetails(connId ConnectionId, ch ssh.Channel, remoteAddr net.Addr) *ConnectionDetails
 ```
 
 ### Client Input Structure
@@ -99,111 +111,67 @@ type ClientInput struct {
 ```go
 type ClientSettings struct {
     Display           DisplaySettings // Screen dimensions and display options
-    MSPEnabled        bool           // MUD Sound Protocol support
-    SendTelnetGoAhead bool           // Telnet IAC GA after prompts
+    MSPEnabled        bool            // MUD Sound Protocol support
+    SendTelnetGoAhead bool            // Telnet IAC GA after prompts
 }
 
 type DisplaySettings struct {
     ScreenWidth  uint32 // Terminal width (default: 80)
-    ScreenHeight uint32 // Terminal height (default: 24)
+    ScreenHeight uint32 // Terminal height (default: 40)
 }
 ```
 
 ## Connection Management
 
+### Adding Connections
+```go
+// Add a telnet or WebSocket connection
+func Add(conn net.Conn, wsConn *websocket.Conn) *ConnectionDetails
+
+// Add an SSH connection
+func AddSSH(ch ssh.Channel, remoteAddr net.Addr) *ConnectionDetails
+```
+
 ### Connection Lifecycle
 ```go
-// Add new connection to management system
-func Add(conn net.Conn, wsConn *websocket.Conn) *ConnectionDetails {
-    lock.Lock()
-    defer lock.Unlock()
-    
-    connectCounter++
-    
-    connDetails := NewConnectionDetails(
-        connectCounter,
-        conn,
-        wsConn,
-        nil, // Default heartbeat config
-    )
-    
-    netConnections[connDetails.ConnectionId()] = connDetails
-    
-    return connDetails
-}
-
 // Remove connection and cleanup resources
-func Remove(id ConnectionId) error {
-    lock.Lock()
-    defer lock.Unlock()
-    
-    if cd, ok := netConnections[id]; ok {
-        cd.Close()                    // Close underlying connection
-        disconnectCounter++           // Track disconnection
-        delete(netConnections, id)    // Remove from tracking
-        return nil
-    }
-    
-    return errors.New("connection not found")
-}
+func Remove(id ConnectionId) error
 
-// Forcibly disconnect with reason
-func Kick(id ConnectionId, reason string) error {
-    lock.Lock()
-    defer lock.Unlock()
-    
-    if cd, ok := netConnections[id]; ok {
-        cd.Close()
-        disconnectCounter++
-        mudlog.Info("connection kicked", 
-            "connectionId", id, 
-            "remoteAddr", cd.RemoteAddr().String(), 
-            "reason", reason)
-        return nil
-    }
-    
-    return errors.New("connection not found")
-}
+// Forcibly disconnect with reason (does not delete from map)
+func Kick(id ConnectionId, reason string) error
+
+// Cleanup all connections
+func Cleanup()
 ```
 
 ### Connection Discovery
 ```go
 // Get connection by ID
-func Get(id ConnectionId) *ConnectionDetails {
-    lock.Lock()
-    defer lock.Unlock()
-    return netConnections[id]
-}
+func Get(id ConnectionId) *ConnectionDetails
 
 // Check if connection is WebSocket
-func IsWebsocket(id ConnectionId) bool {
-    lock.Lock()
-    defer lock.Unlock()
-    
-    if cd, ok := netConnections[id]; ok {
-        return cd.IsWebSocket()
-    }
-    return false
-}
+func IsWebsocket(id ConnectionId) bool
 
 // Get all active connection IDs
-func GetAllConnectionIds() []ConnectionId {
-    lock.Lock()
-    defer lock.Unlock()
-    
-    ids := make([]ConnectionId, len(netConnections))
-    for id := range netConnections {
-        ids = append(ids, id)
-    }
-    return ids
-}
+func GetAllConnectionIds() []ConnectionId
+
+// Get active connection count
+func ActiveConnectionCount() int
 
 // Get connection statistics
-func Stats() (connections uint64, disconnections uint64) {
-    lock.RLock()
-    defer lock.RUnlock()
-    return connectCounter, disconnectCounter
-}
+func Stats() (connections uint64, disconnections uint64)
+```
+
+### Connection Properties
+```go
+func (cd *ConnectionDetails) IsWebSocket() bool
+func (cd *ConnectionDetails) IsSSH() bool
+func (cd *ConnectionDetails) IsLocal() bool      // loopback or unix socket
+func (cd *ConnectionDetails) RemoteAddr() net.Addr
+func (cd *ConnectionDetails) ConnectionId() ConnectionId
+func (cd *ConnectionDetails) State() ConnectState
+func (cd *ConnectionDetails) SetState(state ConnectState)
+func (cd *ConnectionDetails) InputDisabled(setTo ...bool) bool
 ```
 
 ## Input Handling System
@@ -212,73 +180,20 @@ func Stats() (connections uint64, disconnections uint64) {
 ```go
 type InputHandler func(ci *ClientInput, handlerState map[string]any) (doNextHandler bool)
 
-// Add input handler to chain
-func (cd *ConnectionDetails) AddInputHandler(name string, newInputHandler InputHandler, after ...string) {
-    cd.handlerMutex.Lock()
-    defer cd.handlerMutex.Unlock()
-    
-    // Insert after specific handler if specified
-    if len(after) > 0 {
-        for i, handlerName := range cd.inputHandlerNames {
-            if handlerName == after[0] {
-                cd.inputHandlerNames = append(cd.inputHandlerNames[:i+1], 
-                    append([]string{name}, cd.inputHandlerNames[i+1:]...)...)
-                cd.inputHandlers = append(cd.inputHandlers[:i+1], 
-                    append([]InputHandler{newInputHandler}, cd.inputHandlers[i+1:]...)...)
-                return
-            }
-        }
-    }
-    
-    // Append to end of chain
-    cd.inputHandlerNames = append(cd.inputHandlerNames, name)
-    cd.inputHandlers = append(cd.inputHandlers, newInputHandler)
-}
+// Add input handler (optionally after a named handler)
+func (cd *ConnectionDetails) AddInputHandler(name string, newInputHandler InputHandler, after ...string)
 
-// Remove input handler from chain
-func (cd *ConnectionDetails) RemoveInputHandler(name string) {
-    cd.handlerMutex.Lock()
-    defer cd.handlerMutex.Unlock()
-    
-    for i := len(cd.inputHandlerNames) - 1; i >= 0; i-- {
-        if cd.inputHandlerNames[i] == name {
-            cd.inputHandlerNames = append(cd.inputHandlerNames[:i], cd.inputHandlerNames[i+1:]...)
-            cd.inputHandlers = append(cd.inputHandlers[:i], cd.inputHandlers[i+1:]...)
-        }
-    }
-}
+// Remove input handler by name
+func (cd *ConnectionDetails) RemoveInputHandler(name string)
+
+// Process input through handler chain
+func (cd *ConnectionDetails) HandleInput(ci *ClientInput, handlerState map[string]any) (doNextHandler bool, lastHandler string, err error)
 ```
 
 ### Input Processing
 ```go
-// Process input through handler chain
-func (cd *ConnectionDetails) HandleInput(ci *ClientInput, handlerState map[string]any) (doNextHandler bool, lastHandler string, err error) {
-    cd.handlerMutex.Lock()
-    defer cd.handlerMutex.Unlock()
-    
-    cd.lastInputTime = time.Now()
-    
-    if len(cd.inputHandlers) < 1 {
-        return false, lastHandler, errors.New("no input handlers")
-    }
-    
-    // Execute handler chain
-    for i, inputHandler := range cd.inputHandlers {
-        lastHandler = cd.inputHandlerNames[i]
-        if runNextHandler := inputHandler(ci, handlerState); !runNextHandler {
-            return false, lastHandler, nil
-        }
-    }
-    
-    return true, lastHandler, nil
-}
-
-// Reset input state after processing
-func (ci *ClientInput) Reset() {
-    ci.DataIn = ci.DataIn[:0]
-    ci.Buffer = ci.Buffer[:0]
-    ci.EnterPressed = false
-}
+// Reset the client input to "no current input"
+func (ci *ClientInput) Reset()
 ```
 
 ## Command History System
@@ -291,169 +206,40 @@ type InputHistory struct {
     history   [][]byte // Command history buffer (max 10)
 }
 
-// Add command to history
-func (ih *InputHistory) Add(input []byte) {
-    // Maintain maximum history size
-    if len(ih.history) >= MaxHistory {
-        ih.history = ih.history[1:]
-    }
-    
-    // Add new command
-    ih.history = append(ih.history, make([]byte, len(input)))
-    ih.position = len(ih.history) - 1
-    copy(ih.history[ih.position], input)
-    ih.inhistory = false
-}
-
-// Navigate to previous command
-func (ih *InputHistory) Previous() {
-    if !ih.inhistory {
-        ih.inhistory = true
-        return
-    }
-    if ih.position <= 0 {
-        return
-    }
-    ih.position--
-}
-
-// Navigate to next command
-func (ih *InputHistory) Next() {
-    if !ih.inhistory {
-        ih.inhistory = true
-        return
-    }
-    if ih.position >= len(ih.history)-1 {
-        return
-    }
-    ih.position++
-}
-
-// Get current history command
-func (ih *InputHistory) Get() []byte {
-    if len(ih.history) < 1 {
-        return nil
-    }
-    return ih.history[ih.position]
-}
+func (ih *InputHistory) Add(input []byte)
+func (ih *InputHistory) Previous()
+func (ih *InputHistory) Next()
+func (ih *InputHistory) Get() []byte
+func (ih *InputHistory) Position() int
+func (ih *InputHistory) ResetPosition()
+func (ih *InputHistory) InHistory() bool
 ```
 
 ## Communication System
 
 ### Broadcasting and Messaging
 ```go
-// Broadcast message to all connections (with exclusions)
-func Broadcast(colorizedText []byte, skipConnectionIds ...ConnectionId) []ConnectionId {
-    lock.Lock()
-    
-    removeIds := []ConnectionId{}
-    sentToIds := []ConnectionId{}
-    
-    for id, cd := range netConnections {
-        // Skip login state connections
-        if cd.state == Login {
-            continue
-        }
-        
-        // Skip excluded connections
-        skip := false
-        for _, skipId := range skipConnectionIds {
-            if skipId == id {
-                skip = true
-                break
-            }
-        }
-        if skip {
-            continue
-        }
-        
-        // Send message
-        if _, err := cd.Write(colorizedText); err != nil {
-            mudlog.Warn("Broadcast()", "connectionId", id, "error", err)
-            removeIds = append(removeIds, id)
-        } else {
-            sentToIds = append(sentToIds, id)
-        }
-    }
-    
-    lock.Unlock()
-    
-    // Cleanup failed connections
-    for _, id := range removeIds {
-        Remove(id)
-    }
-    
-    return sentToIds
-}
+// Broadcast message to all LoggedIn connections (with optional exclusions)
+func Broadcast(colorizedText []byte, skipConnectionIds ...ConnectionId) []ConnectionId
 
 // Send message to specific connections
-func SendTo(b []byte, ids ...ConnectionId) {
-    lock.Lock()
-    
-    removeIds := []ConnectionId{}
-    
-    for _, id := range ids {
-        if cd, ok := netConnections[id]; ok {
-            if _, err := cd.Write(b); err != nil {
-                mudlog.Warn("SendTo()", "connectionId", id, "error", err)
-                removeIds = append(removeIds, id)
-            }
-        }
-    }
-    
-    lock.Unlock()
-    
-    // Cleanup failed connections
-    for _, id := range removeIds {
-        Remove(id)
-    }
-}
+func SendTo(b []byte, ids ...ConnectionId)
 ```
 
 ### Protocol-Specific I/O
 ```go
-// Write data with protocol handling
-func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
-    // Convert line endings for all protocols
-    p = []byte(strings.ReplaceAll(string(p), "\n", "\r\n"))
-    
-    if len(p) == 0 {
-        return 0, nil
-    }
-    
-    if cd.wsConn != nil {
-        cd.wsLock.Lock()
-        defer cd.wsLock.Unlock()
-        
-        // Prevent telnet commands to WebSocket
-        if p[0] == term.TELNET_IAC {
-            mudlog.Error("conn.Write", "error", "Trying to send telnet command to websocket!")
-            return 0, nil
-        }
-        
-        err := cd.wsConn.WriteMessage(websocket.TextMessage, p)
-        if err != nil {
-            return 0, err
-        }
-        return len(p), nil
-    }
-    
-    return cd.conn.Write(p)
-}
+// Write data (handles SSH, WebSocket, and telnet)
+// - SSH: writes to ssh.Channel
+// - WebSocket: uses wsLock, rejects telnet IAC bytes
+// - Telnet/Unix: writes to net.Conn
+// Line endings \n -> \r\n are applied for all protocols
+func (cd *ConnectionDetails) Write(p []byte) (n int, err error)
 
-// Read data with protocol handling
-func (cd *ConnectionDetails) Read(p []byte) (n int, err error) {
-    if cd.wsConn != nil {
-        _, message, err := cd.wsConn.ReadMessage()
-        if err != nil {
-            return 0, err
-        }
-        copy(p, message)
-        return len(message), nil
-    }
-    
-    return cd.conn.Read(p)
-}
+// Read data (handles SSH, WebSocket, and telnet)
+func (cd *ConnectionDetails) Read(p []byte) (n int, err error)
+
+// Close the connection (stops heartbeat, closes underlying transport)
+func (cd *ConnectionDetails) Close()
 ```
 
 ## Heartbeat System
@@ -468,262 +254,77 @@ type HeartbeatConfig struct {
 
 var DefaultHeartbeatConfig = HeartbeatConfig{
     PongWait:   60 * time.Second,
-    PingPeriod: (60 * time.Second * 9) / 10, // 54 seconds
+    PingPeriod: 54 * time.Second, // (60s * 9) / 10
     WriteWait:  10 * time.Second,
 }
 
-// Start heartbeat monitoring for WebSocket
-func (cd *ConnectionDetails) StartHeartbeat(config HeartbeatConfig) error {
-    if cd.wsConn == nil {
-        return ErrNotWebsocket
-    }
-    
-    hm := newHeartbeatManager(cd, config)
-    
-    // Set up pong handler
-    cd.wsConn.SetReadDeadline(time.Now().Add(hm.config.PongWait))
-    cd.wsConn.SetPongHandler(func(string) error {
-        mudlog.Debug("Heartbeat::Pong", "connectionId", hm.cd.connectionId)
-        cd.wsConn.SetReadDeadline(time.Now().Add(hm.config.PongWait))
-        return nil
-    })
-    
-    // Start ping loop
-    hm.wg.Add(1)
-    go hm.runPingLoop()
-    
-    return nil
-}
-
-// Ping loop for connection monitoring
-func (hm *heartbeatManager) runPingLoop() {
-    defer hm.wg.Done()
-    ticker := time.NewTicker(hm.config.PingPeriod)
-    defer ticker.Stop()
-    
-    for {
-        select {
-        case <-hm.stopChan:
-            return
-        case <-ticker.C:
-            if err := hm.writePing(); err != nil {
-                mudlog.Warn("Heartbeat::Error", "connectionId", hm.cd.connectionId, "error", err)
-                return
-            }
-        }
-    }
-}
+// Start heartbeat monitoring for a WebSocket connection
+func (cd *ConnectionDetails) StartHeartbeat(config HeartbeatConfig) error
 ```
 
 ## Client Settings Management
 
-### Settings Configuration
 ```go
 // Get client settings for connection
-func GetClientSettings(id ConnectionId) ClientSettings {
-    lock.Lock()
-    defer lock.Unlock()
-    
-    if cd, ok := netConnections[id]; ok {
-        return cd.clientSettings
-    }
-    
-    return ClientSettings{} // Return defaults
-}
+func GetClientSettings(id ConnectionId) ClientSettings
 
 // Update client settings
-func OverwriteClientSettings(id ConnectionId, cs ClientSettings) {
-    lock.Lock()
-    defer lock.Unlock()
-    
-    if cd, ok := netConnections[id]; ok {
-        cd.clientSettings = cs
-    }
-}
+func OverwriteClientSettings(id ConnectionId, cs ClientSettings)
 
 // Display settings with defaults
-func (c DisplaySettings) GetScreenWidth() int {
-    if c.ScreenWidth == 0 {
-        return DefaultScreenWidth // 80
-    }
-    return int(c.ScreenWidth)
-}
-
-func (c DisplaySettings) GetScreenHeight() int {
-    if c.ScreenHeight == 0 {
-        return DefaultScreenHeight // 24
-    }
-    return int(c.ScreenHeight)
-}
+func (c DisplaySettings) GetScreenWidth() int   // default 80
+func (c DisplaySettings) GetScreenHeight() int  // default 40
 ```
 
 ## Connection State Management
 
-### State Transitions
 ```go
 type ConnectState uint32
 
 const (
     Login    ConnectState = iota // Initial connection state
     LoggedIn                     // Authenticated and active
-    Zombie                       // Disconnected but not cleaned up
+    LinkDead                     // Disconnected but not cleaned up
 )
-
-// Thread-safe state management
-func (cd *ConnectionDetails) State() ConnectState {
-    return ConnectState(atomic.LoadUint32((*uint32)(&cd.state)))
-}
-
-func (cd *ConnectionDetails) SetState(state ConnectState) {
-    atomic.StoreUint32((*uint32)(&cd.state), uint32(state))
-}
-
-// Input control
-func (cd *ConnectionDetails) InputDisabled(setTo ...bool) bool {
-    if len(setTo) > 0 {
-        cd.inputDisabled = setTo[0]
-    }
-    return cd.inputDisabled
-}
-```
-
-### Connection Properties
-```go
-// Check if connection is local
-func (cd *ConnectionDetails) IsLocal() bool {
-    var remoteAddrStr string
-    
-    if cd.wsConn == nil {
-        // Unix sockets are always local
-        if _, ok := cd.conn.(*net.UnixConn); ok {
-            return true
-        }
-        remoteAddrStr = cd.conn.RemoteAddr().String()
-    } else {
-        remoteAddrStr = cd.wsConn.RemoteAddr().String()
-    }
-    
-    host, _, err := net.SplitHostPort(remoteAddrStr)
-    if err != nil {
-        return false
-    }
-    
-    ip := net.ParseIP(host)
-    if ip == nil {
-        return false
-    }
-    
-    return ip.IsLoopback()
-}
 ```
 
 ## Shutdown and Cleanup
 
-### Graceful Shutdown
 ```go
-// Set shutdown signal channel
-func SetShutdownChan(osSignalChan chan os.Signal) {
-    lock.Lock()
-    defer lock.Unlock()
-    
-    if shutdownChannel != nil {
-        panic("Can't set shutdown channel a second time!")
-    }
-    shutdownChannel = osSignalChan
-}
+// Set shutdown signal channel (call once at startup)
+func SetShutdownChan(osSignalChan chan os.Signal)
 
 // Signal shutdown to all systems
-func SignalShutdown(s os.Signal) {
-    if shutdownChannel != nil {
-        shutdownChannel <- s
-    }
-}
-
-// Cleanup all connections
-func Cleanup() {
-    for _, id := range GetAllConnectionIds() {
-        Remove(id)
-    }
-}
+func SignalShutdown(s os.Signal)
 ```
 
 ## Usage Examples
 
-### Basic Connection Management
+### Telnet Connection Setup
 ```go
-// Accept new connection
 conn, err := listener.Accept()
-if err != nil {
-    return err
-}
-
-// Add to connection management
-connDetails := connections.Add(conn, nil) // nil for telnet
-fmt.Printf("New connection: %d\n", connDetails.ConnectionId())
-
-// Set up input handlers
+connDetails := connections.Add(conn, nil) // nil = telnet
 connDetails.AddInputHandler("auth", authHandler)
-connDetails.AddInputHandler("game", gameHandler, "auth")
-
-// Set connection state
 connDetails.SetState(connections.LoggedIn)
 ```
 
 ### WebSocket Connection Setup
 ```go
-// Upgrade HTTP to WebSocket
 wsConn, err := upgrader.Upgrade(w, r, nil)
-if err != nil {
-    return err
-}
+connDetails := connections.Add(nil, wsConn) // heartbeat auto-started
+```
 
-// Add WebSocket connection
-connDetails := connections.Add(nil, wsConn)
-
-// Heartbeat is automatically started for WebSocket connections
-// Custom heartbeat config can be provided during NewConnectionDetails
+### SSH Connection Setup
+```go
+// After SSH handshake and channel acceptance:
+connDetails := connections.AddSSH(sshChannel, remoteAddr)
+// Terminal dimensions set separately via OverwriteClientSettings
 ```
 
 ### Input Handler Implementation
 ```go
-// Example input handler
-func gameInputHandler(ci *connections.ClientInput, handlerState map[string]any) bool {
-    if ci.EnterPressed {
-        command := string(ci.Buffer)
-        
-        // Add to history
-        ci.History.Add(ci.Buffer)
-        
-        // Process game command
-        processGameCommand(ci.ConnectionId, command)
-        
-        // Reset input
-        ci.Reset()
-        
-        return false // Stop handler chain
-    }
-    
-    return true // Continue to next handler
-}
-
-// Add handler to connection
+func gameInputHandler(ci *connections.ClientInput, handlerState map[string]any) bool
 connDetails.AddInputHandler("game", gameInputHandler)
-```
-
-### Broadcasting Messages
-```go
-// Broadcast to all logged-in users
-message := []byte("Server announcement: Maintenance in 5 minutes!")
-sentTo := connections.Broadcast(message)
-fmt.Printf("Message sent to %d connections\n", len(sentTo))
-
-// Send to specific users (excluding sender)
-userMessage := []byte("You have a new message!")
-connections.SendTo(userMessage, userId1, userId2)
-
-// Broadcast excluding specific user
-announcement := []byte("Player John has joined the game!")
-connections.Broadcast(announcement, johnConnectionId)
 ```
 
 ## Dependencies
@@ -731,7 +332,6 @@ connections.Broadcast(announcement, johnConnectionId)
 - `net` - Network connection handling and address management
 - `sync` - Thread synchronization and atomic operations
 - `github.com/gorilla/websocket` - WebSocket protocol implementation
+- `golang.org/x/crypto/ssh` - SSH protocol implementation
 - `internal/mudlog` - Logging system for connection events and debugging
 - `internal/term` - Terminal control codes and telnet protocol handling
-
-This comprehensive connections system provides robust network connection management with support for multiple protocols, advanced input processing, heartbeat monitoring, and thread-safe operations for reliable MUD server networking.

--- a/internal/copyover/context.md
+++ b/internal/copyover/context.md
@@ -122,28 +122,11 @@ type myState struct {
 ```go
 type myContributor struct{}
 
-func (m *myContributor) CopyoverName() string { return "mypackage" }
+func (m *myContributor) CopyoverName() string
+func (m *myContributor) CopyoverSave(enc *copyover.Encoder) error
+func (m *myContributor) CopyoverRestore(dec *copyover.Decoder) error
 
-func (m *myContributor) CopyoverSave(enc *copyover.Encoder) error {
-    return enc.WriteSection(m.CopyoverName(), myState{
-        Counter: currentCounter,
-        Label:   currentLabel,
-    })
-}
-
-func (m *myContributor) CopyoverRestore(dec *copyover.Decoder) error {
-    var state myState
-    if err := dec.ReadSection(m.CopyoverName(), &state); err != nil {
-        return err
-    }
-    currentCounter = state.Counter
-    currentLabel   = state.Label
-    return nil
-}
-
-func CopyoverContributor() copyover.Contributor {
-    return &myContributor{}
-}
+func CopyoverContributor() copyover.Contributor
 ```
 
 Convention: place this in a file named `copyover.go` inside your package, and

--- a/internal/events/context.md
+++ b/internal/events/context.md
@@ -220,18 +220,14 @@ type RebuildMap struct {
     SkipIfExists  bool
 }
 
-func (r RebuildMap) UniqueID() string {
-    return `RebuildMap-` + strconv.Itoa(r.MapRootRoomId) + `-` + strconv.FormatBool(r.SkipIfExists)
-}
+func (r RebuildMap) UniqueID() string
 
 type RedrawPrompt struct {
     UserId        int
     OnlyIfChanged bool
 }
 
-func (l RedrawPrompt) UniqueID() string {
-    return `RedrawPrompt-` + strconv.Itoa(l.UserId)
-}
+func (l RedrawPrompt) UniqueID() string
 ```
 
 ## Event Flags
@@ -268,11 +264,7 @@ flags.Remove(CmdBlockInput)
 ### Listener Registration
 ```go
 // Register listener for specific event type
-listenerId := events.RegisterListener(PlayerSpawn{}, func(e events.Event) events.ListenerReturn {
-    spawn := e.(events.PlayerSpawn)
-    log.Printf("Player %s spawned in room %d", spawn.CharacterName, spawn.RoomId)
-    return events.Continue
-})
+listenerId := events.RegisterListener(PlayerSpawn{}, func(e events.Event) events.ListenerReturn)
 
 // Register high-priority listener (executes first)
 events.RegisterListener(PlayerDeath{}, handlePlayerDeath, events.First)
@@ -296,33 +288,10 @@ const (
 ### Listener Examples
 ```go
 // Character death handler
-func handlePlayerDeath(e events.Event) events.ListenerReturn {
-    death := e.(events.PlayerDeath)
-    
-    if death.Permanent {
-        // Handle permadeath
-        handlePermaDeath(death.UserId)
-        return events.Cancel // Stop further processing
-    }
-    
-    // Normal death, allow other handlers
-    return events.Continue
-}
+func handlePlayerDeath(e events.Event) events.ListenerReturn
 
 // Level up notification
-func broadcastLevelUp(e events.Event) events.ListenerReturn {
-    levelUp := e.(events.LevelUp)
-    
-    message := fmt.Sprintf("%s has reached level %d!", 
-        levelUp.CharacterName, levelUp.NewLevel)
-    
-    events.AddToQueue(events.Broadcast{
-        Text: message,
-        IsCommunication: false,
-    })
-    
-    return events.Continue
-}
+func broadcastLevelUp(e events.Event) events.ListenerReturn
 ```
 
 ## Event Processing
@@ -360,18 +329,7 @@ events.AddToQueue(events.RedrawPrompt{
 events.ProcessEvents()
 
 // This is typically called from the main game loop:
-func gameLoop() {
-    for {
-        // Handle network input
-        processNetworkInput()
-        
-        // Process all queued events
-        events.ProcessEvents()
-        
-        // Sleep until next tick
-        time.Sleep(tickDuration)
-    }
-}
+func gameLoop()
 ```
 
 ### Custom Event Creation
@@ -383,23 +341,13 @@ type CustomGameEvent struct {
     Data     map[string]any
 }
 
-func (c CustomGameEvent) Type() string {
-    return "CustomGameEvent"
-}
+func (c CustomGameEvent) Type() string
 
 // Register listener for custom event
-events.RegisterListener(CustomGameEvent{}, func(e events.Event) events.ListenerReturn {
-    custom := e.(CustomGameEvent)
-    // Handle custom event
-    return events.Continue
-})
+events.RegisterListener(CustomGameEvent{}, func(e events.Event) events.ListenerReturn)
 
 // Fire custom event
-events.AddToQueue(CustomGameEvent{
-    PlayerId: 123,
-    Action:   "special_action",
-    Data:     map[string]any{"value": 42},
-})
+events.AddToQueue(CustomGameEvent{...})
 ```
 
 ## Integration Patterns
@@ -407,71 +355,27 @@ events.AddToQueue(CustomGameEvent{
 ### Hook System Integration
 ```go
 // Event hooks are registered as listeners
-func init() {
-    events.RegisterListener(events.NewRound{}, handleNewRound)
-    events.RegisterListener(events.PlayerSpawn{}, handlePlayerJoin)
-    events.RegisterListener(events.RoomChange{}, handleRoomChange)
-}
+func init()
 
 // Hook implementations
-func handleNewRound(e events.Event) events.ListenerReturn {
-    round := e.(events.NewRound)
-    
-    // Process combat
-    handleCombat(round)
-    
-    // Process mob AI
-    processMobAI(round)
-    
-    // Auto-healing
-    processAutoHeal(round)
-    
-    return events.Continue
-}
+func handleNewRound(e events.Event) events.ListenerReturn
 ```
 
 ### Module Integration
 ```go
-// Modules can register for events they care about
-type AuctionModule struct {
-    // module fields
-}
+type AuctionModule struct{}
 
-func (m *AuctionModule) Initialize() {
-    events.RegisterListener(events.PlayerSpawn{}, m.onPlayerJoin)
-    events.RegisterListener(events.NewTurn{}, m.processAuctions)
-}
-
-func (m *AuctionModule) onPlayerJoin(e events.Event) events.ListenerReturn {
-    spawn := e.(events.PlayerSpawn)
-    // Send auction notifications to new player
-    return events.Continue
-}
+func (m *AuctionModule) Initialize()
+func (m *AuctionModule) onPlayerJoin(e events.Event) events.ListenerReturn
 ```
 
 ### Scripting Integration
 ```go
 // JavaScript can raise custom events
-func RaiseEvent(name string, data map[string]any) {
-    events.AddToQueue(events.ScriptedEvent{
-        Name: name,
-        Data: data,
-    })
-}
+func RaiseEvent(name string, data map[string]any)
 
 // Event listener handles scripted events
-func handleScriptedEvent(e events.Event) events.ListenerReturn {
-    scripted := e.(events.ScriptedEvent)
-    
-    switch scripted.Name {
-    case "custom-quest-complete":
-        handleQuestComplete(scripted.Data)
-    case "special-room-effect":
-        handleRoomEffect(scripted.Data)
-    }
-    
-    return events.Continue
-}
+func handleScriptedEvent(e events.Event) events.ListenerReturn
 ```
 
 ## Performance Considerations
@@ -487,32 +391,12 @@ func handleScriptedEvent(e events.Event) events.ListenerReturn {
 // Events are processed and removed from queue immediately
 // No long-term event storage or memory leaks
 // Automatic cleanup of unique event tracking
-
-// Performance monitoring
-func ProcessEvents() {
-    start := time.Now()
-    defer func() {
-        if time.Since(start) > threshold {
-            log.Printf("Event processing took %v", time.Since(start))
-        }
-    }()
-    
-    // Process events...
-}
 ```
 
 ### Debug and Monitoring
 ```go
 // Enable event debugging
 events.SetDebug(true)
-
-// Monitor events without listeners
-// Automatically logs when events have no registered listeners
-// Helps identify missing event handlers
-
-// Performance tracking
-// Automatic timing of event processing loops
-// Configurable sampling to reduce overhead
 ```
 
 ## Error Handling
@@ -526,13 +410,7 @@ events.SetDebug(true)
 ### Listener Management
 ```go
 // Safe listener removal
-func cleanup() {
-    // Unregister listeners when no longer needed
-    events.UnregisterListener(PlayerSpawn{}, listenerId)
-    
-    // Clear all listeners (typically for testing)
-    events.ClearListeners()
-}
+func cleanup()
 ```
 
 ## Dependencies
@@ -549,33 +427,18 @@ func cleanup() {
 ```go
 // 1. Define event type
 type PlayerLoginEvent struct {
-    UserId   int
-    Username string
+    UserId    int
+    Username  string
     LoginTime time.Time
 }
 
-func (p PlayerLoginEvent) Type() string { return "PlayerLogin" }
+func (p PlayerLoginEvent) Type() string
 
 // 2. Register listeners
-events.RegisterListener(PlayerLoginEvent{}, func(e events.Event) events.ListenerReturn {
-    login := e.(PlayerLoginEvent)
-    log.Printf("Player %s logged in at %v", login.Username, login.LoginTime)
-    
-    // Send welcome message
-    events.AddToQueue(events.Message{
-        UserId: login.UserId,
-        Text:   "Welcome back!",
-    })
-    
-    return events.Continue
-})
+events.RegisterListener(PlayerLoginEvent{}, func(e events.Event) events.ListenerReturn)
 
 // 3. Fire event
-events.AddToQueue(PlayerLoginEvent{
-    UserId:    123,
-    Username:  "player1",
-    LoginTime: time.Now(),
-})
+events.AddToQueue(PlayerLoginEvent{...})
 
 // 4. Process events
 events.ProcessEvents()

--- a/internal/fileloader/context.md
+++ b/internal/fileloader/context.md
@@ -150,8 +150,8 @@ type ConfigData struct {
     Value int   `yaml:"value"`
 }
 
-func (c ConfigData) Validate() error { return nil }
-func (c ConfigData) Filepath() string { return "config.yaml" }
+func (c ConfigData) Validate() error
+func (c ConfigData) Filepath() string
 
 config, err := fileloader.LoadFlatFile[ConfigData]("/path/to/config.yaml")
 ```
@@ -163,9 +163,9 @@ type ItemData struct {
     Name   string `yaml:"name"`
 }
 
-func (i ItemData) Id() int { return i.ItemId }
-func (i ItemData) Validate() error { return nil }
-func (i ItemData) Filepath() string { return fmt.Sprintf("items/%d.yaml", i.ItemId) }
+func (i ItemData) Id() int
+func (i ItemData) Validate() error
+func (i ItemData) Filepath() string
 
 items, err := fileloader.LoadAllFlatFiles[int, ItemData]("/path/to/items/")
 ```

--- a/internal/flags/context.md
+++ b/internal/flags/context.md
@@ -69,10 +69,7 @@ The `internal/flags` package provides command-line argument processing for the G
 
 ### Integration in Main
 ```go
-func main() {
-    flags.HandleFlags("v1.2.3")
-    // Continue with normal server startup if no utility flags were used
-}
+func main()
 ```
 
 ## Port Search Functionality

--- a/internal/gametime/context.md
+++ b/internal/gametime/context.md
@@ -92,30 +92,7 @@ type GameDate struct {
 ### Time Display and Formatting
 ```go
 // Standard time display with color coding
-func (gd GameDate) String(symbolOnly ...bool) string {
-    dayNight := "day"
-    if gd.Night {
-        dayNight = "night"
-    } else {
-        // Check for dusk transition
-        hoursLeft := int(math.Abs(float64(gd.Hour24) - float64(gd.NightStart)))
-        if hoursLeft < 3 {
-            dayNight = "day-dusk"
-        }
-    }
-    
-    // Symbol-only display for compact representation
-    if len(symbolOnly) > 0 && symbolOnly[0] {
-        if gd.Night {
-            return `<ansi fg="night">☾</ansi>`
-        }
-        return fmt.Sprintf(`<ansi fg="%s">☀️</ansi>`, dayNight)
-    }
-    
-    // Full time display with color coding
-    return fmt.Sprintf("<ansi fg=\"%s\">%d:%02d%s</ansi>", 
-                      dayNight, gd.Hour, gd.Minute, gd.AmPm)
-}
+func (gd GameDate) String(symbolOnly ...bool) string
 ```
 
 ## Time Period System
@@ -129,42 +106,16 @@ type RoundTimer struct {
 }
 
 // Check if timer has expired
-func (r RoundTimer) Expired() bool {
-    if r.Period == "" || r.RoundStart == 0 {
-        return true
-    }
-    
-    // Lazy load GameDate if not cached
-    if r.gd.RoundNumber == 0 {
-        r.gd = GetDate(r.RoundStart)
-    }
-    
-    // Check if current round exceeds timer expiration
-    return r.gd.AddPeriod(r.Period) < util.GetRoundCount()
-}
+func (r RoundTimer) Expired() bool
 ```
 
 ### Period String Processing
 ```go
 // Add time period to current date
-func (gd GameDate) AddPeriod(period string) uint64 {
-    // Parse period strings like:
-    // "1 day", "3 hours", "2 weeks", "30 minutes"
-    
-    // Implementation converts period to rounds based on:
-    // - Game configuration for rounds per day/hour
-    // - Calendar structure for days/weeks/months
-    // - Returns new round number after period addition
-    
-    return newRoundNumber
-}
+func (gd GameDate) AddPeriod(period string) uint64
 
 // Get the last occurrence of a specific period
-func GetLastPeriod(period string, currentRound uint64) uint64 {
-    // Find the most recent round when specified period occurred
-    // Useful for events like "last sunset", "last midnight"
-    return lastOccurrenceRound
-}
+func GetLastPeriod(period string, currentRound uint64) uint64
 ```
 
 ## Calendar and Month System
@@ -187,40 +138,15 @@ var monthNames = []string{
 }
 
 // Get month name by number (1-12)
-func MonthName(month int) string {
-    month-- // Convert to 0-based index
-    return monthNames[month%len(monthNames)]
-}
+func MonthName(month int) string
 ```
 
 ### Date Calculation and Caching
 ```go
-var roundDateCache = map[uint64]GameDate{}
-
 // Get GameDate for specific round with caching
-func GetDate(roundNumber uint64) GameDate {
-    if cached, exists := roundDateCache[roundNumber]; exists {
-        return cached
-    }
-    
-    // Calculate new GameDate
-    gd := calculateGameDate(roundNumber)
-    
-    // Cache for future lookups
-    roundDateCache[roundNumber] = gd
-    
-    return gd
-}
+func GetDate(roundNumber uint64) GameDate
 
-func calculateGameDate(roundNumber uint64) GameDate {
-    // Complex calculation involving:
-    // - Rounds per day configuration
-    // - Calendar math for year/month/day
-    // - Time of day calculation
-    // - Day/night cycle determination
-    
-    return gameDate
-}
+func calculateGameDate(roundNumber uint64) GameDate
 ```
 
 ## Zodiac System
@@ -229,36 +155,17 @@ func calculateGameDate(roundNumber uint64) GameDate {
 ```go
 var zodiacAnimals = []string{
     // Real animals
-    "Aardvark", "Albatross", "Alligator", "Alpaca", "Ant", "Antelope",
-    "Baboon", "Badger", "Bear", "Beaver", "Bee", "Beetle", "Bison",
-    "Boar", "Buffalo", "Butterfly", "Camel", "Cat", "Cheetah", "Chicken",
-    
+    "Aardvark", "Albatross", "Alligator", ...
     // Fantasy creatures
-    "Amphiptere", "Basilisk", "Centaur", "Cerberus", "Chimera", "Cockatrice",
-    "Cyclops", "Dragon", "Dryad", "Fairy", "Firebird", "Gargoyle", "Griffin",
-    "Harpy", "Hippogriff", "Hydra", "Ifrit", "Jabberwocky", "Kraken", "Lamia",
-    "Leviathan", "Manticore", "Medusa", "Mermaid", "Minotaur", "Naga", "Nymph",
-    "Ogre", "Pegasus", "Phoenix", "Pixie", "Poltergeist", "Questing Beast", "Roc",
-    
+    "Amphiptere", "Basilisk", "Centaur", ...
     // And 190+ more creatures...
 }
 
 // Get zodiac animal for specific year
-func GetZodiac(year int) string {
-    if !randomized {
-        randomizeZodiac()
-    }
-    return zodiacAnimals[year%len(zodiacAnimals)]
-}
+func GetZodiac(year int) string
 
 // Seeded randomization for consistent server-wide zodiac order
-func randomizeZodiac() {
-    r := rand.New(rand.NewSource(configs.GetConfig().SeedInt()))
-    r.Shuffle(len(zodiacAnimals), func(i, j int) { 
-        zodiacAnimals[i], zodiacAnimals[j] = zodiacAnimals[j], zodiacAnimals[i] 
-    })
-    randomized = true
-}
+func randomizeZodiac()
 ```
 
 ## Time Manipulation and Events
@@ -266,64 +173,19 @@ func randomizeZodiac() {
 ### Day/Night Cycle Control
 ```go
 // Jump to next night period
-func SetToNight(roundAdjustment ...int) {
-    // Find last sunset
-    dayRound := GetLastPeriod("sunset", util.GetRoundCount())
-    
-    // Apply optional round adjustment
-    if len(roundAdjustment) > 0 {
-        if roundAdjustment[0] < 0 {
-            dayRound -= uint64(-1 * roundAdjustment[0])
-        } else {
-            dayRound += uint64(roundAdjustment[0])
-        }
-    }
-    
-    // Advance to next night and update game time
-    gd := GetDate(dayRound).Add(0, 1, 0) // Add 1 day
-    util.SetRoundCount(gd.RoundNumber)
-}
+func SetToNight(roundAdjustment ...int)
 
 // Jump to next day period
-func SetToDay(roundAdjustment ...int) {
-    // Find last sunrise
-    nightRound := GetLastPeriod("sunrise", util.GetRoundCount())
-    
-    // Apply adjustment and advance time
-    if len(roundAdjustment) > 0 {
-        nightRound += uint64(roundAdjustment[0])
-    }
-    
-    gd := GetDate(nightRound).Add(0, 1, 0)
-    util.SetRoundCount(gd.RoundNumber)
-}
+func SetToDay(roundAdjustment ...int)
 ```
 
 ### Time-Based Event Integration
 ```go
 // Check for day/night transitions
-func CheckDayNightTransition(previousRound, currentRound uint64) (bool, string) {
-    prevDate := GetDate(previousRound)
-    currDate := GetDate(currentRound)
-    
-    // Detect transitions
-    if !prevDate.Night && currDate.Night {
-        return true, "sunset"
-    } else if prevDate.Night && !currDate.Night {
-        return true, "sunrise"
-    }
-    
-    return false, ""
-}
+func CheckDayNightTransition(previousRound, currentRound uint64) (bool, string)
 
 // Schedule time-based events
-func ScheduleTimeEvent(eventType string, targetTime GameDate) {
-    events.AddToQueue(events.TimeEvent{
-        EventType:   eventType,
-        TargetRound: targetTime.RoundNumber,
-        GameDate:    targetTime,
-    })
-}
+func ScheduleTimeEvent(eventType string, targetTime GameDate)
 ```
 
 ## Integration Patterns
@@ -441,20 +303,9 @@ if gameDate.Night {
 ### Administrative Time Control
 ```go
 // Admin command to set time
-func AdminSetNight() {
-    gametime.SetToNight()
-    broadcastMessage("An administrator has brought forth the night!")
-}
-
-func AdminSetDay() {
-    gametime.SetToDay()
-    broadcastMessage("An administrator has summoned the dawn!")
-}
-
-// Set specific time with adjustment
-func AdminSetTime(adjustment int) {
-    gametime.SetToNight(adjustment) // Set to night with round offset
-}
+func AdminSetNight()
+func AdminSetDay()
+func AdminSetTime(adjustment int)
 ```
 
 ## Dependencies

--- a/internal/hooks/NewTurn_CleanupLinkDead.go
+++ b/internal/hooks/NewTurn_CleanupLinkDead.go
@@ -9,11 +9,11 @@ import (
 )
 
 //
-// Cleans up zombie users
-// Zombie users are users who have disconnected but their user/character is still in game.
+// Cleans up link-dead users
+// Link-dead users are users who have disconnected but their user/character is still in game.
 //
 
-func CleanupZombies(e events.Event) events.ListenerReturn {
+func CleanupLinkDead(e events.Event) events.ListenerReturn {
 
 	evt, typeOk := e.(events.NewTurn)
 	if !typeOk {
@@ -24,21 +24,21 @@ func CleanupZombies(e events.Event) events.ListenerReturn {
 	et := configs.GetTimingConfig()
 	gp := configs.GetNetworkConfig()
 
-	expTurns := uint64(et.SecondsToTurns(int(gp.ZombieSeconds)))
+	expTurns := uint64(et.SecondsToTurns(int(gp.LinkDeadSeconds)))
 
 	if expTurns < evt.TurnNumber {
 
-		expZombies := users.GetExpiredZombies(evt.TurnNumber - expTurns)
+		expired := users.GetExpiredLinkDeadUsers(evt.TurnNumber - expTurns)
 
-		if len(expZombies) > 0 {
+		if len(expired) > 0 {
 
-			mudlog.Info("Expired Zombies", "count", len(expZombies))
+			mudlog.Info("Expired Link-Dead Users", "count", len(expired))
 
-			for _, userId := range expZombies {
+			for _, userId := range expired {
 				events.AddToQueue(events.System{
 					Command:     `leaveworld`,
 					Data:        userId,
-					Description: `Zombie Expired`,
+					Description: `Link-Dead Expired`,
 				})
 			}
 

--- a/internal/hooks/PlayerDespawn_HandleLeave.go
+++ b/internal/hooks/PlayerDespawn_HandleLeave.go
@@ -35,9 +35,9 @@ func HandleLeave(e events.Event) events.ListenerReturn {
 
 	connId := user.ConnectionId()
 
-	// Remove any zombie tracking for the user since they've been despawned from the world.
-	if users.IsZombieConnection(connId) {
-		users.RemoveZombieUser(evt.UserId)
+	// Remove any link-dead tracking for the user since they've been despawned from the world.
+	if users.IsLinkDeadConnection(connId) {
+		users.RemoveLinkDeadUser(evt.UserId)
 	}
 
 	room := rooms.LoadRoom(user.Character.RoomId)

--- a/internal/hooks/PlayerSpawn_HandleJoin.go
+++ b/internal/hooks/PlayerSpawn_HandleJoin.go
@@ -31,7 +31,7 @@ func HandleJoin(e events.Event) events.ListenerReturn {
 
 	user.EventLog.Add(`conn`, fmt.Sprintf(`<ansi fg="username">%s</ansi> entered the world`, user.Character.Name))
 
-	users.RemoveZombieUser(evt.UserId)
+	users.RemoveLinkDeadUser(evt.UserId)
 
 	room := rooms.LoadRoom(user.Character.RoomId)
 	sendResetMessage := false

--- a/internal/hooks/context.md
+++ b/internal/hooks/context.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The GoMud hooks system provides comprehensive event-driven game logic through a collection of 39 specialized event listeners that handle everything from combat rounds to quest progression. It serves as the primary integration layer between the event system and game mechanics, implementing core gameplay features like combat resolution, mob AI, player lifecycle management, and system maintenance tasks.
+The GoMud hooks system provides comprehensive event-driven game logic through a collection of specialized event listeners that handle everything from combat rounds to quest progression. It serves as the primary integration layer between the event system and game mechanics, implementing core gameplay features like combat resolution, mob AI, player lifecycle management, and system maintenance tasks.
 
 > **Note:** This package (`internal/hooks`) contains *event listeners* - asynchronous, fire-and-forget handlers wired to the event queue. It is distinct from the synchronous `util.Hook[T]` callback chain described below, which is used when a caller needs to receive a modified return value.
 
@@ -26,14 +26,14 @@ The hooks system is built around several key categories:
 **Event Registration System:**
 - Centralized listener registration in `RegisterListeners()`
 - Type-safe event handling with proper casting
-- Ordered execution with priority support (events.Last)
+- Ordered execution with priority support (`events.Last`)
 - Comprehensive coverage of all game events
 
 **Game Loop Hooks:**
 - **NewRound Events**: Combat, healing, mob AI, player ticks
 - **NewTurn Events**: Autosave, cleanup, buff management
 - **Player Lifecycle**: Spawn, despawn, character changes
-- **System Maintenance**: VM pruning, zombie cleanup, respawns
+- **System Maintenance**: VM pruning, link-dead cleanup, respawns
 
 **Gameplay Integration:**
 - **Combat System**: Full combat round processing with multi-target support
@@ -41,359 +41,125 @@ The hooks system is built around several key categories:
 - **Buff System**: Application, expiration, and effect processing
 - **Audio System**: MSP sound effects and location-based music
 
-## Key Features
+## Complete Listener Registration
 
-### 1. **Comprehensive Game Loop Management**
-- **Round Processing**: 15 different NewRound event handlers
-- **Turn Processing**: 4 NewTurn event handlers for maintenance
-- **Combat Integration**: Complete combat round resolution
-- **Mob AI Processing**: Idle behavior and action execution
+All listeners are registered in `RegisterListeners()` in `hooks.go`:
 
-### 2. **Player Lifecycle Management**
-- **Join/Leave Handling**: Player spawn and despawn processing
-- **Character Updates**: Broadcasting character changes
-- **Level Progression**: Level-up notifications and guide spawning
-- **Connection Management**: Zombie cleanup and inactive player handling
-
-### 3. **Quest and Progression Systems**
-- **Quest Processing**: Multi-step quest advancement and rewards
-- **Item Integration**: Quest item requirements and rewards
-- **Skill Advancement**: Skill-based quest completion
-- **Experience Distribution**: Level-up rewards and notifications
-
-### 4. **System Maintenance and Optimization**
-- **Automatic Cleanup**: Zombie connections, expired buffs, ephemeral rooms
-- **Resource Management**: VM pruning, memory optimization
-- **Data Persistence**: Automatic user saves and data integrity
-- **Performance Monitoring**: Event processing and system health
-
-## Event Listener Categories
-
-### NewRound Event Handlers (15 handlers)
+### Buff Handlers
 ```go
-// Core game loop processing every round
-events.RegisterListener(events.NewRound{}, PruneVMs)              // Clean up JavaScript VMs
-events.RegisterListener(events.NewRound{}, InactivePlayers)       // Handle AFK players
-events.RegisterListener(events.NewRound{}, UpdateZoneMutators)    // Update zone effects
-events.RegisterListener(events.NewRound{}, CheckNewDay)           // Day/night cycle
-events.RegisterListener(events.NewRound{}, SpawnLootGoblin)       // Special mob spawning
-events.RegisterListener(events.NewRound{}, UserRoundTick)         // Player round processing
-events.RegisterListener(events.NewRound{}, MobRoundTick)          // NPC round processing
-events.RegisterListener(events.NewRound{}, HandleRespawns)        // Mob respawning
-events.RegisterListener(events.NewRound{}, DoCombat)              // Combat resolution
-events.RegisterListener(events.NewRound{}, AutoHeal)              // Natural healing
-events.RegisterListener(events.NewRound{}, IdleMobs)              // Mob idle behavior
+events.RegisterListener(events.Buff{}, ApplyBuffs)
 ```
 
-### NewTurn Event Handlers (4 handlers)
+### RoomChange Handlers
 ```go
-// System maintenance every turn (multiple rounds)
-events.RegisterListener(events.NewTurn{}, CleanupZombies)         // Remove disconnected users
-events.RegisterListener(events.NewTurn{}, AutoSave)               // Automatic data saves
-events.RegisterListener(events.NewTurn{}, PruneBuffs)             // Remove expired buffs
-events.RegisterListener(events.NewTurn{}, ActionPoints)           // Regenerate action points
+events.RegisterListener(events.RoomChange{}, LocationMusicChange)
+events.RegisterListener(events.RoomChange{}, CleanupEphemeralRooms)
+events.RegisterListener(events.RoomChange{}, SpawnGuide)
+```
+
+### NewRound Handlers (11 handlers)
+```go
+events.RegisterListener(events.NewRound{}, PruneVMs)
+events.RegisterListener(events.NewRound{}, InactivePlayers)
+events.RegisterListener(events.NewRound{}, UpdateZoneMutators)
+events.RegisterListener(events.NewRound{}, CheckNewDay)
+events.RegisterListener(events.NewRound{}, SpawnLootGoblin)
+events.RegisterListener(events.NewRound{}, UserRoundTick)
+events.RegisterListener(events.NewRound{}, MobRoundTick)
+events.RegisterListener(events.NewRound{}, HandleRespawns)
+events.RegisterListener(events.NewRound{}, DoCombat)   // Combat goes here
+events.RegisterListener(events.NewRound{}, AutoHeal)
+events.RegisterListener(events.NewRound{}, IdleMobs)
+events.RegisterListener(events.MobIdle{}, HandleIdleMobs)
+```
+
+### NewTurn Handlers (4 handlers)
+```go
+events.RegisterListener(events.NewTurn{}, CleanupLinkDead)
+events.RegisterListener(events.NewTurn{}, AutoSave)
+events.RegisterListener(events.NewTurn{}, PruneBuffs)
+events.RegisterListener(events.NewTurn{}, ActionPoints)
 ```
 
 ### Player Lifecycle Handlers
 ```go
-// Player connection and character management
-events.RegisterListener(events.PlayerSpawn{}, HandleJoin)         // Player login processing
-events.RegisterListener(events.PlayerDespawn{}, HandleLeave, events.Last) // Player logout (final)
-events.RegisterListener(events.PlayerDrop{}, HandlePlayerDrop)    // Unexpected disconnection
-events.RegisterListener(events.CharacterCreated{}, BroadcastNewChar) // New character announcements
-events.RegisterListener(events.CharacterChanged{}, BroadcastNewChar) // Character update announcements
+events.RegisterListener(events.PlayerSpawn{}, HandleJoin)
+events.RegisterListener(events.PlayerDespawn{}, HandleLeave, events.Last) // final listener
+events.RegisterListener(events.PlayerDrop{}, HandlePlayerDrop)
+events.RegisterListener(events.CharacterCreated{}, BroadcastNewChar)
+events.RegisterListener(events.CharacterChanged{}, BroadcastNewChar)
 ```
 
 ### Game Mechanics Handlers
 ```go
-// Core gameplay systems
-events.RegisterListener(events.Quest{}, HandleQuestUpdate)        // Quest progression
-events.RegisterListener(events.Buff{}, ApplyBuffs)               // Buff application
-events.RegisterListener(events.LevelUp{}, SendLevelNotifications) // Level-up messages
-events.RegisterListener(events.LevelUp{}, CheckGuide)             // Guide NPC spawning
-events.RegisterListener(events.ItemOwnership{}, CheckItemQuests)  // Item-based quests
-events.RegisterListener(events.MobIdle{}, HandleIdleMobs)         // Mob AI behavior
+events.RegisterListener(events.ItemOwnership{}, CheckItemQuests)
+events.RegisterListener(events.MSP{}, PlaySound)
+events.RegisterListener(events.Quest{}, HandleQuestUpdate)
+events.RegisterListener(events.LevelUp{}, SendLevelNotifications)
+events.RegisterListener(events.LevelUp{}, CheckGuide)
+events.RegisterListener(events.DayNightCycle{}, NotifySunriseSunset)
+events.RegisterListener(events.Looking{}, HandleLookHints)
 ```
 
-## Combat System Integration
-
-### Combat Round Processing
+### Messaging and UI Handlers
 ```go
-func DoCombat(e events.Event) events.ListenerReturn {
-    evt := e.(events.NewRound)
-    
-    // Process all active combat encounters
-    for _, user := range users.GetAllActiveUsers() {
-        if user.Character.IsAggro() {
-            // Handle player combat
-            processCombatRound(user)
-        }
-    }
-    
-    // Process mob vs mob combat
-    for _, mobInstanceId := range mobs.GetAllMobInstanceIds() {
-        mob := mobs.GetInstance(mobInstanceId)
-        if mob != nil && mob.Character.IsAggro() {
-            processMobCombat(mob)
-        }
-    }
-    
-    return events.Continue
-}
-
-// Combat processing includes:
-// - Multi-target combat resolution
-// - Weapon durability and breakage
-// - Death handling and consequences
-// - Experience and loot distribution
-// - Combat state management
+events.RegisterListener(events.Message{}, Message_SendMessage)
+events.RegisterListener(events.RedrawPrompt{}, RedrawPrompt_SendRedraw)
+events.RegisterListener(events.UserSettingChanged{}, ClearSettingCaches)
+events.RegisterListener(events.WebClientCommand{}, WebClientCommand_SendWebClientCommand)
+events.RegisterListener(events.Broadcast{}, Broadcast_SendToAll)
 ```
 
-## Quest System Integration
-
-### Quest Progress Handling
+### System Handlers
 ```go
-func HandleQuestUpdate(e events.Event) events.ListenerReturn {
-    evt := e.(events.Quest)
-    
-    user := users.GetByUserId(evt.UserId)
-    if user == nil {
-        return events.Cancel
-    }
-    
-    // Validate quest progression
-    if !quests.IsTokenAfter(user.Character.GetCurrentQuestToken(), evt.QuestToken) {
-        return events.Cancel
-    }
-    
-    // Update quest progress
-    user.Character.SetQuestFlag(evt.QuestToken)
-    
-    // Check for quest completion
-    quest := quests.GetQuest(evt.QuestToken)
-    if quest != nil && isQuestComplete(quest, evt.QuestToken) {
-        distributeQuestRewards(user, quest)
-    }
-    
-    return events.Continue
-}
-
-// Quest processing includes:
-// - Multi-step quest validation
-// - Item requirement checking
-// - Skill-based quest completion
-// - Reward distribution (gold, items, experience, skills)
-// - Chained quest activation
+events.RegisterListener(events.RebuildMap{}, HandleMapRebuild)
+events.RegisterListener(events.Log{}, FollowLogs)
 ```
 
-## Player Lifecycle Management
+## Handler Files
 
-### Player Join Processing
-```go
-func HandleJoin(e events.Event) events.PlayerSpawn {
-    evt := e.(events.PlayerSpawn)
-    
-    user := users.GetByUserId(evt.UserId)
-    if user == nil {
-        return events.Cancel
-    }
-    
-    // Execute join scripts
-    if room := rooms.LoadRoom(user.Character.RoomId); room != nil {
-        if room.HasScript() {
-            scripting.TryRoomScriptEvent("onPlayerEnter", room.RoomId, evt.UserId, 0)
-        }
-    }
-    
-    // Handle first-time login
-    if user.Character.Level == 1 && user.Character.Experience == 0 {
-        handleNewPlayerSetup(user)
-    }
-    
-    // Broadcast join message
-    broadcastPlayerJoin(user)
-    
-    return events.Continue
-}
-```
+Each listener is implemented in its own file, named `EventType_HandlerName.go`:
 
-### Player Leave Processing
-```go
-func HandleLeave(e events.Event) events.ListenerReturn {
-    evt := e.(events.PlayerDespawn)
-    
-    user := users.GetByUserId(evt.UserId)
-    if user == nil {
-        return events.Cancel
-    }
-    
-    // Save user data
-    if err := user.Save(); err != nil {
-        mudlog.Error("HandleLeave", "userId", evt.UserId, "error", err)
-    }
-    
-    // Clean up combat state
-    user.Character.ClearAggro()
-    
-    // Execute leave scripts
-    if room := rooms.LoadRoom(user.Character.RoomId); room != nil {
-        if room.HasScript() {
-            scripting.TryRoomScriptEvent("onPlayerLeave", room.RoomId, evt.UserId, 0)
-        }
-    }
-    
-    // Broadcast leave message
-    broadcastPlayerLeave(user)
-    
-    return events.Continue
-}
-```
-
-## System Maintenance Hooks
-
-### Automatic Cleanup
-```go
-// Zombie connection cleanup
-func CleanupZombies(e events.Event) events.ListenerReturn {
-    evt := e.(events.NewTurn)
-    
-    expirationTurn := evt.TurnNumber - configs.GetNetworkConfig().LogoutRounds
-    expiredZombies := users.GetExpiredZombies(expirationTurn)
-    
-    for _, userId := range expiredZombies {
-        user := users.GetByUserId(userId)
-        if user != nil {
-            user.Save()
-            users.RemoveUser(userId)
-        }
-    }
-    
-    return events.Continue
-}
-
-// Buff expiration management
-func PruneBuffs(e events.Event) events.ListenerReturn {
-    evt := e.(events.NewTurn)
-    
-    // Prune user buffs
-    for _, user := range users.GetAllActiveUsers() {
-        prunedBuffs := user.Character.Buffs.Prune()
-        for _, buff := range prunedBuffs {
-            notifyBuffExpiration(user, buff)
-        }
-    }
-    
-    // Prune mob buffs
-    for _, mobInstanceId := range mobs.GetAllMobInstanceIds() {
-        mob := mobs.GetInstance(mobInstanceId)
-        if mob != nil {
-            mob.Character.Buffs.Prune()
-        }
-    }
-    
-    return events.Continue
-}
-```
-
-### Automatic Saves
-```go
-func AutoSave(e events.Event) events.ListenerReturn {
-    evt := e.(events.NewTurn)
-    
-    // Save all active users periodically
-    if evt.TurnNumber%configs.GetGamePlayConfig().AutoSaveFrequency == 0 {
-        for _, user := range users.GetAllActiveUsers() {
-            if err := user.Save(); err != nil {
-                mudlog.Error("AutoSave", "userId", user.UserId, "error", err)
-            }
-        }
-    }
-    
-    return events.Continue
-}
-```
-
-## Audio and Visual Effects
-
-### MSP Sound System
-```go
-func PlaySound(e events.Event) events.ListenerReturn {
-    evt := e.(events.MSP)
-    
-    user := users.GetByUserId(evt.UserId)
-    if user == nil || !user.ClientSettings().IsMsp() {
-        return events.Continue
-    }
-    
-    // Send MSP sound command
-    soundCommand := fmt.Sprintf("!!SOUND(%s)", evt.SoundFile)
-    user.SendText(soundCommand)
-    
-    return events.Continue
-}
-
-// Location-based music changes
-func LocationMusicChange(e events.Event) events.ListenerReturn {
-    evt := e.(events.RoomChange)
-    
-    user := users.GetByUserId(evt.UserId)
-    if user == nil {
-        return events.Continue
-    }
-    
-    room := rooms.LoadRoom(evt.RoomId)
-    if room != nil && room.MusicFile != "" {
-        if user.LastMusic != room.MusicFile {
-            user.PlayMusic(room.MusicFile)
-            user.LastMusic = room.MusicFile
-        }
-    }
-    
-    return events.Continue
-}
-```
-
-## Mob AI and Behavior
-
-### Idle Mob Processing
-```go
-func IdleMobs(e events.Event) events.ListenerReturn {
-    evt := e.(events.NewRound)
-    
-    for _, mobInstanceId := range mobs.GetAllMobInstanceIds() {
-        mob := mobs.GetInstance(mobInstanceId)
-        if mob == nil || mob.Character.IsAggro() {
-            continue
-        }
-        
-        // Check activity level for idle behavior
-        if util.Rand(100) < mob.ActivityLevel {
-            events.AddToQueue(events.MobIdle{
-                MobInstanceId: mobInstanceId,
-            })
-        }
-    }
-    
-    return events.Continue
-}
-
-func HandleIdleMobs(e events.Event) events.ListenerReturn {
-    evt := e.(events.MobIdle)
-    
-    mob := mobs.GetInstance(evt.MobInstanceId)
-    if mob == nil {
-        return events.Continue
-    }
-    
-    // Execute idle command
-    idleCommand := mob.GetIdleCommand()
-    if idleCommand != "" {
-        mob.Command(idleCommand)
-    }
-    
-    return events.Continue
-}
-```
+| File | Event | Handler |
+|------|-------|---------|
+| `Buff_ApplyBuffs.go` | `Buff` | `ApplyBuffs` |
+| `RoomChange_LocationMusicChange.go` | `RoomChange` | `LocationMusicChange` |
+| `RoomChange_CleanupEphemeralRooms.go` | `RoomChange` | `CleanupEphemeralRooms` |
+| `RoomChange_SpawnGuide.go` | `RoomChange` | `SpawnGuide` |
+| `NewRound_PruneVMs.go` | `NewRound` | `PruneVMs` |
+| `NewRound_InactivePlayers.go` | `NewRound` | `InactivePlayers` |
+| `NewRound_UpdateZoneMutators.go` | `NewRound` | `UpdateZoneMutators` |
+| `NewRound_CheckNewDay.go` | `NewRound` | `CheckNewDay` |
+| `NewRound_SpawnLootGoblin.go` | `NewRound` | `SpawnLootGoblin` |
+| `NewRound_UserRoundTick.go` | `NewRound` | `UserRoundTick` |
+| `NewRound_MobRoundTick.go` | `NewRound` | `MobRoundTick` |
+| `NewRound_HandleRespawns.go` | `NewRound` | `HandleRespawns` |
+| `NewRound_DoCombat.go` | `NewRound` | `DoCombat` |
+| `NewRound_AutoHeal.go` | `NewRound` | `AutoHeal` |
+| `NewRound_IdleMobs.go` | `NewRound` | `IdleMobs` |
+| `MobIdle_HandleIdleMobs.go` | `MobIdle` | `HandleIdleMobs` |
+| `NewTurn_CleanupLinkDead.go` | `NewTurn` | `CleanupLinkDead` |
+| `NewTurn_AutoSave.go` | `NewTurn` | `AutoSave` |
+| `NewTurn_PruneBuffs.go` | `NewTurn` | `PruneBuffs` |
+| `NewTurn_ActionPoints.go` | `NewTurn` | `ActionPoints` |
+| `ItemOwnership_CheckItemQuests.go` | `ItemOwnership` | `CheckItemQuests` |
+| `MSP_PlaySound.go` | `MSP` | `PlaySound` |
+| `Quest_HandleQuestUpdate.go` | `Quest` | `HandleQuestUpdate` |
+| `PlayerSpawn_HandleJoin.go` | `PlayerSpawn` | `HandleJoin` |
+| `PlayerDespawn_HandleLeave.go` | `PlayerDespawn` | `HandleLeave` |
+| `PlayerDrop_HandlePlayerDrop.go` | `PlayerDrop` | `HandlePlayerDrop` |
+| `LevelUp_SendLevelNotifications.go` | `LevelUp` | `SendLevelNotifications` |
+| `LevelUp_CheckGuide.go` | `LevelUp` | `CheckGuide` |
+| `DayNightCycle_NotifySunriseSunset.go` | `DayNightCycle` | `NotifySunriseSunset` |
+| `Looking_HandleLookHints.go` | `Looking` | `HandleLookHints` |
+| `Message_SendMessages.go` | `Message` | `Message_SendMessage` |
+| `RedrawPrompt_SendRedraw.go` | `RedrawPrompt` | `RedrawPrompt_SendRedraw` |
+| `UserSettingChanged_ClearSettingCaches.go` | `UserSettingChanged` | `ClearSettingCaches` |
+| `WebClientCommand_SendWebClientCommand.go` | `WebClientCommand` | `WebClientCommand_SendWebClientCommand` |
+| `CharacterCreated_BroadcastNewChar.go` | `CharacterCreated` | `BroadcastNewChar` |
+| `Broadcast_SendToAll.go` | `Broadcast` | `Broadcast_SendToAll` |
+| `RebuildMap_HandleMapRebuild.go` | `RebuildMap` | `HandleMapRebuild` |
+| `Log_FollowLogs.go` | `Log` | `FollowLogs` |
 
 ## Integration Patterns
 
@@ -402,7 +168,8 @@ func HandleIdleMobs(e events.Event) events.ListenerReturn {
 // All hooks integrate with the event system
 - events.RegisterListener()        // Register event handlers
 - events.AddToQueue()             // Queue new events from handlers
-- events.Continue/Cancel          // Control event processing flow
+- events.Continue / events.Cancel // Control event processing flow
+- events.Last                     // Priority flag: run this listener last
 ```
 
 ### Cross-System Communication
@@ -413,71 +180,6 @@ func HandleIdleMobs(e events.Event) events.ListenerReturn {
 - mobs.GetInstance()              // Mob system integration
 - combat.AttackPlayerVsMob()      // Combat system integration
 - scripting.TryRoomScriptEvent()  // Scripting system integration
-```
-
-## Usage Examples
-
-### Custom Hook Registration
-```go
-// Register custom event listener
-func RegisterCustomHook() {
-    events.RegisterListener(events.CustomEvent{}, func(e events.Event) events.ListenerReturn {
-        evt := e.(events.CustomEvent)
-        
-        // Custom processing logic
-        processCustomEvent(evt)
-        
-        return events.Continue
-    })
-}
-```
-
-### Event Processing Flow
-```go
-// Example of event flow through hooks
-// 1. Player attacks mob
-events.AddToQueue(events.Combat{
-    AttackerId: userId,
-    TargetId:   mobInstanceId,
-})
-
-// 2. Combat hook processes attack
-func DoCombat(e events.Event) events.ListenerReturn {
-    // Resolve combat
-    result := combat.AttackPlayerVsMob(user, mob)
-    
-    // Check for death
-    if mob.Character.Health <= 0 {
-        events.AddToQueue(events.MobDeath{
-            MobInstanceId: mobInstanceId,
-            KillerId:      userId,
-        })
-    }
-    
-    return events.Continue
-}
-```
-
-### System Maintenance
-```go
-// Hooks handle automatic system maintenance
-func SystemMaintenance(e events.Event) events.ListenerReturn {
-    evt := e.(events.NewTurn)
-    
-    // Periodic maintenance tasks
-    if evt.TurnNumber%100 == 0 {
-        // Clean up resources
-        cleanupExpiredData()
-        
-        // Optimize performance
-        optimizeMemoryUsage()
-        
-        // Update statistics
-        updateSystemStats()
-    }
-    
-    return events.Continue
-}
 ```
 
 ## Dependencies
@@ -492,5 +194,3 @@ func SystemMaintenance(e events.Event) events.ListenerReturn {
 - `internal/buffs` - Status effects for buff management
 - `internal/configs` - Configuration management for system settings
 - `internal/mudlog` - Logging system for debugging and monitoring
-
-This comprehensive hooks system provides the core game logic implementation through event-driven architecture, handling everything from basic gameplay mechanics to complex system maintenance tasks while maintaining clean separation of concerns and extensible design patterns.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -36,7 +36,7 @@ func RegisterListeners() {
 	events.RegisterListener(events.MobIdle{}, HandleIdleMobs)
 
 	// Turn Hooks
-	events.RegisterListener(events.NewTurn{}, CleanupZombies)
+	events.RegisterListener(events.NewTurn{}, CleanupLinkDead)
 	events.RegisterListener(events.NewTurn{}, AutoSave)
 	events.RegisterListener(events.NewTurn{}, PruneBuffs)
 	events.RegisterListener(events.NewTurn{}, ActionPoints)

--- a/internal/inputhandlers/context.md
+++ b/internal/inputhandlers/context.md
@@ -178,13 +178,7 @@ if strings.HasPrefix(input, "/") {
 ### Input Validation
 ```go
 // Custom validation function
-func validateEmail(input string, results map[string]string) (string, error) {
-    input = strings.TrimSpace(input)
-    if _, err := mail.ParseAddress(input); err != nil {
-        return "", errors.New("invalid email format")
-    }
-    return input, nil
-}
+func validateEmail(input string, results map[string]string) (string, error)
 ```
 
 ## Integration Points

--- a/internal/inputhandlers/login.go
+++ b/internal/inputhandlers/login.go
@@ -39,7 +39,7 @@ func FinalizeLoginOrCreate(results map[string]string, sharedState map[string]any
 				tplTxt, _ := templates.Process("goodbye", nil)
 				connections.SendTo([]byte(templates.AnsiParse(tplTxt)), existingConnectionId)
 
-				users.SetZombieUser(userid)
+				users.SetLinkDeadUser(userid)
 				connections.Kick(existingConnectionId, fmt.Sprintf(`Duplicate login (ip: %s)`, connDetails.RemoteAddr()))
 
 			}

--- a/internal/items/context.md
+++ b/internal/items/context.md
@@ -174,52 +174,19 @@ type Damage struct {
 ### Item Creation and Validation
 ```go
 // Create new item instance
-func New(itemId int) Item {
-    itemSpec := GetItemSpec(itemId)
-    newItm := Item{
-        UUID:   uuid.New(UUIDItem),
-        ItemId: itemId,
-        Uses:   itemSpec.Uses,
-    }
-    newItm.Validate()
-    return newItm
-}
+func New(itemId int) Item
 
 // Item validation ensures consistency
-func (i *Item) Validate() {
-    if i.UUID.IsNil() {
-        i.UUID = uuid.New(UUIDItem)
-    }
-    
-    iSpec := i.GetSpec()
-    if i.Uses == 0 && iSpec.Uses > 0 {
-        i.Uses = iSpec.Uses
-    }
-}
+func (i *Item) Validate()
 ```
 
 ### Item Identification and Matching
 ```go
 // Multiple identification methods
-func (i *Item) ShorthandId() string {
-    return fmt.Sprintf("!%d:%s", i.ItemId, i.UUID.String())
-}
+func (i *Item) ShorthandId() string
 
 // Name matching with partial and full match support
-func (i *Item) NameMatch(input string, allowContains bool) (partialMatch bool, fullMatch bool) {
-    input = strings.ToLower(input)
-    simpleName := strings.ToLower(i.Name())
-    
-    if allowContains && strings.Contains(simpleName, input) {
-        return true, simpleName == input
-    }
-    
-    if strings.HasPrefix(simpleName, input) {
-        return true, simpleName == input
-    }
-    
-    return false, false
-}
+func (i *Item) NameMatch(input string, allowContains bool) (partialMatch bool, fullMatch bool)
 ```
 
 ## Enchantment and Modification System
@@ -227,74 +194,20 @@ func (i *Item) NameMatch(input string, allowContains bool) (partialMatch bool, f
 ### Dynamic Item Enhancement
 ```go
 // Enchant item with bonuses
-func (i *Item) Enchant(damageBonus int, defenseBonus int, statBonus map[string]int, cursed bool) {
-    var newSpec ItemSpec
-    
-    if i.Spec == nil {
-        specCopy := *GetItemSpec(i.ItemId)
-        newSpec = specCopy
-    } else {
-        newSpec = *i.Spec
-    }
-    
-    // Apply enhancements
-    newSpec.Damage.BonusDamage += damageBonus
-    newSpec.DamageReduction += defenseBonus
-    
-    for statName, statBonusAmt := range statBonus {
-        newSpec.StatMods.Add(statName, statBonusAmt)
-    }
-    
-    i.Enchantments++
-    newSpec.Cursed = cursed
-    newSpec.AutoCalculateValue()
-    
-    i.Spec = &newSpec
-}
+func (i *Item) Enchant(damageBonus int, defenseBonus int, statBonus map[string]int, cursed bool)
 
 // Curse management
-func (i *Item) IsCursed() bool {
-    return i.GetSpec().Cursed && !i.Uncursed
-}
-
-func (i *Item) Uncurse() {
-    i.Uncursed = true
-}
+func (i *Item) IsCursed() bool
+func (i *Item) Uncurse()
 ```
 
 ### Adjective System
 ```go
 // Visual effects through adjectives
-func (i *Item) SetAdjective(adj string, addToList bool) {
-    if i.Adjectives == nil {
-        i.Adjectives = []string{}
-    }
-    
-    for idx, a := range i.Adjectives {
-        if a == adj {
-            if !addToList {
-                i.Adjectives = append(i.Adjectives[:idx], i.Adjectives[idx+1:]...)
-            }
-            return
-        }
-    }
-    
-    if addToList {
-        i.Adjectives = append(i.Adjectives, adj)
-    }
-}
+func (i *Item) SetAdjective(adj string, addToList bool)
 
 // Display name with adjectives
-func (i *Item) DisplayName() string {
-    name := i.GetSpec().Name
-    
-    if len(i.Adjectives) > 0 {
-        suffix := " <ansi fg=\"black-bold\">(" + strings.Join(i.Adjectives, "|") + ")</ansi>"
-        name += suffix
-    }
-    
-    return name
-}
+func (i *Item) DisplayName() string
 ```
 
 ## Combat Message System
@@ -323,35 +236,10 @@ type TogetherMessages struct {
 ### Message Selection and Token Replacement
 ```go
 // Get attack message based on damage percentage
-func GetAttackMessage(subType ItemSubType, pctDamage int) AttackOptions {
-    var intensity Intensity
-    if pctDamage >= 101 {
-        intensity = Critical
-    } else if pctDamage >= 75 {
-        intensity = Heavy
-    } else if pctDamage >= 30 {
-        intensity = Normal
-    } else if pctDamage >= 1 {
-        intensity = Weak
-    } else {
-        intensity = Miss
-    }
-    
-    // Get messages for weapon subtype and intensity
-    if attackMsgOptions, ok := attackMessages[subType]; ok {
-        if messages, ok := attackMsgOptions.Options[intensity]; ok {
-            return messages
-        }
-    }
-    
-    // Fallback to generic messages
-    return GetAttackMessage(Generic, pctDamage)
-}
+func GetAttackMessage(subType ItemSubType, pctDamage int) AttackOptions
 
 // Token replacement in messages
-func (am ItemMessage) SetTokenValue(tokenName TokenName, tokenValue string) ItemMessage {
-    return ItemMessage(strings.Replace(string(am), string(tokenName), tokenValue, -1))
-}
+func (am ItemMessage) SetTokenValue(tokenName TokenName, tokenValue string) ItemMessage
 ```
 
 ## Durability and Usage System
@@ -359,32 +247,10 @@ func (am ItemMessage) SetTokenValue(tokenName TokenName, tokenValue string) Item
 ### Break Mechanics
 ```go
 // Break chance testing
-func (i *Item) BreakTest(increaseChance ...int) bool {
-    bc := i.GetSpec().BreakChance
-    if bc < 1 {
-        return false
-    }
-    
-    randNum := uint8(util.Rand(100))
-    if len(increaseChance) > 0 {
-        if uint8(increaseChance[0]) >= randNum {
-            randNum = 0
-        } else {
-            randNum -= uint8(increaseChance[0])
-        }
-    }
-    
-    return bc > randNum
-}
+func (i *Item) BreakTest(increaseChance ...int) bool
 
 // Usage tracking
-func (i *Item) UseItem() bool {
-    if i.Uses > 0 {
-        i.Uses--
-        return i.Uses > 0  // Return true if item still has uses
-    }
-    return false
-}
+func (i *Item) UseItem() bool
 ```
 
 ## Data Storage and Persistence
@@ -392,52 +258,17 @@ func (i *Item) UseItem() bool {
 ### Blob Content System
 ```go
 // Store custom data in items
-func (i *Item) SetBlob(blob string) {
-    compressed := util.Compress([]byte(blob))
-    i.Blob = util.Encode(compressed)
-}
-
-func (i *Item) GetBlob() string {
-    if len(i.Blob) == 0 {
-        return ""
-    }
-    
-    decoded := util.Decode(i.Blob)
-    return string(util.Decompress(decoded))
-}
+func (i *Item) SetBlob(blob string)
+func (i *Item) GetBlob() string
 
 // Temporary data storage
-func (i *Item) SetTempData(key string, value any) {
-    if i.tempDataStore == nil {
-        i.tempDataStore = make(map[string]any)
-    }
-    
-    if value == nil {
-        delete(i.tempDataStore, key)
-        return
-    }
-    i.tempDataStore[key] = value
-}
+func (i *Item) SetTempData(key string, value any)
 ```
 
 ### File Organization
 ```go
 // Automatic file organization by item ID ranges
-func (i *ItemSpec) ItemFolder(baseonly ...bool) string {
-    if i.ItemId >= 30000 {
-        return "consumables-30000"
-    } else if i.ItemId >= 20000 {
-        if len(baseonly) > 0 && baseonly[0] {
-            return "armor-20000"
-        } else {
-            return "armor-20000/" + string(i.Type)
-        }
-    } else if i.ItemId >= 10000 {
-        return "weapons-10000"
-    } else {
-        return "other-0"
-    }
-}
+func (i *ItemSpec) ItemFolder(baseonly ...bool) string
 ```
 
 ## Integration Patterns
@@ -445,16 +276,8 @@ func (i *ItemSpec) ItemFolder(baseonly ...bool) string {
 ### Scripting Integration
 ```go
 // JavaScript event integration
-func (i *Item) GetScript() string {
-    return i.GetSpec().GetScript()
-}
-
-func (i *ItemSpec) GetScriptPath() string {
-    return strings.Replace(
-        string(configs.GetFilePathsConfig().DataFiles)+"/items/"+i.Filepath(),
-        ".yaml", ".js", 1,
-    )
-}
+func (i *Item) GetScript() string
+func (i *ItemSpec) GetScriptPath() string
 
 // Script events: onFound, onLost, onUse, onPurchase
 // Called from various game systems when items are manipulated
@@ -463,22 +286,10 @@ func (i *ItemSpec) GetScriptPath() string {
 ### Character Equipment Integration
 ```go
 // Stat modification when equipped
-func (i *Item) StatMod(statName ...string) int {
-    if i.ItemId < 1 {
-        return 0
-    }
-    
-    itemInfo := i.GetSpec()
-    return itemInfo.StatMods.Get(statName...)
-}
+func (i *Item) StatMod(statName ...string) int
 
 // Equipment comparison
-func (i *Item) IsBetterThan(otherItm Item) bool {
-    if otherItm.ItemId < 1 {
-        return i.ItemId > 0
-    }
-    return i.GetSpec().Value > otherItm.GetSpec().Value
-}
+func (i *Item) IsBetterThan(otherItm Item) bool
 ```
 
 ### Quest System Integration
@@ -497,73 +308,14 @@ type ItemSpec struct {
 ### Item Finding Functions
 ```go
 // Multiple search methods
-func FindItem(nameOrId string) int {
-    if itemId, err := strconv.Atoi(nameOrId); err == nil {
-        if itm := New(itemId); itm.ItemId != 0 {
-            return itm.ItemId
-        }
-    }
-    return FindItemByName(nameOrId)
-}
-
-func FindItemByName(name string) int {
-    name = strings.ToLower(name)
-    
-    // Exact match first
-    for _, item := range items {
-        if strings.ToLower(item.Name) == name {
-            return item.ItemId
-        }
-    }
-    
-    // Prefix match
-    for _, item := range items {
-        if strings.HasPrefix(strings.ToLower(item.Name), name) {
-            return item.ItemId
-        }
-    }
-    
-    // Contains match
-    for _, item := range items {
-        if strings.Contains(strings.ToLower(item.Name), name) {
-            return item.ItemId
-        }
-    }
-    
-    return 0
-}
+func FindItem(nameOrId string) int
+func FindItemByName(name string) int
 ```
 
 ### Advanced Item Matching
 ```go
 // Find items in collections with numbering support
-func FindMatchIn(itemName string, items ...Item) (pMatch Item, fMatch Item) {
-    // Support for !itemId:uuid format for exact identification
-    if len(itemName) > 1 && itemName[0] == '!' {
-        parts := strings.Split(itemName[1:], ":")
-        itemIdMatch, _ := strconv.Atoi(parts[0])
-        
-        var itemUUIDMatch uuid.UUID
-        if len(parts) > 1 {
-            itemUUIDMatch, _ = uuid.FromString(parts[1])
-        }
-        
-        for _, itm := range items {
-            if !itemUUIDMatch.IsNil() && itm.UUID == itemUUIDMatch {
-                return itm, itm
-            }
-            if itemIdMatch > 0 && itm.ItemId == itemIdMatch {
-                return itm, itm
-            }
-        }
-    }
-    
-    // Support for numbered items (e.g., "sword 2" for second sword)
-    itemName, itemNumber := util.GetMatchNumber(itemName)
-    
-    // Find matches with numbering support
-    // Returns partial match and full match separately
-}
+func FindMatchIn(itemName string, items ...Item) (pMatch Item, fMatch Item)
 ```
 
 ## Performance Considerations
@@ -577,33 +329,7 @@ func FindMatchIn(itemName string, items ...Item) (pMatch Item, fMatch Item) {
 ### File Loading Optimization
 ```go
 // Batch loading of all item specifications
-func LoadDataFiles() {
-    start := time.Now()
-    
-    tmpItems, err := fileloader.LoadAllFlatFiles[int, *ItemSpec](
-        string(configs.GetFilePathsConfig().DataFiles) + "/items"
-    )
-    if err != nil {
-        panic(err)
-    }
-    
-    items = tmpItems
-    
-    // Load attack messages
-    tmpAttackMessages, err := fileloader.LoadAllFlatFiles[ItemSubType, *WeaponAttackMessageGroup](
-        string(configs.GetFilePathsConfig().DataFiles) + "/combat-messages"
-    )
-    if err != nil {
-        panic(err)
-    }
-    
-    attackMessages = tmpAttackMessages
-    
-    mudlog.Info("itemspec.LoadDataFiles()", 
-        "itemLoadedCount", len(items),
-        "attackMessageCount", len(attackMessages),
-        "Time Taken", time.Since(start))
-}
+func LoadDataFiles()
 ```
 
 ## Dependencies

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -387,7 +387,7 @@ func (r *mapper) FindRoomsInDistance(centerRoomId int, xyRadius int, zRadiusOpt 
 
 	xyRadius = int(math.Abs(float64(xyRadius)))
 	zRadius := 0
-	if len(zRadiusOpt) == 0 {
+	if len(zRadiusOpt) > 0 {
 		zRadius = int(math.Abs(float64(zRadiusOpt[0])))
 	}
 

--- a/internal/mobs/context.md
+++ b/internal/mobs/context.md
@@ -115,39 +115,7 @@ type Mob struct {
 ### Mob Creation and Spawning
 ```go
 // Create new mob instance from specification
-func NewMobById(mobId MobId, homeRoomId int, forceLevel ...int) *Mob {
-    if spec, ok := mobs[int(mobId)]; ok {
-        instanceCounter++
-        
-        // Create copy of mob specification
-        mob := *spec
-        mob.HomeRoomId = homeRoomId
-        mob.Character.RoomId = homeRoomId
-        mob.InstanceId = instanceCounter
-        mob.Character.PlayerDamage = make(map[int]int)
-        
-        // Level scaling
-        if len(forceLevel) > 0 && forceLevel[0] > 0 {
-            mob.Character.Level = forceLevel[0]
-        }
-        
-        // Apply training and initialize stats
-        mob.Character.AutoTrain()
-        mob.Character.Health = mob.Character.HealthMax.Value
-        mob.Character.Mana = mob.Character.ManaMax.Value
-        
-        // Apply permanent buffs
-        mob.Character.SetPermaBuffs(mob.BuffIds)
-        
-        // Validate all equipment
-        mob.validateEquipment()
-        
-        // Store instance
-        mobInstances[mob.InstanceId] = &mob
-        return &mob
-    }
-    return nil
-}
+func NewMobById(mobId MobId, homeRoomId int, forceLevel ...int) *Mob
 ```
 
 ## AI Behavior System
@@ -155,72 +123,19 @@ func NewMobById(mobId MobId, homeRoomId int, forceLevel ...int) *Mob {
 ### Command Execution and Scheduling
 ```go
 // Schedule commands with timing
-func (m *Mob) Command(inputTxt string, waitSeconds ...float64) {
-    readyTurn := util.GetTurnCount()
-    turnDelay := uint64(0)
-    
-    // Ensure sequential command execution
-    if readyTurn > m.lastCommandTurn {
-        m.lastCommandTurn = readyTurn
-    } else {
-        readyTurn = m.lastCommandTurn
-    }
-    
-    if len(waitSeconds) > 0 {
-        turnDelay = uint64(float64(configs.GetTimingConfig().SecondsToTurns(1)) * waitSeconds[0])
-    }
-    
-    // Handle multiple commands separated by semicolons
-    for i, cmd := range strings.Split(inputTxt, ";") {
-        m.lastCommandTurn = readyTurn + turnDelay + uint64(i)
-        
-        events.AddToQueue(events.Input{
-            MobInstanceId: m.InstanceId,
-            InputText:     cmd,
-            ReadyTurn:     m.lastCommandTurn,
-        })
-    }
-}
+func (m *Mob) Command(inputTxt string, waitSeconds ...float64)
 
 // Sleep functionality
-func (m *Mob) Sleep(seconds int) {
-    m.Command("noop", float64(seconds))
-}
+func (m *Mob) Sleep(seconds int)
 ```
 
 ### Behavioral Command Selection
 ```go
 // Get idle command based on mob or race defaults
-func (m *Mob) GetIdleCommand() string {
-    // 1% chance to do nothing (prevents required empty commands)
-    if util.Rand(100) == 0 {
-        return ""
-    }
-    
-    // Check mob-specific idle commands
-    if len(m.IdleCommands) > 0 {
-        return m.IdleCommands[util.Rand(len(m.IdleCommands))]
-    }
-    
-    return ""
-}
+func (m *Mob) GetIdleCommand() string
 
 // Get angry command when entering combat
-func (m *Mob) GetAngryCommand() string {
-    // Check mob-specific angry commands
-    if len(m.AngryCommands) > 0 {
-        return m.AngryCommands[util.Rand(len(m.AngryCommands))]
-    }
-    
-    // Fall back to race-based commands
-    if r := races.GetRace(m.Character.RaceId); r != nil {
-        if len(r.AngryCommands) > 0 {
-            return r.AngryCommands[util.Rand(len(r.AngryCommands))]
-        }
-    }
-    
-    return ""
-}
+func (m *Mob) GetAngryCommand() string
 ```
 
 ## Social Dynamics System
@@ -228,94 +143,24 @@ func (m *Mob) GetAngryCommand() string {
 ### Group Allegiances and Hostilities
 ```go
 // Check if two mobs are allies
-func (r *Mob) ConsidersAnAlly(m *Mob) bool {
-    if m.MobId == r.MobId {
-        return true // Same mob type = ally
-    }
-    
-    if len(m.Groups) == 0 && len(r.Groups) == 0 {
-        return true // No factions = neutral allies
-    }
-    
-    // Check for shared group membership
-    for _, targetGroup := range r.Groups {
-        for _, testGroup := range m.Groups {
-            if testGroup == targetGroup {
-                return true
-            }
-        }
-    }
-    
-    return false
-}
+func (r *Mob) ConsidersAnAlly(m *Mob) bool
 
 // Check race-based hatred
-func (r *Mob) HatesRace(raceName string) bool {
-    raceName = strings.ToLower(raceName)
-    for _, hateGroup := range r.Hates {
-        if hateGroup == raceName {
-            return true
-        }
-    }
-    return false
-}
+func (r *Mob) HatesRace(raceName string) bool
 
 // Check alignment-based hostility
-func (r *Mob) HatesAlignment(otherAlignment int8) bool {
-    // Neutral alignment = no hatred
-    if characters.AlignmentToString(r.Character.Alignment) == "neutral" || 
-       characters.AlignmentToString(otherAlignment) == "neutral" {
-        return false
-    }
-    
-    // Same side = no hatred
-    if (r.Character.Alignment > 0 && otherAlignment > 0) ||
-       (r.Character.Alignment < 0 && otherAlignment < 0) {
-        return false
-    }
-    
-    // Check alignment difference threshold
-    delta := int(math.Abs(float64(r.Character.Alignment) - float64(otherAlignment)))
-    return delta > characters.AlignmentAggroThreshold
-}
+func (r *Mob) HatesAlignment(otherAlignment int8) bool
 ```
 
 ### Player Relationship Tracking
 ```go
 // Track player attacks for memory system
-func (m *Mob) PlayerAttacked(userId int) {
-    if m.playersAttacked == nil {
-        m.playersAttacked = map[int]struct{}{}
-    }
-    m.playersAttacked[userId] = struct{}{}
-}
-
-func (m *Mob) HasAttackedPlayer(userId int) bool {
-    if m.playersAttacked == nil {
-        return false
-    }
-    _, ok := m.playersAttacked[userId]
-    return ok
-}
+func (m *Mob) PlayerAttacked(userId int)
+func (m *Mob) HasAttackedPlayer(userId int) bool
 
 // Global hostility tracking
-func MakeHostile(groupName string, userId int, rounds int) {
-    if _, ok := mobsHatePlayers[groupName]; !ok {
-        mobsHatePlayers[groupName] = make(map[int]int)
-    }
-    
-    if mobsHatePlayers[groupName][userId] < rounds {
-        mobsHatePlayers[groupName][userId] = rounds
-    }
-}
-
-func IsHostile(groupName string, userId int) bool {
-    if group, ok := mobsHatePlayers[groupName]; ok {
-        _, hostile := group[userId]
-        return hostile
-    }
-    return false
-}
+func MakeHostile(groupName string, userId int, rounds int)
+func IsHostile(groupName string, userId int) bool
 ```
 
 ## Conversation System Integration
@@ -323,55 +168,13 @@ func IsHostile(groupName string, userId int) bool {
 ### Multi-Mob Conversations
 ```go
 // Check if mob is in conversation
-func (m *Mob) InConversation() bool {
-    return m.conversationId > 0
-}
+func (m *Mob) InConversation() bool
 
 // Set conversation participation
-func (m *Mob) SetConversation(id int) {
-    m.conversationId = id
-}
+func (m *Mob) SetConversation(id int)
 
 // Execute conversation actions
-func (m *Mob) Converse() {
-    mobInst1, mobInst2, actions := conversations.GetNextActions(m.conversationId)
-    
-    var mob1, mob2 *Mob
-    
-    // Determine which mob is which in the conversation
-    if mobInst1 == int(m.InstanceId) {
-        mob1 = m
-        mob2 = GetInstance(mobInst2)
-    } else {
-        mob1 = GetInstance(mobInst1)
-        mob2 = m
-    }
-    
-    // Execute conversation actions
-    for _, act := range actions {
-        if len(act) >= 3 {
-            target := act[0:3]
-            cmd := act[3:]
-            
-            // Replace mob references in commands
-            cmd = strings.ReplaceAll(cmd, " #1 ", " "+mob1.ShorthandId()+" ")
-            cmd = strings.ReplaceAll(cmd, " #2 ", " "+mob2.ShorthandId()+" ")
-            
-            if target == "#1 " {
-                mob1.Command(cmd)
-            } else {
-                mob2.Command(cmd, 1)
-            }
-        }
-    }
-    
-    // Clean up completed conversations
-    if conversations.IsComplete(m.conversationId) {
-        conversations.Destroy(m.conversationId)
-        mob1.SetConversation(0)
-        mob2.SetConversation(0)
-    }
-}
+func (m *Mob) Converse()
 ```
 
 ## Pathfinding and Movement
@@ -384,35 +187,11 @@ type PathQueue struct {
 }
 
 // Path management
-func (p *PathQueue) SetPath(path []PathRoom) {
-    p.roomQueue = path
-    p.currentRoom = nil
-}
-
-func (p *PathQueue) Next() PathRoom {
-    if len(p.roomQueue) == 0 {
-        return nil
-    }
-    p.currentRoom = p.roomQueue[0]
-    p.roomQueue = p.roomQueue[1:]
-    return p.currentRoom
-}
+func (p *PathQueue) SetPath(path []PathRoom)
+func (p *PathQueue) Next() PathRoom
 
 // Get remaining waypoints
-func (p *PathQueue) Waypoints() []int {
-    wpList := []int{}
-    if p.currentRoom != nil && p.currentRoom.Waypoint() {
-        wpList = append(wpList, p.currentRoom.RoomId())
-    }
-    
-    for _, r := range p.roomQueue {
-        if r.Waypoint() {
-            wpList = append(wpList, r.RoomId())
-        }
-    }
-    
-    return wpList
-}
+func (p *PathQueue) Waypoints() []int
 ```
 
 ## Shop and Trading System
@@ -420,63 +199,10 @@ func (p *PathQueue) Waypoints() []int {
 ### NPC Merchant Behavior
 ```go
 // Check if mob has shop
-func (m *Mob) HasShop() bool {
-    return len(m.Character.Shop) > 0
-}
+func (m *Mob) HasShop() bool
 
 // Calculate sell price for items
-func (m *Mob) GetSellPrice(item items.Item) int {
-    if item.IsSpecial() {
-        return 0 // Don't buy special items
-    }
-    
-    itemType := item.GetSpec().Type
-    itemSubtype := item.GetSpec().Subtype
-    value := 0
-    likesType := false
-    likesSubtype := false
-    newAddition := true
-    priceScale := 0.0
-    
-    currentSaleItems := m.Character.Shop.GetInstock()
-    
-    // Check existing inventory for pricing
-    for _, stockItm := range currentSaleItems {
-        if stockItm.ItemId == item.ItemId {
-            newAddition = false
-            likesType = true
-            likesSubtype = true
-            value = stockItm.Price
-            // Reduce price based on current stock
-            priceScale = 1.0 - (float64(stockItm.Quantity) / 20)
-            break
-        }
-        
-        // Check for type/subtype preferences
-        tmpItm := items.New(stockItm.ItemId)
-        if tmpItm.GetSpec().Type == itemType {
-            likesType = true
-            priceScale += 0.5
-        }
-        if tmpItm.GetSpec().Subtype == itemSubtype {
-            likesSubtype = true
-            priceScale += 0.5
-        }
-    }
-    
-    // Limit inventory variety
-    if newAddition && len(currentSaleItems) >= 20 {
-        return 0
-    }
-    
-    if value == 0 {
-        value = item.GetSpec().Value
-    }
-    
-    // Apply price scaling (max 25% of item value)
-    priceScale = math.Max(0, math.Min(priceScale * 0.25, 1.0))
-    return int(math.Ceil(float64(value) * priceScale))
-}
+func (m *Mob) GetSellPrice(item items.Item) int
 ```
 
 ## Scripting Integration
@@ -484,70 +210,20 @@ func (m *Mob) GetSellPrice(item items.Item) int {
 ### Script System Support
 ```go
 // Check for custom scripts
-func (m *Mob) HasScript() bool {
-    scriptPath := m.GetScriptPath()
-    if _, err := os.Stat(scriptPath); err == nil {
-        return true
-    }
-    return false
-}
+func (m *Mob) HasScript() bool
 
 // Load mob script content
-func (m *Mob) GetScript() string {
-    scriptPath := m.GetScriptPath()
-    if _, err := os.Stat(scriptPath); err == nil {
-        if bytes, err := os.ReadFile(scriptPath); err == nil {
-            return string(bytes)
-        }
-    }
-    return ""
-}
+func (m *Mob) GetScript() string
 
 // Generate script file path
-func (m *Mob) GetScriptPath() string {
-    mobFilePath := m.Filename()
-    
-    newExt := ".js"
-    if m.ScriptTag != "" {
-        newExt = fmt.Sprintf("-%s.js", m.ScriptTag)
-    }
-    
-    scriptFilePath := "scripts/" + strings.Replace(mobFilePath, ".yaml", newExt, 1)
-    fullScriptPath := strings.Replace(
-        configs.GetFilePathsConfig().DataFiles.String()+"/mobs/"+m.Filepath(),
-        mobFilePath,
-        scriptFilePath,
-        1)
-    
-    return util.FilePath(fullScriptPath)
-}
+func (m *Mob) GetScriptPath() string
 ```
 
 ### Temporary Data Storage
 ```go
 // Runtime data storage for scripts and AI
-func (m *Mob) SetTempData(key string, value any) {
-    if m.tempDataStore == nil {
-        m.tempDataStore = make(map[string]any)
-    }
-    
-    if value == nil {
-        delete(m.tempDataStore, key)
-        return
-    }
-    m.tempDataStore[key] = value
-}
-
-func (m *Mob) GetTempData(key string) any {
-    if m.tempDataStore == nil {
-        m.tempDataStore = make(map[string]any)
-    }
-    
-    if value, ok := m.tempDataStore[key]; ok {
-        return value
-    }
-    return nil
-}
+func (m *Mob) SetTempData(key string, value any)
+func (m *Mob) GetTempData(key string) any
 ```
 
 ## Special Mob Types and Behaviors
@@ -555,31 +231,13 @@ func (m *Mob) GetTempData(key string) any {
 ### Tameable Mobs
 ```go
 // Check if mob can be tamed by players
-func (m *Mob) IsTameable() bool {
-    if m.HasShop() {
-        return false // Merchants can't be tamed
-    }
-    if len(m.ScriptTag) > 0 {
-        return false // Scripted mobs can't be tamed
-    }
-    if r := races.GetRace(m.Character.RaceId); r != nil {
-        if !r.Tameable {
-            return false // Race doesn't allow taming
-        }
-    }
-    return true
-}
+func (m *Mob) IsTameable() bool
 ```
 
 ### Persistent vs Temporary Mobs
 ```go
 // Check if mob should despawn when room unloads
-func (m *Mob) Despawns() bool {
-    if m.HasShop() {
-        return false // Merchants are persistent
-    }
-    return true // Most mobs despawn with room
-}
+func (m *Mob) Despawns() bool
 ```
 
 ## Memory and Performance Management
@@ -587,58 +245,17 @@ func (m *Mob) Despawns() bool {
 ### Instance Tracking
 ```go
 // Memory usage reporting
-func GetMemoryUsage() map[string]util.MemoryResult {
-    ret := map[string]util.MemoryResult{}
-    
-    ret["mobs"] = util.MemoryResult{util.MemoryUsage(mobs), len(mobs)}
-    ret["allMobNames"] = util.MemoryResult{util.MemoryUsage(allMobNames), len(allMobNames)}
-    ret["mobInstances"] = util.MemoryResult{util.MemoryUsage(mobInstances), len(mobInstances)}
-    ret["mobsHatePlayers"] = util.MemoryResult{util.MemoryUsage(mobsHatePlayers), len(mobsHatePlayers)}
-    
-    return ret
-}
+func GetMemoryUsage() map[string]util.MemoryResult
 
 // Recent death tracking
-func TrackRecentDeath(instanceId int) {
-    recentlyDied[instanceId] = int(util.GetRoundCount())
-}
-
-func RecentlyDied(instanceId int) bool {
-    // Automatic cleanup of old entries
-    if len(recentlyDied) > 30 {
-        roundNow := int(util.GetRoundCount())
-        for k, v := range recentlyDied {
-            if roundNow-v > 15 {
-                delete(recentlyDied, k)
-            }
-        }
-    }
-    
-    _, ok := recentlyDied[instanceId]
-    return ok
-}
+func TrackRecentDeath(instanceId int)
+func RecentlyDied(instanceId int) bool
 ```
 
 ### Hostility Management
 ```go
 // Reduce hostility over time
-func ReduceHostility() {
-    for groupName, group := range mobsHatePlayers {
-        for userId, rounds := range group {
-            rounds--
-            if rounds < 1 {
-                delete(mobsHatePlayers[groupName], userId)
-            } else {
-                mobsHatePlayers[groupName][userId] = rounds
-            }
-        }
-        
-        // Clean up empty groups
-        if len(mobsHatePlayers[groupName]) < 1 {
-            delete(mobsHatePlayers, groupName)
-        }
-    }
-}
+func ReduceHostility()
 ```
 
 ## File Organization and Persistence
@@ -646,57 +263,17 @@ func ReduceHostility() {
 ### Zone-Based File Structure
 ```go
 // Automatic file organization by zone
-func (m *Mob) Filepath() string {
-    zone := ZoneNameSanitize(m.Zone)
-    return util.FilePath(zone, "/", m.Filename())
-}
-
-func (m *Mob) Filename() string {
-    if name, ok := mobNameCache[m.MobId]; ok {
-        return fmt.Sprintf("%d-%s.yaml", m.Id(), util.ConvertForFilename(name))
-    }
-    // Fallback to character name
-    filename := util.ConvertForFilename(m.Character.Name)
-    return fmt.Sprintf("%d-%s.yaml", m.Id(), filename)
-}
+func (m *Mob) Filepath() string
+func (m *Mob) Filename() string
 
 // Zone name sanitization
-func ZoneNameSanitize(zone string) string {
-    if zone == "" {
-        return ""
-    }
-    zone = strings.ReplaceAll(zone, " ", "_")
-    return strings.ToLower(zone)
-}
+func ZoneNameSanitize(zone string) string
 ```
 
 ### Data Loading and Validation
 ```go
 // Load all mob specifications from files
-func LoadDataFiles() {
-    start := time.Now()
-    
-    tmpMobs, err := fileloader.LoadAllFlatFiles[int, *Mob](
-        configs.GetFilePathsConfig().DataFiles.String() + "/mobs"
-    )
-    if err != nil {
-        panic(err)
-    }
-    
-    mobs = tmpMobs
-    clear(mobNameCache)
-    
-    // Build name cache and validation
-    for _, mob := range mobs {
-        mob.Character.CacheDescription()
-        allMobNames = append(allMobNames, mob.Character.Name)
-        mobNameCache[mob.MobId] = mob.Character.Name
-    }
-    
-    mudlog.Info("mobs.LoadDataFiles()", 
-        "loadedCount", len(mobs), 
-        "Time Taken", time.Since(start))
-}
+func LoadDataFiles()
 ```
 
 ## Integration Patterns
@@ -704,16 +281,7 @@ func LoadDataFiles() {
 ### Event System Integration
 ```go
 // Buff application through events
-func (m *Mob) AddBuff(buffId int, source string) {
-    events.AddToQueue(events.Buff{
-        MobInstanceId: m.InstanceId,
-        BuffId:        buffId,
-        Source:        source,
-    })
-}
-
-// Command execution through Input events
-// All mob commands go through the same event system as player commands
+func (m *Mob) AddBuff(buffId int, source string)
 ```
 
 ### Character System Integration
@@ -771,17 +339,7 @@ if mob.Hostile && playerInRoom {
 ### Social Dynamics
 ```go
 // Check relationships before combat
-func shouldAttack(attacker *Mob, target *Mob) bool {
-    if attacker.ConsidersAnAlly(target) {
-        return false
-    }
-    
-    if attacker.HatesMob(target) {
-        return true
-    }
-    
-    return attacker.Hostile
-}
+func shouldAttack(attacker *Mob, target *Mob) bool
 ```
 
 ## Dependencies
@@ -801,66 +359,10 @@ func shouldAttack(attacker *Mob, target *Mob) bool {
 ### New Mob Creation System
 ```go
 // Create new mob with optional script template
-func CreateNewMobFile(newMobInfo Mob, copyScript string) (MobId, error) {
-    newMobInfo.MobId = getNextMobId()
-    
-    if newMobInfo.MobId == 0 {
-        return 0, errors.New("Could not find a new mob id to assign.")
-    }
-    
-    // Apply quest template if specified
-    if copyScript == ScriptTemplateQuest {
-        newMobInfo.QuestFlags = []string{"1000000-start"}
-    }
-    
-    // Validate mob configuration
-    if err := newMobInfo.Validate(); err != nil {
-        return 0, err
-    }
-    
-    // Save to file system with optional careful save mode
-    saveModes := []fileloader.SaveOption{}
-    if configs.GetFilePathsConfig().CarefulSaveFiles {
-        saveModes = append(saveModes, fileloader.SaveCareful)
-    }
-    
-    if err := fileloader.SaveFlatFile[*Mob](
-        configs.GetFilePathsConfig().DataFiles.String()+"/mobs", 
-        &newMobInfo, 
-        saveModes...
-    ); err != nil {
-        return 0, err
-    }
-    
-    // Update in-memory cache
-    allMobNames = append(allMobNames, newMobInfo.Character.Name)
-    mobNameCache[newMobInfo.MobId] = newMobInfo.Character.Name
-    mobs[newMobInfo.Id()] = &newMobInfo
-    
-    // Copy script template if requested
-    if copyScript != "" {
-        newScriptPath := newMobInfo.GetScriptPath()
-        os.MkdirAll(filepath.Dir(newScriptPath), os.ModePerm)
-        
-        fileloader.CopyFileContents(
-            util.FilePath("_datafiles/sample-scripts/mobs/"+copyScript),
-            newMobInfo.GetScriptPath(),
-        )
-    }
-    
-    return newMobInfo.MobId, nil
-}
+func CreateNewMobFile(newMobInfo Mob, copyScript string) (MobId, error)
 
 // Automatic ID assignment
-func getNextMobId() MobId {
-    lowestFreeId := MobId(0)
-    for _, mInfo := range mobs {
-        if mInfo.MobId >= lowestFreeId {
-            lowestFreeId = mInfo.MobId + 1
-        }
-    }
-    return lowestFreeId
-}
+func getNextMobId() MobId
 ```
 
 ### Script Templates

--- a/internal/plugins/context.md
+++ b/internal/plugins/context.md
@@ -137,16 +137,10 @@ plugin := &Plugin{
     Name:        "MyPlugin",
     Version:     "1.0.0",
     Description: "Example plugin functionality",
-    FileSystem:  myPluginFS, // embed.FS or other fs.ReadFileFS
+    FileSystem:  myPluginFS,
     Callbacks: PluginCallbacks{
-        LoadCallback: func() error {
-            // Initialize plugin
-            return nil
-        },
-        CommandCallback: func(cmdName string) usercommands.UserCommand {
-            // Return custom commands
-            return myCommands[cmdName]
-        },
+        LoadCallback:    func() error { ... },
+        CommandCallback: func(cmdName string) usercommands.UserCommand { ... },
     },
 }
 

--- a/internal/prompt/context.md
+++ b/internal/prompt/context.md
@@ -84,116 +84,28 @@ type Prompt struct {
 
 **Example: Password Change**
 ```go
-func Password(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
-    cmdPrompt, _ := user.StartPrompt(`password`, rest)
-    
-    question := cmdPrompt.Ask(`What is your current password?`, []string{})
-    if !question.Done {
-        return true, nil
-    }
-    
-    if !user.PasswordMatches(question.Response) {
-        user.SendText(`Sorry, your password was incorrect.`)
-        user.ClearPrompt()
-        return true, nil
-    }
-    
-    // Continue with new password questions...
-}
+func Password(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error)
 ```
 
 ### 2. Multi-Step Creation Workflow
 
 **Example: Mob Creation**
 ```go
-func mob_Create(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
-    cmdPrompt, isNew := user.StartPrompt(`mob create`, rest)
-    
-    if isNew {
-        user.SendText(`Starting mob creation...`)
-    }
-    
-    // Step 1: Get mob name
-    question := cmdPrompt.Ask(`What name do you want to give this mob?`, []string{})
-    if !question.Done {
-        return true, nil
-    }
-    if question.Response == `` {
-        user.SendText("Aborting...")
-        user.ClearPrompt()
-        return true, nil
-    }
-    cmdPrompt.Remember(`name`, question.Response)
-    
-    // Step 2: Get description
-    question = cmdPrompt.Ask(`Describe this mob:`, []string{})
-    if !question.Done {
-        return true, nil
-    }
-    // Continue with additional steps...
-    
-    // Final confirmation
-    question = cmdPrompt.Ask(`Create this mob? (y/n)`, []string{`y`, `n`})
-    if !question.Done {
-        return true, nil
-    }
-    
-    user.ClearPrompt()
-    
-    if question.Response != `y` {
-        user.SendText("Aborting...")
-        return true, nil
-    }
-    
-    // Create the mob using collected data
-    return true, nil
-}
+func mob_Create(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error)
 ```
 
 ### 3. Menu-Driven Selection
 
 **Example: Character Management**
 ```go
-func Character(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
-    menuOptions := []string{`new`, `delete`, `switch`, `hire`, `dismiss`, `quit`}
-    
-    cmdPrompt, isNew := user.StartPrompt(`character`, rest)
-    
-    question := cmdPrompt.Ask(`Choose an option:`, menuOptions, `new`)
-    if !question.Done {
-        return true, nil
-    }
-    
-    if question.Response == `quit` {
-        user.ClearPrompt()
-        return true, nil
-    }
-    
-    // Handle selected option...
-}
+func Character(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error)
 ```
 
 ### 4. Conditional Branching
 
 **Example: Room Container Editing**
 ```go
-func room_EditContainers(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
-    cmdPrompt, _ := user.StartPrompt(`room edit containers`, rest)
-    
-    question := cmdPrompt.Ask(`Choose one:`, []string{`new`}, `new`)
-    if !question.Done {
-        return true, nil
-    }
-    
-    if question.Response == `new` {
-        // Branch to new container creation
-        question = cmdPrompt.Ask(`Container name:`, []string{})
-        // Handle new container...
-    } else {
-        // Branch to existing container editing
-        // Handle container selection and editing...
-    }
-}
+func room_EditContainers(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error)
 ```
 
 ## Integration with Input Loop

--- a/internal/quests/context.md
+++ b/internal/quests/context.md
@@ -97,74 +97,16 @@ type QuestReward struct {
 const QuestTokenSeparator = "-"
 
 // Convert quest ID and step to token format
-func PartsToToken(questId int, questStep string) string {
-    return fmt.Sprintf("%d%s%s", questId, QuestTokenSeparator, questStep)
-}
+func PartsToToken(questId int, questStep string) string
 
 // Parse token into quest ID and step
-func TokenToParts(questToken string) (questId int, questStep string) {
-    parts := strings.Split(questToken, QuestTokenSeparator)
-    questId, _ = strconv.Atoi(parts[0])
-    
-    if len(parts) > 1 {
-        questStep = parts[1]
-    } else {
-        questStep = "start" // Default to start step
-    }
-    
-    return questId, questStep
-}
+func TokenToParts(questToken string) (questId int, questStep string)
 ```
 
 ### Quest Progress Validation
 ```go
 // Check if next token represents valid progression from current token
-func IsTokenAfter(currentToken string, nextToken string) bool {
-    currentId, currentStep := TokenToParts(currentToken)
-    nextId, nextStep := TokenToParts(nextToken)
-    
-    // No current progress - can only start quests
-    if currentStep == "" {
-        if nextStep == "start" {
-            return true
-        } else if nextStep == "end" {
-            // Single-step quest can be completed immediately
-            if questInfo := GetQuest(nextToken); questInfo != nil {
-                if len(questInfo.Steps) == 1 {
-                    return true
-                }
-            }
-        }
-        return false
-    }
-    
-    // Must be same quest and different step
-    if currentId != nextId || currentStep == nextStep {
-        return false
-    }
-    
-    // Validate step progression
-    questInfo := GetQuest(currentToken)
-    if questInfo == nil {
-        return false
-    }
-    
-    // Find current step and check if next step follows
-    result := false
-    startLooking := false
-    
-    for _, step := range questInfo.Steps {
-        if step.Id == currentStep {
-            startLooking = true
-        }
-        if startLooking && step.Id == nextStep {
-            result = true
-            break
-        }
-    }
-    
-    return result
-}
+func IsTokenAfter(currentToken string, nextToken string) bool
 ```
 
 ## Quest Discovery and Management
@@ -172,60 +114,16 @@ func IsTokenAfter(currentToken string, nextToken string) bool {
 ### Quest Retrieval
 ```go
 // Get quest by token (validates step existence)
-func GetQuest(questToken string) *Quest {
-    questId, questStep := TokenToParts(questToken)
-    
-    quest := quests[questId]
-    if quest == nil {
-        return nil
-    }
-    
-    // Special case: return full quest info
-    if questStep == "all+" {
-        return quest
-    }
-    
-    // Validate step exists in quest
-    stepIsValid := true
-    if len(questStep) > 0 {
-        stepIsValid = false
-        for _, step := range quest.Steps {
-            if step.Id == questStep {
-                stepIsValid = true
-                break
-            }
-        }
-    }
-    
-    if stepIsValid {
-        return quest
-    }
-    
-    return nil
-}
+func GetQuest(questToken string) *Quest
 
 // Get all available quests (returns copies)
-func GetAllQuests() []Quest {
-    ret := []Quest{}
-    for _, q := range quests {
-        ret = append(ret, *q)
-    }
-    return ret
-}
+func GetAllQuests() []Quest
 ```
 
 ### Quest Statistics
 ```go
 // Get count of quests (optionally including secret quests)
-func GetQuestCt(includeSecret bool) int {
-    ret := 0
-    for _, q := range quests {
-        if includeSecret || !q.Secret {
-            ret++
-        }
-    }
-    return ret
-}
+func GetQuestCt(includeSecret bool) int
 ```
 
 ## File Management and Validation
@@ -233,46 +131,22 @@ func GetQuestCt(includeSecret bool) int {
 ### Quest File Operations
 ```go
 // Generate filename for quest
-func (r *Quest) Filename() string {
-    filename := util.ConvertForFilename(r.Name)
-    return fmt.Sprintf("%d-%s.yaml", r.Id(), filename)
-}
+func (r *Quest) Filename() string
 
 // Get file path for quest
-func (r *Quest) Filepath() string {
-    return r.Filename()
-}
+func (r *Quest) Filepath() string
 
 // Get unique identifier
-func (r *Quest) Id() int {
-    return r.QuestId
-}
+func (r *Quest) Id() int
 
 // Validate quest configuration
-func (r *Quest) Validate() error {
-    return nil // Placeholder for validation logic
-}
+func (r *Quest) Validate() error
 ```
 
 ### Data Loading
 ```go
 // Load all quest files from data directory
-func LoadDataFiles() {
-    start := time.Now()
-    
-    tmpQuests, err := fileloader.LoadAllFlatFiles[int, *Quest](
-        configs.GetFilePathsConfig().DataFiles.String() + "/quests"
-    )
-    if err != nil {
-        panic(err)
-    }
-    
-    quests = tmpQuests
-    
-    mudlog.Info("quests.LoadDataFiles()", 
-        "loadedCount", len(quests), 
-        "Time Taken", time.Since(start))
-}
+func LoadDataFiles()
 ```
 
 ## Quest Progression Patterns
@@ -473,57 +347,7 @@ if quest != nil {
 ### Reward Distribution
 ```go
 // Distribute quest completion rewards
-func distributeRewards(character *characters.Character, rewards QuestReward) {
-    // Gold reward
-    if rewards.Gold > 0 {
-        character.Gold += rewards.Gold
-    }
-    
-    // Experience reward
-    if rewards.Experience > 0 {
-        character.Experience += rewards.Experience
-    }
-    
-    // Item reward
-    if rewards.ItemId > 0 {
-        item := items.New(rewards.ItemId)
-        character.GiveItem(item)
-    }
-    
-    // Skill reward
-    if rewards.SkillInfo != "" {
-        parts := strings.Split(rewards.SkillInfo, ":")
-        if len(parts) == 2 {
-            skillId := parts[0]
-            level, _ := strconv.Atoi(parts[1])
-            character.SetSkillLevel(skillId, level)
-        }
-    }
-    
-    // Buff reward
-    if rewards.BuffId > 0 {
-        character.Buffs.AddBuff(rewards.BuffId, false)
-    }
-    
-    // Chained quest reward
-    if rewards.QuestId != "" {
-        character.AddQuestFlag(rewards.QuestId)
-    }
-    
-    // Teleportation reward
-    if rewards.RoomId > 0 {
-        character.RoomId = rewards.RoomId
-    }
-    
-    // Messages
-    if rewards.PlayerMessage != "" {
-        user.SendText(rewards.PlayerMessage)
-    }
-    
-    if rewards.RoomMessage != "" {
-        room.SendText(rewards.RoomMessage, user)
-    }
-}
+func distributeRewards(character *characters.Character, rewards QuestReward)
 ```
 
 ### Quest Statistics

--- a/internal/skills/context.md
+++ b/internal/skills/context.md
@@ -54,18 +54,10 @@ The skills system is built around several key components:
 type SkillTag string
 
 // Hierarchical skill identification with subtag support
-func (s SkillTag) String(subtag ...string) string {
-    result := string(s)
-    if len(subtag) > 0 {
-        result += ":" + strings.Join(subtag, ":")
-    }
-    return result
-}
+func (s SkillTag) String(subtag ...string) string
 
 // Create skill subtags for specialized abilities
-func (s SkillTag) Sub(subtag string) SkillTag {
-    return SkillTag(string(s) + subtag)
-}
+func (s SkillTag) Sub(subtag string) SkillTag
 ```
 
 ### Core Skills Enumeration
@@ -126,91 +118,13 @@ type ProfessionRank struct {
 }
 
 // Calculate profession rankings based on skill investments
-func GetProfessionRanks(allRanks map[string]int) []ProfessionRank {
-    professionList := []ProfessionRank{}
-    
-    for professionName, skills := range Professions {
-        ranking := ProfessionRank{Profession: professionName}
-        
-        for _, skillName := range skills {
-            skillLevel := 0
-            if rankVal, ok := allRanks[string(skillName)]; ok {
-                skillLevel = rankVal
-            }
-            
-            // Cap at level 4
-            if skillLevel > 4 {
-                skillLevel = 4
-            }
-            
-            // Calculate cumulative cost: 1+2+3+4 = 10 points max per skill
-            totalSkill := (skillLevel * (skillLevel + 1)) / 2
-            
-            ranking.PointsToMax += 10.0 // Maximum 10 points per skill
-            ranking.TotalPointsSpent += float64(totalSkill)
-            ranking.Skills = append(ranking.Skills, string(skillName))
-        }
-        
-        ranking.Completion = ranking.TotalPointsSpent / ranking.PointsToMax
-        ranking.ExperienceTitle = GetExperienceLevel(ranking.Completion)
-        
-        professionList = append(professionList, ranking)
-    }
-    
-    return professionList
-}
+func GetProfessionRanks(allRanks map[string]int) []ProfessionRank
 ```
 
 ### Dynamic Profession Assignment
 ```go
 // Determine primary profession based on highest completion
-func GetProfession(allRanks map[string]int) string {
-    rankData := GetProfessionRanks(allRanks)
-    
-    var highestCompletion float64 = 0
-    chosenProfessions := []string{}
-    experienceName := ""
-    
-    // Find highest completion percentage
-    for _, pRank := range rankData {
-        if pRank.Completion == 0 {
-            continue
-        }
-        
-        if pRank.Completion > highestCompletion {
-            highestCompletion = pRank.Completion
-            chosenProfessions = []string{}
-        }
-        
-        if pRank.Completion == highestCompletion {
-            experienceName = pRank.ExperienceTitle
-            chosenProfessions = append(chosenProfessions, pRank.Profession)
-        }
-    }
-    
-    // Handle special cases
-    if len(chosenProfessions) < 1 {
-        return "scrub" // No skill investment
-    }
-    
-    if len(experienceName) > 0 {
-        experienceName = experienceName + " "
-    }
-    
-    // Demigod status for mastering all professions
-    if len(chosenProfessions) == len(Professions) {
-        return experienceName + "demigod"
-    }
-    
-    // Limit display to 3 professions
-    extra := ""
-    if len(chosenProfessions) > 3 {
-        chosenProfessions = chosenProfessions[0:3]
-        extra = " (and more)"
-    }
-    
-    return experienceName + strings.Join(chosenProfessions, "/") + extra
-}
+func GetProfession(allRanks map[string]int) string
 ```
 
 ## Experience Level System
@@ -218,25 +132,7 @@ func GetProfession(allRanks map[string]int) string {
 ### Experience Title Calculation
 ```go
 // Convert completion percentage to experience title
-func GetExperienceLevel(percentage float64) string {
-    if percentage >= 0.9 { // ~90% completion (avg level 4)
-        return "expert"
-    }
-    
-    if percentage >= 0.6 { // ~60% completion (avg level 3)
-        return "journeyman"
-    }
-    
-    if percentage >= 0.3 { // ~30% completion (avg level 2)
-        return "apprentice"
-    }
-    
-    if percentage >= 0.1 { // ~10% completion (avg level 1)
-        return "novice"
-    }
-    
-    return "scrub" // No meaningful investment
-}
+func GetExperienceLevel(percentage float64) string
 ```
 
 ### Progression Philosophy
@@ -258,39 +154,16 @@ This creates meaningful choices:
 ### Skill Validation
 ```go
 // Check if skill exists in the system
-func SkillExists(sk string) bool {
-    for _, skTag := range allSkillNames {
-        if sk == string(skTag) {
-            return true
-        }
-    }
-    return false
-}
+func SkillExists(sk string) bool
 
 // Get all available skill names
-func GetAllSkillNames() []SkillTag {
-    return append([]SkillTag{}, allSkillNames...)
-}
+func GetAllSkillNames() []SkillTag
 ```
 
 ### Skill Discovery and Initialization
 ```go
 // Automatic skill discovery from profession definitions
-func init() {
-    skillNameSet := map[SkillTag]struct{}{}
-    
-    // Extract unique skills from all professions
-    for _, skills := range Professions {
-        for _, skillName := range skills {
-            if _, ok := skillNameSet[skillName]; ok {
-                continue // Skip duplicates
-            }
-            
-            skillNameSet[skillName] = struct{}{}
-            allSkillNames = append(allSkillNames, skillName)
-        }
-    }
-}
+func init()
 ```
 
 ## Skill Training Locations
@@ -435,19 +308,7 @@ fmt.Printf("Specialized skill: %s\n", specializedSkill.String())
 ### Training Cost Calculation
 ```go
 // Calculate cost to train skill to specific level
-func calculateTrainingCost(currentLevel, targetLevel int) int {
-    cost := 0
-    for level := currentLevel + 1; level <= targetLevel; level++ {
-        cost += level // Level 1=1pt, Level 2=2pts, etc.
-    }
-    return cost
-}
-
-// Examples:
-// Level 0 → 1: 1 point
-// Level 0 → 2: 3 points (1+2)
-// Level 0 → 4: 10 points (1+2+3+4)
-// Level 2 → 4: 7 points (3+4)
+func calculateTrainingCost(currentLevel, targetLevel int) int
 ```
 
 ### Profession Specialization Strategies

--- a/internal/spells/context.md
+++ b/internal/spells/context.md
@@ -102,60 +102,16 @@ const (
 ### Spell Finding System
 ```go
 // Find spell by name or ID with exact and fuzzy matching
-func FindSpell(spellName string) string {
-    // Check for exact ID match first
-    if sd, ok := allSpells[spellName]; ok {
-        return sd.SpellId
-    }
-    
-    // Check for exact name match
-    for _, spellInfo := range allSpells {
-        if strings.ToLower(spellInfo.Name) == spellName {
-            return spellInfo.SpellId
-        }
-    }
-    
-    return ""
-}
+func FindSpell(spellName string) string
 
 // Advanced spell search with prefix matching
-func FindSpellByName(spellName string) *SpellData {
-    var closestMatch *SpellData = nil
-    spellName = strings.ToLower(spellName)
-    
-    for _, spellData := range allSpells {
-        testName := strings.ToLower(spellData.Name)
-        
-        // Exact match takes priority
-        if testName == spellName {
-            return spellData
-        }
-        
-        // Store first prefix match as fallback
-        if closestMatch == nil && strings.HasPrefix(testName, spellName) {
-            closestMatch = spellData
-        }
-    }
-    
-    return closestMatch
-}
+func FindSpellByName(spellName string) *SpellData
 
 // Get spell by exact ID
-func GetSpell(spellId string) *SpellData {
-    if sd, ok := allSpells[spellId]; ok {
-        return sd
-    }
-    return nil
-}
+func GetSpell(spellId string) *SpellData
 
 // Get all available spells (returns copy)
-func GetAllSpells() map[string]*SpellData {
-    retSpellBook := make(map[string]*SpellData)
-    for k, v := range allSpells {
-        retSpellBook[k] = v
-    }
-    return retSpellBook
-}
+func GetAllSpells() map[string]*SpellData
 ```
 
 ## Spell Type Classification
@@ -163,51 +119,13 @@ func GetAllSpells() map[string]*SpellData {
 ### Harm/Help Classification
 ```go
 // Determine if spell is harmful, helpful, or neutral
-func (s SpellType) HelpOrHarmString() string {
-    switch s {
-    case Neutral:
-        return "Neutral"
-    case HelpSingle, HelpMulti, HelpArea:
-        return "Helpful"
-    case HarmSingle, HarmMulti, HarmArea:
-        return "Harmful"
-    }
-    return "Unknown"
-}
+func (s SpellType) HelpOrHarmString() string
 ```
 
 ### Target Type Classification
 ```go
 // Get targeting description (short or long form)
-func (s SpellType) TargetTypeString(short ...bool) string {
-    // Short form for UI display
-    if len(short) > 0 && short[0] {
-        switch s {
-        case Neutral:
-            return "Unknown"
-        case HelpSingle, HarmSingle:
-            return "Single"
-        case HelpMulti, HarmMulti:
-            return "Group"
-        case HelpArea, HarmArea:
-            return "Area"
-        }
-        return "Unknown"
-    }
-    
-    // Long form for detailed descriptions
-    switch s {
-    case Neutral:
-        return "Unknown"
-    case HelpSingle, HarmSingle:
-        return "Single Target"
-    case HelpMulti, HarmMulti:
-        return "Group Target"
-    case HelpArea, HarmArea:
-        return "Area Target"
-    }
-    return "Unknown"
-}
+func (s SpellType) TargetTypeString(short ...bool) string
 ```
 
 ## Spell Creation and Management
@@ -215,65 +133,16 @@ func (s SpellType) TargetTypeString(short ...bool) string {
 ### New Spell Creation
 ```go
 // Create new spell with automatic script template
-func CreateNewSpellFile(newSpellInfo SpellData) (string, error) {
-    // Check for existing spell
-    if sp := GetSpell(newSpellInfo.SpellId); sp != nil {
-        return "", errors.New("Spell already exists.")
-    }
-    
-    // Validate spell data
-    if err := newSpellInfo.Validate(); err != nil {
-        return "", err
-    }
-    
-    // Configure save options
-    saveModes := []fileloader.SaveOption{}
-    if configs.GetFilePathsConfig().CarefulSaveFiles {
-        saveModes = append(saveModes, fileloader.SaveCareful)
-    }
-    
-    // Save spell to file system
-    if err := fileloader.SaveFlatFile[*SpellData](
-        string(configs.GetFilePathsConfig().DataFiles)+"/spells", 
-        &newSpellInfo, 
-        saveModes...
-    ); err != nil {
-        return "", err
-    }
-    
-    // Update in-memory cache
-    allSpells[newSpellInfo.Id()] = &newSpellInfo
-    
-    // Create script directory and copy template
-    newScriptPath := newSpellInfo.GetScriptPath()
-    os.MkdirAll(filepath.Dir(newScriptPath), os.ModePerm)
-    
-    // Copy type-specific script template
-    templatePath := util.FilePath("_datafiles/sample-scripts/spells/" + string(newSpellInfo.Type) + ".js")
-    fileloader.CopyFileContents(templatePath, newScriptPath)
-    
-    return newSpellInfo.SpellId, nil
-}
+func CreateNewSpellFile(newSpellInfo SpellData) (string, error)
 ```
 
 ### Spell Validation
 ```go
 // Validate spell configuration
-func (s *SpellData) Validate() error {
-    // Clamp difficulty to valid range (0-100%)
-    if s.Difficulty < 0 {
-        s.Difficulty = 0
-    } else if s.Difficulty > 100 {
-        s.Difficulty = 100
-    }
-    
-    return nil
-}
+func (s *SpellData) Validate() error
 
 // Get validated difficulty value
-func (s *SpellData) GetDifficulty() int {
-    return s.Difficulty
-}
+func (s *SpellData) GetDifficulty() int
 ```
 
 ## Scripting Integration
@@ -281,40 +150,19 @@ func (s *SpellData) GetDifficulty() int {
 ### Script System Support
 ```go
 // Load spell script content
-func (s *SpellData) GetScript() string {
-    scriptPath := s.GetScriptPath()
-    
-    if _, err := os.Stat(scriptPath); err == nil {
-        if bytes, err := os.ReadFile(scriptPath); err == nil {
-            return string(bytes)
-        }
-    }
-    
-    return ""
-}
+func (s *SpellData) GetScript() string
 
 // Generate script file path
-func (s *SpellData) GetScriptPath() string {
-    return strings.Replace(
-        string(configs.GetFilePathsConfig().DataFiles)+"/spells/"+s.Filepath(), 
-        ".yaml", 
-        ".js", 
-        1
-    )
-}
+func (s *SpellData) GetScriptPath() string
 ```
 
 ### File Path Management
 ```go
 // Generate YAML file path for spell
-func (s *SpellData) Filepath() string {
-    return util.FilePath(fmt.Sprintf("%s.yaml", s.SpellId))
-}
+func (s *SpellData) Filepath() string
 
 // Get unique identifier
-func (s *SpellData) Id() string {
-    return s.SpellId
-}
+func (s *SpellData) Id() string
 ```
 
 ## Summoning System
@@ -322,16 +170,7 @@ func (s *SpellData) Id() string {
 ### Summoning Framework
 ```go
 // Summoning spell implementation framework
-func Summon(sourceUserId int, sourceMobId int, details any) (bool, error) {
-    // details contains summoning specifics (creature type, duration, etc.)
-    // Implementation would handle:
-    // - Creature selection based on details
-    // - Summoning location determination
-    // - Duration and control mechanics
-    // - Integration with mob system
-    
-    return false, nil // Placeholder implementation
-}
+func Summon(sourceUserId int, sourceMobId int, details any) (bool, error)
 ```
 
 ### Summoning Integration Points
@@ -394,22 +233,7 @@ func Summon(sourceUserId int, sourceMobId int, details any) (bool, error) {
 ### Spell Data Loading
 ```go
 // Load all spell files from data directory
-func LoadSpellFiles() {
-    start := time.Now()
-    
-    tmpAllSpells, err := fileloader.LoadAllFlatFiles[string, *SpellData](
-        string(configs.GetFilePathsConfig().DataFiles) + "/spells"
-    )
-    if err != nil {
-        panic(err)
-    }
-    
-    allSpells = tmpAllSpells
-    
-    mudlog.Info("spells.loadAllSpells()", 
-        "loadedCount", len(allSpells), 
-        "Time Taken", time.Since(start))
-}
+func LoadSpellFiles()
 ```
 
 ## Integration Patterns

--- a/internal/stats/context.md
+++ b/internal/stats/context.md
@@ -84,57 +84,19 @@ const (
 ### Level-Based Progression
 ```go
 // Calculate automatic stat gains for a given level
-func (si *StatInfo) GainsForLevel(level int) int {
-    if level < 1 {
-        level = 1
-    }
-    
-    // Racial base scaling: (level-1) * 1/3 * racial_base
-    levelScale := float64(level-1) * BaseModFactor
-    basePoints := int(levelScale * float64(si.Base))
-    
-    // Natural progression: level * 1/2 (free points)
-    freeStatPoints := int(float64(level) * NaturalGainsModFactor)
-    
-    return basePoints + freeStatPoints
-}
+func (si *StatInfo) GainsForLevel(level int) int
 ```
 
 ### Complete Stat Recalculation
 ```go
 // Recalculate all stat components for current level
-func (si *StatInfo) Recalculate(level int) {
-    // Calculate racial component
-    si.Racial = si.GainsForLevel(level)
-    
-    // Sum all components
-    si.Value = si.Racial + si.Training + si.Mods
-    
-    // Apply diminishing returns for values over 100
-    si.ValueAdj = si.Value
-    if si.ValueAdj >= 105 {
-        overage := si.ValueAdj - 100
-        // Square root scaling: 100 + sqrt(overage) * 2
-        si.ValueAdj = 100 + int(math.Round(math.Sqrt(float64(overage))*2))
-    }
-}
+func (si *StatInfo) Recalculate(level int)
 ```
 
 ### Modifier Management
 ```go
 // Set equipment and effect modifiers
-func (si *StatInfo) SetMod(mod ...int) {
-    if len(mod) == 0 {
-        si.Mods = 0 // Clear all modifiers
-        return
-    }
-    
-    // Sum all provided modifiers
-    si.Mods = 0
-    for _, m := range mod {
-        si.Mods += m
-    }
-}
+func (si *StatInfo) SetMod(mod ...int)
 ```
 
 ## Progression Mathematics
@@ -264,47 +226,13 @@ balanced.Stats.Perception.Training = 20
 ### Dynamic Stat Modification
 ```go
 // Apply equipment bonuses
-func ApplyEquipmentBonuses(character *Character) {
-    // Reset all modifiers
-    character.Stats.Strength.SetMod()
-    character.Stats.Speed.SetMod()
-    // ... reset all stats
-    
-    // Apply equipment bonuses
-    for _, item := range character.Equipment.GetAllEquipped() {
-        if item.StatMod("strength") != 0 {
-            currentMod := character.Stats.Strength.Mods
-            character.Stats.Strength.SetMod(currentMod + item.StatMod("strength"))
-        }
-        // ... apply all stat modifications
-    }
-    
-    // Apply buff/spell effects
-    strengthBuff := character.Buffs.StatMod("strength")
-    if strengthBuff != 0 {
-        currentMod := character.Stats.Strength.Mods
-        character.Stats.Strength.SetMod(currentMod + strengthBuff)
-    }
-    
-    // Recalculate all stats
-    character.Stats.Strength.Recalculate(character.Level)
-    character.Stats.Speed.Recalculate(character.Level)
-    // ... recalculate all stats
-}
+func ApplyEquipmentBonuses(character *Character)
 ```
 
 ### Temporary Stat Changes
 ```go
 // Spell effect example: Bull's Strength (+10 Strength for 30 rounds)
-func CastBullsStrength(caster *Character, target *Character) {
-    // Add temporary modifier
-    currentMod := target.Stats.Strength.Mods
-    target.Stats.Strength.SetMod(currentMod + 10)
-    target.Stats.Strength.Recalculate(target.Level)
-    
-    // Apply buff for duration tracking
-    target.Buffs.AddBuff(bullsStrengthBuffId, false)
-}
+func CastBullsStrength(caster *Character, target *Character)
 ```
 
 ## Integration Patterns
@@ -339,110 +267,27 @@ func CastBullsStrength(caster *Character, target *Character) {
 ### Character Creation
 ```go
 // Create new character with racial stats
-func CreateCharacter(raceId int) *Character {
-    character := &Character{
-        Level: 1,
-        Stats: GetRacialStats(raceId), // Base racial statistics
-    }
-    
-    // Calculate initial stat values
-    character.Stats.Strength.Recalculate(character.Level)
-    character.Stats.Speed.Recalculate(character.Level)
-    character.Stats.Smarts.Recalculate(character.Level)
-    character.Stats.Vitality.Recalculate(character.Level)
-    character.Stats.Mysticism.Recalculate(character.Level)
-    character.Stats.Perception.Recalculate(character.Level)
-    
-    return character
-}
+func CreateCharacter(raceId int) *Character
 ```
 
 ### Training Point Allocation
 ```go
 // Spend training points on a stat
-func TrainStat(character *Character, statName string, points int) error {
-    if character.TrainingPoints < points {
-        return errors.New("insufficient training points")
-    }
-    
-    switch statName {
-    case "strength":
-        character.Stats.Strength.Training += points
-        character.Stats.Strength.Recalculate(character.Level)
-    case "speed":
-        character.Stats.Speed.Training += points
-        character.Stats.Speed.Recalculate(character.Level)
-    // ... handle all stats
-    }
-    
-    character.TrainingPoints -= points
-    return nil
-}
+func TrainStat(character *Character, statName string, points int) error
 ```
 
 ### Level Up Processing
 ```go
 // Handle character level increase
-func LevelUp(character *Character) {
-    character.Level++
-    
-    // Recalculate all stats for new level
-    character.Stats.Strength.Recalculate(character.Level)
-    character.Stats.Speed.Recalculate(character.Level)
-    character.Stats.Smarts.Recalculate(character.Level)
-    character.Stats.Vitality.Recalculate(character.Level)
-    character.Stats.Mysticism.Recalculate(character.Level)
-    character.Stats.Perception.Recalculate(character.Level)
-    
-    // Grant training points for allocation
-    character.TrainingPoints += 5 // Example: 5 points per level
-    
-    // Update derived values
-    character.HealthMax.Value = CalculateMaxHealth(character)
-    character.ManaMax.Value = CalculateMaxMana(character)
-}
+func LevelUp(character *Character)
 ```
 
 ### Equipment Change Handling
 ```go
 // Update stats when equipment changes
-func EquipItem(character *Character, item *Item) {
-    // Add item to equipment
-    character.Equipment.Equip(item)
-    
-    // Recalculate stats with new equipment bonuses
-    ApplyAllModifiers(character)
-}
+func EquipItem(character *Character, item *Item)
 
-func ApplyAllModifiers(character *Character) {
-    // Clear existing modifiers
-    character.Stats.Strength.SetMod()
-    character.Stats.Speed.SetMod()
-    // ... clear all stats
-    
-    // Apply equipment modifiers
-    totalStrengthMod := 0
-    totalSpeedMod := 0
-    // ... initialize all stat totals
-    
-    for _, item := range character.Equipment.GetAllEquipped() {
-        totalStrengthMod += item.StatMod("strength")
-        totalSpeedMod += item.StatMod("speed")
-        // ... sum all stat modifications
-    }
-    
-    // Apply buff modifiers
-    totalStrengthMod += character.Buffs.StatMod("strength")
-    totalSpeedMod += character.Buffs.StatMod("speed")
-    // ... add all buff modifications
-    
-    // Set final modifiers and recalculate
-    character.Stats.Strength.SetMod(totalStrengthMod)
-    character.Stats.Strength.Recalculate(character.Level)
-    character.Stats.Speed.SetMod(totalSpeedMod)
-    character.Stats.Speed.Recalculate(character.Level)
-    // ... apply to all stats
-}
+func ApplyAllModifiers(character *Character)
 ```
 
 ## Dependencies

--- a/internal/usercommands/attack.go
+++ b/internal/usercommands/attack.go
@@ -185,6 +185,8 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 
 			events.AddToQueue(events.AggroChanged{UserId: user.UserId, RoomId: user.Character.RoomId})
 
+			user.SendText(fmt.Sprintf(`You prepare to fight <ansi fg="mobname">%s</ansi>!`, m.Character.Name))
+
 			if !isSneaking {
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="mobname">%s</ansi>.`, user.Character.Name, m.Character.Name),
@@ -239,6 +241,8 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 
 			events.AddToQueue(events.AggroChanged{UserId: user.UserId, RoomId: user.Character.RoomId})
 
+			user.SendText(fmt.Sprintf(`You prepare to fight <ansi fg="mobname">%s</ansi>!`, p.Character.Name))
+
 			if !isSneaking {
 
 				p.SendText(
@@ -246,7 +250,7 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 				)
 
 				room.SendText(
-					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="mobname">%s</ansi>.`, user.Character.Name, p.Character.Name),
+					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="username">%s</ansi>.`, p.Character.Name, p.Character.Name),
 					user.UserId, attackPlayerId)
 			}
 

--- a/internal/users/context.md
+++ b/internal/users/context.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The GoMud users system provides comprehensive user account management with support for authentication, character association, connection tracking, item storage, messaging, and configuration management. It features a sophisticated indexing system for fast user lookups, zombie connection handling, role-based permissions, and persistent user data storage with YAML serialization.
+The GoMud users system provides comprehensive user account management with support for authentication, character association, connection tracking, item storage, messaging, and configuration management. It features a sophisticated indexing system for fast user lookups, link-dead connection handling, role-based permissions, and persistent user data storage with YAML serialization.
 
 ## Architecture
 
@@ -13,7 +13,7 @@ The users system is built around several key components:
 **User Management:**
 - Active user tracking with connection mapping
 - Role-based permission system (guest, user, admin)
-- Zombie connection handling for graceful disconnections
+- Link-dead connection handling for graceful disconnections
 - Thread-safe user operations with proper cleanup
 
 **User Index System:**
@@ -37,10 +37,10 @@ The users system is built around several key components:
 ## Key Features
 
 ### 1. **Comprehensive User Management**
-- **Authentication**: Password hashing and validation
+- **Authentication**: bcrypt password hashing with migration from legacy SHA256 hashes
 - **Role System**: Guest, user, and admin roles with permissions
 - **Connection Tracking**: Real-time user connection mapping
-- **Zombie Handling**: Graceful disconnection and cleanup
+- **Link-Dead Handling**: Graceful disconnection and cleanup
 
 ### 2. **High-Performance Index System**
 - **Binary Index**: Fast username lookups with O(log n) performance
@@ -56,9 +56,12 @@ The users system is built around several key components:
 
 ### 4. **Advanced Features**
 - **Screen Reader Support**: Accessibility features for visually impaired users
-- **Audio Integration**: Music and sound effect tracking
+- **Audio Integration**: Music and sound effect tracking via `PlayMusic`/`PlaySound`
 - **Tip System**: Tutorial completion tracking
 - **Temporary Data**: Session-based data storage for scripting
+- **Alt Characters**: Support for multiple characters per account via `SwapToAlt`
+- **Wimpy System**: Auto-flee at configurable health percentage via `WimpyCheck`
+- **Connection Type Tracking**: Telnet, WebSocket, and SSH connection type reported in `OnlineInfo`
 
 ## User Structure
 
@@ -68,7 +71,7 @@ type UserRecord struct {
     UserId         int                   // Unique user identifier
     Role           string                // Permission role (guest/user/admin)
     Username       string                // Login username
-    Password       string                // Hashed password
+    Password       string                // bcrypt-hashed password
     Joined         time.Time             // Account creation date
     Macros         map[string]string     // User-defined command macros
     Aliases        map[string]string     // Command aliases and shortcuts
@@ -81,7 +84,7 @@ type UserRecord struct {
     ScreenReader   bool                  // Accessibility mode
     EmailAddress   string                // Contact email (optional)
     TipsComplete   map[string]bool       // Tutorial completion tracking
-    
+
     // Runtime fields (not persisted)
     EventLog       UserLog               // Session event logging
     LastMusic      string                // Audio state tracking
@@ -92,7 +95,7 @@ type UserRecord struct {
     lastInputRound uint64                // Last input round number
     tempDataStore  map[string]any        // Temporary session data
     activePrompt   *prompt.Prompt        // Current prompt state
-    isZombie       bool                  // Zombie connection flag
+    isLinkDead     bool                  // Link-dead connection flag
     inputBlocked   bool                  // Input processing control
 }
 ```
@@ -100,11 +103,11 @@ type UserRecord struct {
 ### Active Users Management
 ```go
 type ActiveUsers struct {
-    Users             map[int]*UserRecord                 // userId -> UserRecord
-    Usernames         map[string]int                      // username -> userId
-    Connections       map[connections.ConnectionId]int    // connectionId -> userId
-    UserConnections   map[int]connections.ConnectionId    // userId -> connectionId
-    ZombieConnections map[connections.ConnectionId]uint64 // connectionId -> zombie turn
+    Users               map[int]*UserRecord                 // userId -> UserRecord
+    Usernames           map[string]int                      // username -> userId
+    Connections         map[connections.ConnectionId]int    // connectionId -> userId
+    UserConnections     map[int]connections.ConnectionId    // userId -> connectionId
+    LinkDeadConnections map[connections.ConnectionId]uint64 // connectionId -> turn they became link-dead
 }
 ```
 
@@ -126,182 +129,66 @@ type IndexUserRecord struct {
 }
 ```
 
-### Index Operations
-```go
-// Create new index from scratch
-func (idx *UserIndex) Create() error {
-    idx.Delete() // Remove existing index
-    
-    f, err := os.Create(idx.Filename)
-    if err != nil {
-        return err
-    }
-    defer f.Close()
-    
-    // Write header
-    idx.metaData = IndexMetaData{
-        MetaDataSize: FixedHeaderTotalLength,
-        IndexVersion: IndexVersion,
-        RecordCount:  0,
-        RecordSize:   IndexRecordSizeV1,
-    }
-    
-    headerBytes, err := idx.metaData.Format()
-    if err != nil {
-        return err
-    }
-    
-    return f.Write(headerBytes)
-}
-
-// Fast username lookup
-func (idx *UserIndex) GetByUsername(username string) (int, error) {
-    if !idx.Exists() {
-        return 0, ErrIndexMissing
-    }
-    
-    if len(username) > 79 {
-        return 0, ErrSearchNameTooLong
-    }
-    
-    f, err := os.Open(idx.Filename)
-    if err != nil {
-        return 0, err
-    }
-    defer f.Close()
-    
-    // Skip header
-    f.Seek(int64(idx.metaData.MetaDataSize), 0)
-    
-    // Binary search through fixed-width records
-    for i := uint64(0); i < idx.metaData.RecordCount; i++ {
-        var record IndexUserRecord
-        if err := binary.Read(f, binary.LittleEndian, &record); err != nil {
-            return 0, err
-        }
-        
-        // Read terminator
-        var terminator byte
-        binary.Read(f, binary.LittleEndian, &terminator)
-        
-        recordUsername := strings.TrimRight(string(record.Username[:]), "\x00")
-        if strings.EqualFold(recordUsername, username) {
-            return int(record.UserID), nil
-        }
-    }
-    
-    return 0, ErrNotFound
-}
-```
-
 ## User Management Operations
 
 ### User Creation and Authentication
 ```go
 // Create new user record
-func NewUserRecord(userId int, connectionId uint64) *UserRecord {
-    c := configs.GetGamePlayConfig()
-    
-    u := &UserRecord{
-        connectionId:   connectionId,
-        UserId:         userId,
-        Role:           RoleUser,
-        Username:       "",
-        Password:       "",
-        Macros:         make(map[string]string),
-        Character:      characters.New(),
-        ConfigOptions:  map[string]any{},
-        Joined:         time.Now(),
-        connectionTime: time.Now(),
-        tempDataStore:  make(map[string]any),
-        EventLog:       UserLog{},
-    }
-    
-    // Set extra lives for permadeath mode
-    if c.Death.PermaDeath {
-        u.Character.ExtraLives = int(c.LivesStart)
-    }
-    
-    return u
-}
+func NewUserRecord(userId int, connectionId uint64) *UserRecord
 
-// Password validation with multiple formats
-func (u *UserRecord) PasswordMatches(input string) bool {
-    // Direct match (legacy)
-    if input == u.Password {
-        return true
-    }
-    
-    // Hashed match (current)
-    if u.Password == util.Hash(input) {
-        return true
-    }
-    
-    return false
-}
+// Password validation: tries bcrypt first, then migrates legacy SHA256 hashes to bcrypt
+func (u *UserRecord) PasswordMatches(input string) bool
+
+// Set password (bcrypt-hashes the provided value)
+func (u *UserRecord) SetPassword(pw string) error
 ```
 
 ### Connection Management
 ```go
 // Get connection ID for user
-func GetConnectionId(userId int) connections.ConnectionId {
-    if user, ok := userManager.Users[userId]; ok {
-        return user.connectionId
-    }
-    return 0
-}
+func GetConnectionId(userId int) connections.ConnectionId
 
 // Get multiple connection IDs
-func GetConnectionIds(userIds []int) []connections.ConnectionId {
-    connectionIds := make([]connections.ConnectionId, 0, len(userIds))
-    for _, userId := range userIds {
-        if user, ok := userManager.Users[userId]; ok {
-            connectionIds = append(connectionIds, user.connectionId)
-        }
-    }
-    return connectionIds
-}
+func GetConnectionIds(userIds []int) []connections.ConnectionId
 
-// Get all active users
-func GetAllActiveUsers() []*UserRecord {
-    ret := []*UserRecord{}
-    for _, user := range userManager.Users {
-        ret = append(ret, user)
-    }
-    return ret
-}
+// Get all active (non-link-dead) users
+func GetAllActiveUsers() []*UserRecord
+
+// Get all online user IDs (including link-dead)
+func GetOnlineUserIds() []int
 ```
 
-### Zombie Connection Handling
+### Link-Dead Connection Handling
 ```go
-// Mark user as zombie (disconnected but not cleaned up)
-func RemoveZombieUser(userId int) {
-    if u := userManager.Users[userId]; u != nil {
-        u.Character.SetAdjective("zombie", false)
-    }
-    if connId, ok := userManager.UserConnections[userId]; ok {
-        delete(userManager.ZombieConnections, connId)
-    }
-}
+// Mark user as link-dead
+func SetLinkDeadUser(userId int)
 
-// Check if connection is zombie
-func IsZombieConnection(connectionId connections.ConnectionId) bool {
-    _, ok := userManager.ZombieConnections[connectionId]
-    return ok
-}
+// Clear link-dead status for a user
+func RemoveLinkDeadUser(userId int)
 
-// Get expired zombie connections for cleanup
-func GetExpiredZombies(expirationTurn uint64) []int {
-    expiredUsers := make([]int, 0)
-    
-    for connectionId, zombieTurn := range userManager.ZombieConnections {
-        if zombieTurn < expirationTurn {
-            expiredUsers = append(expiredUsers, userManager.Connections[connectionId])
-        }
-    }
-    
-    return expiredUsers
-}
+// Remove a link-dead connection entry directly
+func RemoveLinkDeadConnection(connectionId connections.ConnectionId)
+
+// Check if connection is link-dead
+func IsLinkDeadConnection(connectionId connections.ConnectionId) bool
+
+// Get expired link-dead users for cleanup
+func GetExpiredLinkDeadUsers(expirationTurn uint64) []int
+```
+
+### Login / Logout
+```go
+// Log in a user (handles link-dead reconnect)
+func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRecord, string, error)
+
+// Log in a user reconnecting after a copyover
+func CopyoverReconnectUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRecord, string, error)
+
+// Log out a user by connection ID (saves data and cleans up maps)
+func LogOutUserByConnectionId(connectionId connections.ConnectionId) error
+
+// Create a brand-new user account
+func CreateUser(u *UserRecord) error
 ```
 
 ## Storage Systems
@@ -312,44 +199,9 @@ type Storage struct {
     Items []items.Item // Personal item storage
 }
 
-// Find item by name with fuzzy matching
-func (s *Storage) FindItem(itemName string) (items.Item, bool) {
-    if itemName == "" {
-        return items.Item{}, false
-    }
-    
-    closeMatchItem, matchItem := items.FindMatchIn(itemName, s.Items...)
-    
-    if matchItem.ItemId != 0 {
-        return matchItem, true
-    }
-    
-    if closeMatchItem.ItemId != 0 {
-        return closeMatchItem, true
-    }
-    
-    return items.Item{}, false
-}
-
-// Add item to storage
-func (s *Storage) AddItem(i items.Item) bool {
-    if i.ItemId < 1 {
-        return false
-    }
-    s.Items = append(s.Items, i)
-    return true
-}
-
-// Remove specific item instance
-func (s *Storage) RemoveItem(i items.Item) bool {
-    for j := len(s.Items) - 1; j >= 0; j-- {
-        if s.Items[j].Equals(i) {
-            s.Items = append(s.Items[:j], s.Items[j+1:]...)
-            return true
-        }
-    }
-    return false
-}
+func (s *Storage) FindItem(itemName string) (items.Item, bool)
+func (s *Storage) AddItem(i items.Item) bool
+func (s *Storage) RemoveItem(i items.Item) bool
 ```
 
 ### Inbox Messaging System
@@ -366,93 +218,37 @@ type Message struct {
     DateSent   time.Time   // Timestamp
 }
 
-// Add message to inbox (newest first)
-func (i *Inbox) Add(msg Message) {
-    msg.DateSent = time.Now()
-    
-    newInbox := &Inbox{msg}
-    
-    if i == nil {
-        (*i) = *newInbox
-        return
-    }
-    
-    // Prepend new message
-    (*i) = append(*newInbox, (*i)...)
-}
-
-// Count read/unread messages
-func (i *Inbox) CountRead() int {
-    ct := 0
-    for _, msg := range *i {
-        if msg.Read {
-            ct++
-        }
-    }
-    return ct
-}
-
-func (i *Inbox) CountUnread() int {
-    ct := 0
-    for _, msg := range *i {
-        if !msg.Read {
-            ct++
-        }
-    }
-    return ct
-}
+func (i *Inbox) Add(msg Message)
+func (i *Inbox) CountRead() int
+func (i *Inbox) CountUnread() int
 ```
 
 ## User Data Management
 
 ### Temporary Data Storage
 ```go
-// Set temporary session data
-func (u *UserRecord) SetTempData(key string, value any) {
-    if u.tempDataStore == nil {
-        u.tempDataStore = make(map[string]any)
-    }
-    
-    if value == nil {
-        delete(u.tempDataStore, key)
-        return
-    }
-    
-    u.tempDataStore[key] = value
-}
-
-// Get temporary session data
-func (u *UserRecord) GetTempData(key string) any {
-    if u.tempDataStore == nil {
-        u.tempDataStore = make(map[string]any)
-    }
-    
-    if value, ok := u.tempDataStore[key]; ok {
-        return value
-    }
-    
-    return nil
-}
+func (u *UserRecord) SetTempData(key string, value any)
+func (u *UserRecord) GetTempData(key string) any
 ```
 
-### Configuration Management
+### Configuration Options
 ```go
-// Get client display settings
-func (u *UserRecord) ClientSettings() connections.ClientSettings {
-    return connections.GetClientSettings(u.connectionId)
-}
+func (u *UserRecord) SetConfigOption(key string, value any)
+func (u *UserRecord) GetConfigOption(key string) any
 
-// Configuration options stored in ConfigOptions map
-// Examples:
-// - "auto_attack": bool
-// - "brief_mode": bool
-// - "color_enabled": bool
-// - "sound_enabled": bool
+// Client display settings (screen width/height, MSP, etc.)
+func (u *UserRecord) ClientSettings() connections.ClientSettings
+```
+
+### Unsent Text (prompt redraw support)
+```go
+func (u *UserRecord) SetUnsentText(t string, suggest string)
+func (u *UserRecord) GetUnsentText() (unsent string, suggestion string)
 ```
 
 ## Online User Information
 
-### Online Status Tracking
+### OnlineInfo Structure
 ```go
 type OnlineInfo struct {
     Username      string // Login username
@@ -461,17 +257,19 @@ type OnlineInfo struct {
     Alignment     string // Character alignment
     Profession    string // Character profession
     OnlineTime    int64  // Seconds online
-    OnlineTimeStr string // Formatted time string
+    OnlineTimeStr string // Formatted time string (e.g. "2h30m")
     IsAFK         bool   // Away from keyboard status
     Role          string // User role (guest/user/admin)
+    ConnType      string // Connection type: "telnet", "websocket", or "ssh"
 }
 ```
+
+`ConnType` is determined at runtime from the underlying `ConnectionDetails` via `cd.IsWebSocket()` / `cd.IsSSH()`.
 
 ## Integration Patterns
 
 ### Character System Integration
 ```go
-// Users have associated characters
 - user.Character                                          // Full character data
 - user.Character.Name                                    // Character name
 - user.Character.Level                                   // Character progression
@@ -483,137 +281,68 @@ type OnlineInfo struct {
 
 ### Connection System Integration
 ```go
-// Users map to network connections
 - user.connectionId                // Current connection
 - connections.GetClientSettings()  // Display preferences
 - connections.SendTo()             // Send messages to user
+- connections.Get(id).IsSSH()      // Detect SSH connection type
 ```
 
 ### Prompt System Integration
 ```go
-// Users can have active prompts
 - user.activePrompt               // Current prompt state
 - user.inputBlocked               // Input processing control
-- prompt.Ask()                    // Interactive prompts
+- user.StartPrompt(cmd, rest)     // Start or reuse a prompt
+- user.GetPrompt()                // Retrieve current prompt
+- user.ClearPrompt()              // Clear active prompt
 ```
 
 ### Event System Integration
 ```go
-// Users participate in game events
 - events.AddToQueue()             // Queue user actions
 - user.EventLog                   // Track user events
 - user.lastInputRound             // Input timing
+- user.Command(inputTxt)          // Queue a command for the user
+- user.CommandFlagged(inputTxt, flags) // Queue a command with event flags
+- user.SendText(txt)              // Queue a Message event to the user
+- user.AddBuff(buffId, source)    // Queue a Buff event for the user
+- user.GrantXP(amt, source)       // Grant XP and fire LevelUp events if needed
 ```
 
 ## Usage Examples
 
 ### User Authentication
 ```go
-// Authenticate user login
-username := "player1"
-password := "secretpass"
-
-// Look up user by username
-userId, err := userIndex.GetByUsername(username)
+user, err := users.LoadUser(username)
 if err != nil {
     return errors.New("user not found")
 }
-
-// Load user record
-user, err := LoadUser(userId)
-if err != nil {
-    return err
-}
-
-// Verify password
 if !user.PasswordMatches(password) {
     return errors.New("invalid password")
 }
-
 // User authenticated successfully
-fmt.Printf("Welcome back, %s!\n", user.Username)
-```
-
-### User Management
-```go
-// Create new user
-connectionId := uint64(12345)
-userId := getNextUserId()
-
-user := users.NewUserRecord(userId, connectionId)
-user.Username = "newplayer"
-user.Password = util.Hash("password123")
-user.Character.Name = "NewPlayer"
-
-// Save user
-if err := user.Save(); err != nil {
-    return err
-}
-
-// Add to active users
-userManager.Users[userId] = user
-userManager.Usernames[user.Username] = userId
-userManager.Connections[connectionId] = userId
-userManager.UserConnections[userId] = connectionId
-```
-
-### Item Storage Operations
-```go
-// Store item in user's personal storage
-sword := items.New(101) // Create sword item
-if user.ItemStorage.AddItem(sword) {
-    user.SendText("Item stored successfully.")
-}
-
-// Retrieve item from storage
-storedItem, found := user.ItemStorage.FindItem("sword")
-if found {
-    user.Character.GiveItem(storedItem)
-    user.ItemStorage.RemoveItem(storedItem)
-    user.SendText("Item retrieved from storage.")
-}
-```
-
-### Messaging System
-```go
-// Send message with attachment
-message := users.Message{
-    FromUserId: senderUserId,
-    FromName:   sender.Character.Name,
-    Message:    "Here's that sword I promised you!",
-    Item:       &sword,
-    Gold:       100,
-    Read:       false,
-}
-
-recipient.Inbox.Add(message)
-recipient.SendText("You have a new message!")
-
-// Check unread messages
-unreadCount := recipient.Inbox.CountUnread()
-if unreadCount > 0 {
-    recipient.SendText(fmt.Sprintf("You have %d unread messages.", unreadCount))
-}
 ```
 
 ### Zombie Connection Cleanup
 ```go
-// Handle disconnected users
 currentTurn := util.GetTurnCount()
-expirationTurn := currentTurn - 100 // 100 turns ago
+expirationTurn := currentTurn - linkDeadTurns
 
-expiredZombies := users.GetExpiredZombies(expirationTurn)
-for _, userId := range expiredZombies {
+expiredUsers := users.GetExpiredLinkDeadUsers(expirationTurn)
+for _, userId := range expiredUsers {
     user := users.GetByUserId(userId)
     if user != nil {
-        // Save user data
         user.Save()
-        
-        // Remove from active users
-        users.RemoveUser(userId)
-        
-        fmt.Printf("Cleaned up zombie user: %s\n", user.Username)
+        users.LogOutUserByConnectionId(user.ConnectionId())
     }
+}
+```
+
+### Alt Character Swap
+```go
+if user.SwapToAlt("AltName") {
+    user.SendText("Swapped to alt character.")
+} else {
+    user.SendText("Alt character not found.")
 }
 ```
 
@@ -626,6 +355,7 @@ for _, userId := range expiredZombies {
 - `internal/prompt` - Interactive prompt system for user input
 - `internal/util` - Utility functions for hashing, file operations, and validation
 - `internal/mudlog` - Logging system for user events and debugging
+- `internal/audio` - Audio file lookup for MSP sound/music events
+- `internal/skills` - Profession lookup for online info display
+- `golang.org/x/crypto/bcrypt` - Secure password hashing
 - `gopkg.in/yaml.v2` - YAML serialization for user data persistence
-
-This comprehensive users system provides robust user account management with authentication, connection tracking, data persistence, messaging, and seamless integration with all game systems while maintaining high performance through efficient indexing and caching.

--- a/internal/users/copyover.go
+++ b/internal/users/copyover.go
@@ -17,8 +17,8 @@ import (
 type userEntry struct {
 	UserId       int                      `json:"user_id"`
 	ConnectionId connections.ConnectionId `json:"connection_id"`
-	IsZombie     bool                     `json:"is_zombie"`
-	ZombieTurn   uint64                   `json:"zombie_turn,omitempty"`
+	IsLinkDead   bool                     `json:"is_link_dead"`
+	LinkDeadTurn uint64                   `json:"link_dead_turn,omitempty"`
 }
 
 type usersState struct {
@@ -36,17 +36,17 @@ func (u *usersCopyoverContributor) CopyoverSave(enc *copyover.Encoder) error {
 
 	for userId, user := range userManager.Users {
 		connId := userManager.UserConnections[userId]
-		isZombie := false
-		zombieTurn := uint64(0)
-		if turn, ok := userManager.ZombieConnections[connId]; ok {
-			isZombie = true
-			zombieTurn = turn
+		isLinkDead := false
+		linkDeadTurn := uint64(0)
+		if turn, ok := userManager.LinkDeadConnections[connId]; ok {
+			isLinkDead = true
+			linkDeadTurn = turn
 		}
 		state.Entries = append(state.Entries, userEntry{
 			UserId:       userId,
 			ConnectionId: connId,
-			IsZombie:     isZombie,
-			ZombieTurn:   zombieTurn,
+			IsLinkDead:   isLinkDead,
+			LinkDeadTurn: linkDeadTurn,
 		})
 		_ = user
 	}
@@ -76,8 +76,8 @@ func (u *usersCopyoverContributor) CopyoverRestore(dec *copyover.Decoder) error 
 		userManager.Connections[user.connectionId] = user.UserId
 		userManager.UserConnections[user.UserId] = user.connectionId
 
-		if entry.IsZombie {
-			userManager.ZombieConnections[user.connectionId] = entry.ZombieTurn
+		if entry.IsLinkDead {
+			userManager.LinkDeadConnections[user.connectionId] = entry.LinkDeadTurn
 		}
 	}
 

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -55,7 +55,7 @@ type UserRecord struct {
 	lastInputRound uint64
 	tempDataStore  map[string]any
 	activePrompt   *prompt.Prompt
-	isZombie       bool // are they a zombie currently?
+	isLinkDead     bool // are they a link-dead connection currently?
 	inputBlocked   bool // Whether input is currently intentionally turned off (for a certain category of commands)
 }
 

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -26,50 +26,50 @@ var (
 )
 
 type ActiveUsers struct {
-	Users             map[int]*UserRecord                 // userId to UserRecord
-	Usernames         map[string]int                      // username to userId
-	Connections       map[connections.ConnectionId]int    // connectionId to userId
-	UserConnections   map[int]connections.ConnectionId    // userId to connectionId
-	ZombieConnections map[connections.ConnectionId]uint64 // connectionId to turn they became a zombie
+	Users               map[int]*UserRecord                 // userId to UserRecord
+	Usernames           map[string]int                      // username to userId
+	Connections         map[connections.ConnectionId]int    // connectionId to userId
+	UserConnections     map[int]connections.ConnectionId    // userId to connectionId
+	LinkDeadConnections map[connections.ConnectionId]uint64 // connectionId to turn they became link-dead
 }
 
 func newUserManager() *ActiveUsers {
 	return &ActiveUsers{
-		Users:             make(map[int]*UserRecord),
-		Usernames:         make(map[string]int),
-		Connections:       make(map[connections.ConnectionId]int),
-		UserConnections:   make(map[int]connections.ConnectionId),
-		ZombieConnections: make(map[connections.ConnectionId]uint64),
+		Users:               make(map[int]*UserRecord),
+		Usernames:           make(map[string]int),
+		Connections:         make(map[connections.ConnectionId]int),
+		UserConnections:     make(map[int]connections.ConnectionId),
+		LinkDeadConnections: make(map[connections.ConnectionId]uint64),
 	}
 }
 
-func RemoveZombieUser(userId int) {
+func RemoveLinkDeadUser(userId int) {
 
 	if u := userManager.Users[userId]; u != nil {
 		u.Character.SetAdjective(`zombie`, false)
 	}
 	if connId, ok := userManager.UserConnections[userId]; ok {
-		delete(userManager.ZombieConnections, connId)
+		delete(userManager.LinkDeadConnections, connId)
 	}
 }
 
-func IsZombieConnection(connectionId connections.ConnectionId) bool {
-	_, ok := userManager.ZombieConnections[connectionId]
+func IsLinkDeadConnection(connectionId connections.ConnectionId) bool {
+	_, ok := userManager.LinkDeadConnections[connectionId]
 	return ok
 }
 
-func RemoveZombieConnection(connectionId connections.ConnectionId) {
-	delete(userManager.ZombieConnections, connectionId)
+func RemoveLinkDeadConnection(connectionId connections.ConnectionId) {
+	delete(userManager.LinkDeadConnections, connectionId)
 }
 
 // Returns a slice of userId's
-// These userId's are zombies that have reached expiration
-func GetExpiredZombies(expirationTurn uint64) []int {
+// These userId's are link-dead players that have reached expiration
+func GetExpiredLinkDeadUsers(expirationTurn uint64) []int {
 
 	expiredUsers := make([]int, 0)
 
-	for connectionId, zombieTurn := range userManager.ZombieConnections {
-		if zombieTurn < expirationTurn {
+	for connectionId, linkDeadTurn := range userManager.LinkDeadConnections {
+		if linkDeadTurn < expirationTurn {
 			expiredUsers = append(expiredUsers, userManager.Connections[connectionId])
 		}
 	}
@@ -100,7 +100,7 @@ func GetAllActiveUsers() []*UserRecord {
 	ret := []*UserRecord{}
 
 	for _, userPtr := range userManager.Users {
-		if !userPtr.isZombie {
+		if !userPtr.isLinkDead {
 			ret = append(ret, userPtr)
 		}
 	}
@@ -171,7 +171,7 @@ func CopyoverReconnectUser(user *UserRecord, connectionId connections.Connection
 		}
 
 		if oldConnId, ok := userManager.UserConnections[userId]; ok {
-			delete(userManager.ZombieConnections, oldConnId)
+			delete(userManager.LinkDeadConnections, oldConnId)
 			delete(userManager.Connections, oldConnId)
 		}
 	}
@@ -210,16 +210,16 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 		// Do they have a connection tracked?
 		if otherConnId, ok := userManager.UserConnections[userId]; ok {
 
-			// Is it a zombie connection? If so, lets make this new connection the owner
-			if IsZombieConnection(otherConnId) {
+			// Is it a link-dead connection? If so, lets make this new connection the owner
+			if IsLinkDeadConnection(otherConnId) {
 
-				mudlog.Info("LoginUser()", "Zombie", true)
+				mudlog.Info("LoginUser()", "LinkDead", true)
 
-				if zombieUser, ok := userManager.Users[user.UserId]; ok {
-					user = zombieUser
+				if linkDeadUser, ok := userManager.Users[user.UserId]; ok {
+					user = linkDeadUser
 				}
 
-				RemoveZombieConnection(otherConnId)
+				RemoveLinkDeadConnection(otherConnId)
 
 				user.connectionId = connectionId
 
@@ -248,7 +248,7 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 		return nil, "That user is already logged in.", errors.New("user is already logged in")
 	}
 
-	mudlog.Info("LoginUser()", "Zombie", false)
+	mudlog.Info("LoginUser()", "LinkDead", false)
 
 	// Set their input round to current to track idle time fresh
 	user.SetLastInputRound(util.GetRoundCount())
@@ -273,7 +273,7 @@ func LoginUser(user *UserRecord, connectionId connections.ConnectionId) (*UserRe
 	return user, "", nil
 }
 
-func SetZombieUser(userId int) {
+func SetLinkDeadUser(userId int) {
 
 	if u, ok := userManager.Users[userId]; ok {
 
@@ -289,11 +289,11 @@ func SetZombieUser(userId int) {
 			}
 		}
 
-		if _, ok := userManager.ZombieConnections[u.connectionId]; ok {
+		if _, ok := userManager.LinkDeadConnections[u.connectionId]; ok {
 			return
 		}
 
-		userManager.ZombieConnections[u.connectionId] = util.GetTurnCount()
+		userManager.LinkDeadConnections[u.connectionId] = util.GetTurnCount()
 	}
 
 }

--- a/internal/util/context.md
+++ b/internal/util/context.md
@@ -2,717 +2,352 @@
 
 ## Overview
 
-The GoMud util system provides essential utility functions and infrastructure services including game timing management, string processing, file operations, cryptographic functions, memory monitoring, performance tracking, and cross-platform compatibility utilities. It serves as the foundational layer supporting all other game systems with thread-safe operations and comprehensive debugging tools.
+The GoMud util system provides essential utility functions and infrastructure services including game timing management, string processing, file operations, cryptographic functions, memory monitoring, performance tracking, and a generic synchronous hook mechanism. It serves as the foundational layer supporting all other game systems.
 
-## Architecture
+## Files
 
-The util system is built around several key categories:
-
-### Core Components
-
-**Game Timing System:**
-- Turn and round counting with persistent state
-- High-level mutex synchronization for game data
-- Performance tracking and accumulator system
-- Time-based event coordination
-
-**String Processing:**
-- Text matching and fuzzy search algorithms
-- Color code processing and ANSI conversion
-- Filename sanitization and path utilities
-- Multi-language text processing (CJK support)
-
-**Cryptographic Services:**
-- Password hashing with SHA-256 and MD5 support
-- Secure random number generation
-- Base64 encoding/decoding utilities
-- Hash-based data integrity
-
-**Memory Management:**
-- Memory usage tracking and reporting
-- Performance monitoring and statistics
-- Resource cleanup and optimization
-- System health monitoring
-
-## Key Features
-
-### 1. **Game Timing and Synchronization**
-- **Turn/Round Counting**: Persistent game time tracking
-- **Thread Safety**: High-level mutex for game data synchronization
-- **Performance Tracking**: Accumulator system for timing analysis
-- **State Persistence**: Round count persistence across server restarts
-
-### 2. **Advanced String Processing**
-- **Fuzzy Matching**: Sophisticated text matching algorithms
-- **Color Processing**: ANSI color code handling and conversion
-- **Filename Sanitization**: Cross-platform safe filename generation
-- **Multi-language Support**: Unicode and CJK character handling
-
-### 3. **Comprehensive Utilities**
-- **File Operations**: Path utilities and file manipulation
-- **Random Generation**: Seeded random numbers and dice rolling
-- **Data Compression**: Gzip compression for data storage
-- **Network Utilities**: HTTP helpers and address management
-
-### 4. **System Monitoring**
-- **Memory Tracking**: Detailed memory usage reporting
-- **Performance Metrics**: Execution time tracking and analysis
-- **Resource Monitoring**: System resource usage statistics
-- **Debug Support**: Comprehensive logging and debugging utilities
+| File | Purpose |
+|------|---------|
+| `util.go` | Core utilities: timing, string processing, hashing, file I/O, dice, compression |
+| `hook.go` | Generic type-safe synchronous callback chain (`Hook[T]`) |
+| `memory.go` | Memory reporting, `MemoryUsage`, `ServerStats`, `FormatBytes` |
+| `copyover.go` | Copyover (hot-restart) helpers |
 
 ## Game Timing System
 
-### Turn and Round Management
-```go
-var (
-    turnCount  uint64 = 0
-    roundCount uint64 = RoundCountMinimum // Start at 1314000 for stability
-)
+### Turn and Round Counting
 
+```go
 const (
-    RoundCountMinimum  = 1314000        // ~4 years offset for delta safety
-    RoundCountFilename = ".roundcount"  // Persistence file
+    RoundCountMinimum  = 1314000       // ~4 years offset for delta safety
+    RoundCountFilename = ".roundcount" // Persistence file name
 )
 
-// Thread-safe turn counting
-func IncrementTurnCount() uint64 {
-    turnCount++
-    return turnCount
-}
-
-func GetTurnCount() uint64 {
-    return turnCount
-}
-
-// Thread-safe round counting with persistence
-func IncrementRoundCount() uint64 {
-    roundCount++
-    return roundCount
-}
-
-func GetRoundCount() uint64 {
-    return roundCount
-}
-
-func SetRoundCount(newRoundCount uint64) {
-    roundCount = newRoundCount
-}
+func IncrementTurnCount() uint64  // Increment and return the turn counter
+func GetTurnCount() uint64        // Read the current turn counter
+func IncrementRoundCount() uint64 // Increment and return the round counter
+func GetRoundCount() uint64       // Read the current round counter
+func SetRoundCount(newRoundCount uint64) // Override the round counter
 ```
 
-### High-Level Synchronization
+Turns are the smallest time unit (driven by `TurnMs`). Rounds are coarser (driven by `RoundSeconds`). The round counter starts at `RoundCountMinimum` to keep delta comparisons safe even after a fresh start.
+
+### Round Count Persistence
+
 ```go
-var mudLock = sync.RWMutex{}
-
-// Exclusive lock for game data modifications
-func LockMud() {
-    mudLock.Lock()
-}
-
-func UnlockMud() {
-    mudLock.Unlock()
-}
-
-// Shared lock for game data reading
-func RLockMud() {
-    mudLock.RLock()
-}
-
-func RUnlockMud() {
-    mudLock.RUnlock()
-}
+func SaveRoundCount(fpath string)      // Write current roundCount to file
+func LoadRoundCount(fpath string) uint64 // Read roundCount from file; creates file if missing
 ```
 
-### Performance Tracking
+### High-Level Mutex
+
+A single `sync.RWMutex` (`mudLock`) synchronizes high-level access to game data between asynchronous components.
+
+```go
+func LockMud()    // Exclusive write lock
+func UnlockMud()  // Release write lock
+func RLockMud()   // Shared read lock
+func RUnlockMud() // Release read lock
+```
+
+### Performance Tracking (Accumulator)
+
 ```go
 type Accumulator struct {
-    Name    string    // Tracker name
-    Total   float64   // Total time accumulated
-    Lowest  float64   // Fastest execution time
-    Highest float64   // Slowest execution time
-    Count   float64   // Number of samples
-    Average float64   // Calculated average
-    Start   time.Time // Tracker creation time
+    Name    string
+    Total   float64
+    Lowest  float64
+    Highest float64
+    Count   float64
+    Start   time.Time
 }
 
-var timeTrackers = map[string]*Accumulator{}
+func (t *Accumulator) Record(nextValue float64) // Add a sample
+func (t *Accumulator) Average() float64         // Compute mean
+func (t *Accumulator) Stats() (lowest, highest, average, count float64)
 
-// Track execution time for performance analysis
-func TrackTime(name string, timePassed float64) {
-    if _, ok := timeTrackers[name]; !ok {
-        timeTrackers[name] = &Accumulator{
-            Name:  name,
-            Start: time.Now(),
-        }
-    }
-    timeTrackers[name].Record(timePassed)
-}
-
-// Get all performance tracking data
-func GetTimeTrackers() []Accumulator {
-    result := []Accumulator{}
-    for _, t := range timeTrackers {
-        result = append(result, *t)
-    }
-    return result
-}
+func TrackTime(name string, timePassed float64) // Record a timing sample by name
+func GetTimeTrackers() []Accumulator            // Return all accumulated stats
 ```
 
-## String Processing System
+## String Processing
 
-### Text Matching and Search
+### Text Matching
+
 ```go
-// Sophisticated fuzzy matching algorithm
-func FindMatchIn(searchFor string, searchIn ...string) (closeMatch string, exactMatch string) {
-    searchFor = strings.ToLower(strings.TrimSpace(searchFor))
-    
-    if searchFor == "" {
-        return "", ""
-    }
-    
-    var bestPartialMatch string
-    var bestPartialScore int
-    
-    for _, candidate := range searchIn {
-        candidateLower := strings.ToLower(candidate)
-        
-        // Exact match takes priority
-        if candidateLower == searchFor {
-            return candidate, candidate
-        }
-        
-        // Prefix matching
-        if strings.HasPrefix(candidateLower, searchFor) {
-            if bestPartialMatch == "" || len(candidate) < len(bestPartialMatch) {
-                bestPartialMatch = candidate
-            }
-        }
-        
-        // Substring matching with scoring
-        if strings.Contains(candidateLower, searchFor) {
-            score := calculateMatchScore(searchFor, candidateLower)
-            if score > bestPartialScore {
-                bestPartialScore = score
-                bestPartialMatch = candidate
-            }
-        }
-    }
-    
-    return bestPartialMatch, ""
-}
+// FindMatchIn searches a list of strings for the best match.
+// Returns (exactMatch, closeMatch). Supports "#N" suffix for nth-match selection
+// (e.g. "sword#2" finds the second sword). Falls back to substring search if no
+// prefix/exact match is found.
+func FindMatchIn(searchName string, items ...string) (match string, closeMatch string)
 
-// Strip common prepositions for better matching
-var strippablePrepositions = []string{
-    "onto", "into", "over", "to", "toward", "towards",
-    "from", "in", "under", "upon", "with", "the", "my",
-}
+// GetMatchNumber splits "sword#2" -> ("sword", 2). Returns 1 if no # present.
+func GetMatchNumber(input string) (string, int)
 
-func StripPrepositions(input string) string {
-    words := strings.Fields(strings.ToLower(input))
-    filtered := []string{}
-    
-    for _, word := range words {
-        isPreposition := false
-        for _, prep := range strippablePrepositions {
-            if word == prep {
-                isPreposition = true
-                break
-            }
-        }
-        if !isPreposition {
-            filtered = append(filtered, word)
-        }
-    }
-    
-    return strings.Join(filtered, " ")
-}
+// BreakIntoParts splits "a b c" into ["a b c", "b c", "c"] for progressive matching.
+func BreakIntoParts(full string) []string
+```
+
+### Preposition Stripping
+
+```go
+// StripPrepositions removes leading/embedded prepositions:
+// onto, into, over, to, toward, towards, from, in, under, upon, with, the, my
+func StripPrepositions(input string) string
+```
+
+### String Splitting
+
+```go
+// SplitString word-wraps text to lineWidth, respecting CJK character widths.
+// Handles existing \n line breaks and punctuation attachment.
+func SplitString(input string, lineWidth int) []string
+
+// SplitStringNL is like SplitString but joins with \r\n (and optional line prefix).
+func SplitStringNL(input string, lineWidth int, nlPrefix ...string) string
+
+// SplitButRespectQuotes splits on whitespace but keeps quoted strings together.
+// Removes surrounding quotes from matched tokens.
+func SplitButRespectQuotes(s string) []string
+```
+
+### Wildcard Matching
+
+```go
+// StringWildcardMatch matches stringToSearch against a pattern.
+// Supports leading * (endsWith), trailing * (startsWith), both * (contains).
+func StringWildcardMatch(stringToSearch string, patternToSearch string) bool
 ```
 
 ### Color Code Processing
+
 ```go
-var colorShortTagRegex = regexp.MustCompile(`\{(\d*)(?::)?(\d*)?\}`)
+// ConvertColorShortTags converts {fg:bg} short tags to <ansi> XML tags.
+// Example: {1:2} -> <ansi fg="1" bg="2">
+func ConvertColorShortTags(input string) string
 
-// Convert short color tags to full ANSI codes
-func ConvertColorShortTags(input string) string {
-    return colorShortTagRegex.ReplaceAllStringFunc(input, func(match string) string {
-        // Extract color codes and convert to ANSI
-        return convertToAnsiColor(match)
-    })
-}
+// StripANSI removes ANSI escape sequences (\x1b[...m) from a string.
+func StripANSI(str string) string
 
-// Strip all color codes for plain text output
-func StripColorCodes(input string) string {
-    // Remove ANSI escape sequences
-    ansiRegex := regexp.MustCompile(`\x1b\[[0-9;]*m`)
-    stripped := ansiRegex.ReplaceAllString(input, "")
-    
-    // Remove custom color tags
-    stripped = colorShortTagRegex.ReplaceAllString(stripped, "")
-    
-    return stripped
-}
+// StripCharsForScreenReaders replaces box-drawing and decorative characters
+// with spaces for screen-reader accessibility.
+func StripCharsForScreenReaders(s string) string
 ```
 
 ### Filename Sanitization
-```go
-// Convert text to safe filename across all platforms
-func ConvertForFilename(input string) string {
-    // Remove/replace unsafe characters
-    unsafe := regexp.MustCompile(`[<>:"/\\|?*\x00-\x1f]`)
-    safe := unsafe.ReplaceAllString(input, "_")
-    
-    // Handle reserved names on Windows
-    reserved := []string{"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", 
-                         "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", 
-                         "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", 
-                         "LPT7", "LPT8", "LPT9"}
-    
-    upper := strings.ToUpper(safe)
-    for _, name := range reserved {
-        if upper == name {
-            safe = "_" + safe
-            break
-        }
-    }
-    
-    // Trim spaces and dots
-    safe = strings.Trim(safe, " .")
-    
-    // Ensure not empty
-    if safe == "" {
-        safe = "unnamed"
-    }
-    
-    return safe
-}
 
-// Cross-platform file path construction
-func FilePath(parts ...string) string {
-    return filepath.Join(parts...)
-}
+```go
+// ConvertForFilename lowercases input and replaces any character that is not
+// [a-z0-9] with '_'. Apostrophes are silently dropped.
+func ConvertForFilename(input string) string
+
+// FilePath joins path parts using the OS path separator (filepath.FromSlash).
+func FilePath(pathParts ...string) string
 ```
 
-## Cryptographic Services
+### Number Formatting
 
-### Password Hashing
 ```go
-// Secure password hashing with SHA-256
-func Hash(input string) string {
-    hasher := sha256.New()
-    hasher.Write([]byte(input))
-    return hex.EncodeToString(hasher.Sum(nil))
-}
+// FormatNumber formats an integer with comma separators (e.g. 1234567 -> "1,234,567").
+func FormatNumber(n int) string
 
-// Legacy MD5 support for compatibility
-func Md5Hash(input string) string {
-    hasher := md5.New()
-    hasher.Write([]byte(input))
-    return hex.EncodeToString(hasher.Sum(nil))
-}
-
-// Base64 encoding utilities
-func EncodeBase64(data []byte) string {
-    return base64.StdEncoding.EncodeToString(data)
-}
-
-func DecodeBase64(encoded string) ([]byte, error) {
-    return base64.StdEncoding.DecodeString(encoded)
-}
+// BoolYN returns "yes" or "no".
+func BoolYN(b bool) string
 ```
 
-### Random Number Generation
+### Visual / UI Helpers
+
 ```go
-// Seeded random number generation
-func Rand(max int) int {
-    if max <= 0 {
-        return 0
-    }
-    return rand.Intn(max)
-}
+// ProgressBar returns (fullBar, emptyBar) strings using block characters.
+// complete is a 0.0–1.0 fraction. Custom bar characters can be provided.
+func ProgressBar(complete float64, maxBarSize int, barParts ...string) (fullBar string, emptyBar string)
 
-// Dice rolling simulation
-func RollDice(count, sides int) int {
-    if count <= 0 || sides <= 0 {
-        return 0
-    }
-    
-    total := 0
-    for i := 0; i < count; i++ {
-        total += rand.Intn(sides) + 1
-    }
-    return total
-}
+// HealthClass returns a CSS class string like "health-70" quantized to 10s.
+func HealthClass(health int, maxHealth int) string
 
-// Percentage chance evaluation
-func RollPercent(chance int) bool {
-    if chance <= 0 {
-        return false
-    }
-    if chance >= 100 {
-        return true
-    }
-    return rand.Intn(100) < chance
-}
+// ManaClass returns a CSS class string like "mana-50" quantized to 10s.
+func ManaClass(mana int, maxMana int) string
+
+// QuantizeTens returns value/max as a percentage quantized to the nearest 10.
+func QuantizeTens(value int, max int) int
+
+// PercentOfTotal returns (value1+value2)/value1 as a float64.
+func PercentOfTotal(value1 int, value2 int) float64
 ```
 
-## Memory Management System
+## Cryptographic and Hashing
 
-### Memory Tracking
+```go
+// Hash returns the hex-encoded SHA-256 of input (used for legacy password hashing).
+func Hash(input string) string
+
+// HashBytes returns the hex-encoded SHA-256 of a byte slice.
+func HashBytes(input []byte) string
+
+// Md5 returns the hex-encoded MD5 of a string.
+func Md5(input string) string
+
+// Md5Bytes returns the raw MD5 bytes of a byte slice.
+func Md5Bytes(input []byte) []byte
+```
+
+### Lock Sequence Generation
+
+```go
+// GetLockSequence generates a deterministic UP/DOWN sequence (e.g. "UUDUDD")
+// from a lock identifier, difficulty (2–32 steps), and seed string.
+// Used for puzzle locks in the game world.
+func GetLockSequence(lockIdentifier string, difficulty int, seed string) string
+```
+
+## Random Number Generation
+
+```go
+// Rand returns a random int in [0, maxInt). Returns 0 if maxInt < 1.
+func Rand(maxInt int) int
+
+// RollDice rolls `dice` dice with `sides` sides each, summing the results.
+// Negative dice count inverts the total. Uses Rand internally.
+func RollDice(dice int, sides int) int
+
+// LogRoll logs a debug message for a roll result vs target number.
+func LogRoll(name string, rollResult int, targetNumber int)
+```
+
+### Dice Roll Parsing
+
+```go
+// ParseDiceRoll parses a dice expression like "2@1d6+3#9,11" into components.
+// Format: [attacks@]dCount d dSides [+/-bonus] [#buffId,buffId,...]
+func ParseDiceRoll(dRoll string) (attacks int, dCount int, dSides int, bonus int, buffOnCrit []int)
+
+// FormatDiceRoll serializes the components back into a dice expression string.
+func FormatDiceRoll(attacks int, dCount int, dSides int, bonus int, buffOnCrit []int) string
+```
+
+## Data Compression and Encoding
+
+```go
+// Compress gzip-compresses a byte slice. Returns empty slice on error.
+func Compress(input []byte) []byte
+
+// Decompress gzip-decompresses a byte slice. Returns empty slice on error.
+func Decompress(input []byte) []byte
+
+// Encode base64-encodes a byte slice (standard encoding).
+func Encode(blobdata []byte) string
+
+// Decode base64-decodes a string. Ignores errors (returns nil on failure).
+func Decode(base64str string) []byte
+```
+
+## File Operations
+
+```go
+// SafeSave writes data to path+".new" then renames it to path.
+// Reduces risk of corruption from interrupted writes.
+func SafeSave(path string, data []byte) error
+
+// Save writes data to path. If doSafe is true, delegates to SafeSave.
+func Save(path string, data []byte, doSafe ...bool) error
+
+// ValidateWorldFiles checks that all subdirectories present in exampleWorldPath
+// also exist in worldPath. Returns an error if any are missing.
+func ValidateWorldFiles(exampleWorldPath string, worldPath string) error
+```
+
+## Network Utilities
+
+```go
+// SetServerAddress / GetServerAddress manage a global server address string.
+func SetServerAddress(addr string)
+func GetServerAddress() string
+
+// GetMyIP fetches the server's public IP from api.ipify.org.
+func GetMyIP() string
+```
+
+## Memory Management (`memory.go`)
+
 ```go
 type MemReport func() map[string]MemoryResult
 
 type MemoryResult struct {
-    Memory uint64 // Memory usage in bytes
-    Count  int    // Number of items
+    Memory uint64 // Bytes
+    Count  int    // Item count
 }
 
-var (
-    memoryTrackerNames []string
-    memoryTrackers     []MemReport
-)
+// AddMemoryReporter registers a named memory reporter function.
+func AddMemoryReporter(name string, reporter MemReport)
 
-// Register memory tracking for a system
-func AddMemoryReporter(name string, reporter MemReport) {
-    memoryTrackerNames = append(memoryTrackerNames, name)
-    memoryTrackers = append(memoryTrackers, reporter)
-}
+// GetMemoryReport calls all registered reporters and returns their results.
+func GetMemoryReport() (names []string, trackedResults []map[string]MemoryResult)
 
-// Get comprehensive memory report
-func GetMemoryReport() (names []string, trackedResults []map[string]MemoryResult) {
-    names = append([]string{}, memoryTrackerNames...)
-    trackedResults = []map[string]MemoryResult{}
-    
-    for _, reporter := range memoryTrackers {
-        trackedResults = append(trackedResults, reporter())
-    }
-    
-    return names, trackedResults
-}
+// MemoryUsage estimates the memory footprint of any value using reflection.
+// Handles pointers, slices, structs, maps, arrays, and strings.
+func MemoryUsage(i interface{}) uint64
 
-// Calculate memory usage of any data structure
-func MemoryUsage(v interface{}) uint64 {
-    return calculateMemoryUsage(reflect.ValueOf(v), make(map[uintptr]bool))
-}
+// FormatBytes formats a byte count as a human-readable string (KB, MB, GB, etc.).
+func FormatBytes(bytes uint64) string
 
-func calculateMemoryUsage(v reflect.Value, visited map[uintptr]bool) uint64 {
-    if !v.IsValid() {
-        return 0
-    }
-    
-    var size uint64
-    
-    switch v.Kind() {
-    case reflect.Ptr, reflect.Interface:
-        if v.IsNil() {
-            return 0
-        }
-        
-        ptr := v.Pointer()
-        if visited[ptr] {
-            return 0 // Avoid infinite loops
-        }
-        visited[ptr] = true
-        
-        size += 8 // Pointer size
-        size += calculateMemoryUsage(v.Elem(), visited)
-        
-    case reflect.Slice:
-        size += 24 // Slice header
-        for i := 0; i < v.Len(); i++ {
-            size += calculateMemoryUsage(v.Index(i), visited)
-        }
-        
-    case reflect.Map:
-        size += 8 // Map header
-        for _, key := range v.MapKeys() {
-            size += calculateMemoryUsage(key, visited)
-            size += calculateMemoryUsage(v.MapIndex(key), visited)
-        }
-        
-    case reflect.String:
-        size += uint64(v.Len())
-        
-    case reflect.Struct:
-        for i := 0; i < v.NumField(); i++ {
-            size += calculateMemoryUsage(v.Field(i), visited)
-        }
-        
-    default:
-        size += uint64(v.Type().Size())
-    }
-    
-    return size
-}
+// ServerStats returns a formatted ANSI string with Go runtime memory stats
+// (heap, stack, total, GC count, GOMAXPROCS, goroutine count).
+func ServerStats() string
+
+// ServerGetMemoryUsage returns a MemoryResult map of Go runtime stats.
+// Automatically registered as the "Go" memory reporter on init.
+func ServerGetMemoryUsage() map[string]MemoryResult
 ```
 
-### System Statistics
-```go
-// Get comprehensive server statistics
-func ServerStats() string {
-    var m runtime.MemStats
-    runtime.ReadMemStats(&m)
-    
-    return fmt.Sprintf(
-        "Heap: %dMB  Largest Heap: %dMB\n"+
-        "Stack: %dMB\n"+
-        "Total Mem: %dMB\n"+
-        "GC Count: %d\n"+
-        "NumCPU: %d\n",
-        bToMb(m.HeapInuse),
-        bToMb(m.HeapSys),
-        bToMb(m.StackSys),
-        bToMb(m.Sys),
-        m.NumGC,
-        runtime.NumCPU(),
-    )
-}
+## Synchronous Hook System (`hook.go`)
 
-func bToMb(b uint64) uint64 {
-    return b / 1024 / 1024
-}
+`Hook[T]` is a generic, type-safe synchronous callback chain. Each registered handler receives the current value, may modify it, and returns the (possibly modified) value. All handlers run in registration order. The final value is returned to the caller.
+
+```go
+type Hook[T any] struct { ... }
+
+// Register adds a handler. Thread-safe.
+func (h *Hook[T]) Register(fn func(T) T)
+
+// Fire runs all handlers in order, threading the return value through each.
+// Thread-safe. Returns the original value unchanged if no handlers are registered.
+func (h *Hook[T]) Fire(data T) T
 ```
 
-## File and Data Operations
+### Defining a Hook Point
 
-### File Utilities
 ```go
-// Check if file exists
-func FileExists(filename string) bool {
-    _, err := os.Stat(filename)
-    return err == nil
-}
+// In the package that owns the data:
+var OnGetDetails util.Hook[RoomTemplateDetails]
 
-// Create directory if it doesn't exist
-func EnsureDirectory(path string) error {
-    return os.MkdirAll(path, 0755)
-}
-
-// Copy file contents
-func CopyFile(src, dst string) error {
-    sourceFile, err := os.Open(src)
-    if err != nil {
-        return err
-    }
-    defer sourceFile.Close()
-    
-    destFile, err := os.Create(dst)
-    if err != nil {
-        return err
-    }
-    defer destFile.Close()
-    
-    _, err = io.Copy(destFile, sourceFile)
-    return err
-}
+// At the call site:
+details = rooms.OnGetDetails.Fire(details)
 ```
 
-### Data Compression
+### Registering a Handler
+
 ```go
-// Compress data using gzip
-func CompressData(data []byte) ([]byte, error) {
-    var buf bytes.Buffer
-    writer := gzip.NewWriter(&buf)
-    
-    _, err := writer.Write(data)
-    if err != nil {
-        return nil, err
-    }
-    
-    err = writer.Close()
-    if err != nil {
-        return nil, err
-    }
-    
-    return buf.Bytes(), nil
-}
-
-// Decompress gzip data
-func DecompressData(data []byte) ([]byte, error) {
-    reader, err := gzip.NewReader(bytes.NewReader(data))
-    if err != nil {
-        return nil, err
-    }
-    defer reader.Close()
-    
-    return io.ReadAll(reader)
-}
-```
-
-## Text Processing and Internationalization
-
-### Multi-language Support
-```go
-// Regular expressions for different text types
-var (
-    // CJK character support (Chinese, Japanese, Korean)
-    wordRegex = regexp.MustCompile(`([\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}]|\w+|[\p{P}\p{S}\s]+)`)
-    punctuationRegex = regexp.MustCompile(`[\p{P}]+`)
-)
-
-// Count visual width accounting for CJK characters
-func VisualWidth(text string) int {
-    return runewidth.StringWidth(text)
-}
-
-// Word wrapping with CJK support
-func WordWrap(text string, width int) []string {
-    if width <= 0 {
-        return []string{text}
-    }
-    
-    words := wordRegex.FindAllString(text, -1)
-    lines := []string{}
-    currentLine := ""
-    currentWidth := 0
-    
-    for _, word := range words {
-        wordWidth := runewidth.StringWidth(word)
-        
-        if currentWidth+wordWidth > width && currentLine != "" {
-            lines = append(lines, currentLine)
-            currentLine = word
-            currentWidth = wordWidth
-        } else {
-            currentLine += word
-            currentWidth += wordWidth
-        }
-    }
-    
-    if currentLine != "" {
-        lines = append(lines, currentLine)
-    }
-    
-    return lines
-}
-```
-
-## Network and Server Utilities
-
-### Server Management
-```go
-var serverAddr string = "Unknown"
-
-// Set server address for identification
-func SetServerAddress(addr string) {
-    serverAddr = addr
-}
-
-func GetServerAddress() string {
-    return serverAddr
-}
-
-// HTTP utility functions
-func IsValidURL(url string) bool {
-    _, err := http.Get(url)
-    return err == nil
-}
-
-// Network address validation
-func ValidateIPAddress(ip string) bool {
-    return net.ParseIP(ip) != nil
-}
-```
-
-## Integration Patterns
-
-### Performance Monitoring Integration
-```go
-// Track function execution time
-func TrackExecutionTime(name string, fn func()) {
-    start := time.Now()
-    fn()
-    duration := time.Since(start)
-    TrackTime(name, duration.Seconds())
-}
-
-// Memory usage monitoring
-func MonitorMemoryUsage(system string, data interface{}) {
-    usage := MemoryUsage(data)
-    mudlog.Debug("Memory Usage", "system", system, "bytes", usage, "mb", usage/1024/1024)
-}
-```
-
-### Thread Safety Integration
-```go
-// Safe game data access pattern
-func SafeGameOperation(operation func()) {
-    LockMud()
-    defer UnlockMud()
-    operation()
-}
-
-// Safe game data reading pattern
-func SafeGameRead(reader func()) {
-    RLockMud()
-    defer RUnlockMud()
-    reader()
-}
-```
-
-## Usage Examples
-
-### Performance Tracking
-```go
-// Track command execution time
-start := time.Now()
-executePlayerCommand(user, command)
-duration := time.Since(start)
-util.TrackTime("player_commands", duration.Seconds())
-
-// Get performance report
-trackers := util.GetTimeTrackers()
-for _, tracker := range trackers {
-    fmt.Printf("%s: avg=%.3fs, min=%.3fs, max=%.3fs, count=%.0f\n",
-        tracker.Name, tracker.Average, tracker.Lowest, tracker.Highest, tracker.Count)
-}
-```
-
-### Text Processing
-```go
-// Fuzzy item search
-itemName := "rusty sword"
-items := []string{"Rusty Iron Sword", "Sharp Blade", "Old Rusty Dagger"}
-
-closeMatch, exactMatch := util.FindMatchIn(itemName, items...)
-if exactMatch != "" {
-    fmt.Printf("Found exact match: %s\n", exactMatch)
-} else if closeMatch != "" {
-    fmt.Printf("Found close match: %s\n", closeMatch)
-}
-
-// Filename sanitization
-playerName := "Player/Name<With>Bad:Characters"
-safeFilename := util.ConvertForFilename(playerName)
-// Result: "Player_Name_With_Bad_Characters"
-```
-
-### Memory Monitoring
-```go
-// Register memory reporter for a system
-util.AddMemoryReporter("Users", func() map[string]util.MemoryResult {
-    return map[string]util.MemoryResult{
-        "active_users": {util.MemoryUsage(activeUsers), len(activeUsers)},
-        "user_cache":   {util.MemoryUsage(userCache), len(userCache)},
-    }
+// From a module or plugin:
+rooms.OnGetDetails.Register(func(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
+    // modify d...
+    return d
 })
-
-// Get memory report
-names, results := util.GetMemoryReport()
-for i, name := range names {
-    fmt.Printf("System: %s\n", name)
-    for component, result := range results[i] {
-        fmt.Printf("  %s: %d bytes (%d items)\n", 
-            component, result.Memory, result.Count)
-    }
-}
 ```
+
+### Currently Defined Hook Points
+
+- **`rooms.OnGetDetails`** (`util.Hook[RoomTemplateDetails]`) — fired at the end of `rooms.GetDetails`, allowing modules to modify room details before they reach the caller.
 
 ## Dependencies
 
-- `crypto/sha256` - Secure password hashing
-- `crypto/md5` - Legacy hash support
-- `compress/gzip` - Data compression utilities
-- `github.com/mattn/go-runewidth` - CJK character width calculation
-- `internal/mudlog` - Logging system integration
-- `internal/term` - Terminal control and ANSI codes
-
-This comprehensive util system provides the essential foundation for all GoMud operations with thread-safe utilities, performance monitoring, advanced text processing, and robust system management capabilities.
+- `crypto/sha256`, `crypto/md5` - Hashing
+- `compress/gzip` - Data compression
+- `encoding/base64` - Base64 encoding
+- `math/rand` - Pseudo-random number generation
+- `sync` - Mutex for `mudLock` and `Hook[T]`
+- `reflect` - `MemoryUsage` implementation
+- `runtime` - `ServerStats` / `ServerGetMemoryUsage`
+- `path/filepath` - Cross-platform path handling
+- `github.com/mattn/go-runewidth` - CJK character width for `SplitString`
+- `internal/mudlog` - Debug logging for `LogRoll`, `LoadRoundCount`
+- `internal/term` - `CRLFStr` used in `SplitStringNL` and `ServerStats`

--- a/internal/web/context.md
+++ b/internal/web/context.md
@@ -194,23 +194,8 @@ type WebPlugin interface {
 web.SetWebPlugin(plugins.GetPluginRegistry())
 
 // Plugin implementation
-func (p *MyPlugin) NavLinks() map[string]string {
-    return map[string]string{
-        "My Feature": "/myplugin/dashboard",
-        "Settings":   "/myplugin/config",
-    }
-}
-
-func (p *MyPlugin) WebRequest(r *http.Request) (string, map[string]any, bool) {
-    if strings.HasPrefix(r.URL.Path, "/myplugin/") {
-        html := "<h1>Custom Plugin Page</h1>"
-        data := map[string]any{
-            "PluginData": "Custom content",
-        }
-        return html, data, true
-    }
-    return "", nil, false
-}
+func (p *MyPlugin) NavLinks() map[string]string
+func (p *MyPlugin) WebRequest(r *http.Request) (string, map[string]any, bool)
 ```
 
 ## Security Implementation
@@ -225,13 +210,7 @@ func (p *MyPlugin) WebRequest(r *http.Request) (string, map[string]any, bool) {
 ### Game State Protection
 ```go
 // All admin operations wrapped with mutex
-func RunWithMUDLocked(next http.HandlerFunc) http.HandlerFunc {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        util.LockMud()
-        defer util.UnlockMud()
-        next.ServeHTTP(w, r)
-    })
-}
+func RunWithMUDLocked(next http.HandlerFunc) http.HandlerFunc
 ```
 
 ## Configuration and Setup
@@ -397,35 +376,8 @@ mudlog.Info("Web",
 
 ### Plugin Web Integration
 ```go
-func (p *MyPlugin) WebRequest(r *http.Request) (string, map[string]any, bool) {
-    switch r.URL.Path {
-    case "/myplugin/dashboard":
-        return p.renderDashboard(r)
-    case "/myplugin/api/data":
-        return p.handleAPIRequest(r)
-    }
-    return "", nil, false
-}
-
-func (p *MyPlugin) renderDashboard(r *http.Request) (string, map[string]any, bool) {
-    html := `
-    {{template "_header.html" .}}
-    <h1>{{.PLUGIN_NAME}} Dashboard</h1>
-    <div class="plugin-content">
-        {{range .PLUGIN_ITEMS}}
-        <div class="item">{{.Name}}: {{.Value}}</div>
-        {{end}}
-    </div>
-    {{template "_footer.html" .}}
-    `
-    
-    data := map[string]any{
-        "PLUGIN_NAME":  "My Custom Plugin",
-        "PLUGIN_ITEMS": p.getPluginData(),
-    }
-    
-    return html, data, true
-}
+func (p *MyPlugin) WebRequest(r *http.Request) (string, map[string]any, bool)
+func (p *MyPlugin) renderDashboard(r *http.Request) (string, map[string]any, bool)
 ```
 
 This web system provides a robust foundation for both player-facing web interfaces and comprehensive administrative tools, with strong security, plugin extensibility, and real-time game integration capabilities.

--- a/main.go
+++ b/main.go
@@ -459,9 +459,9 @@ func resumeRestoredConnection(connDetails *connections.ConnectionDetails, userOb
 		if err != nil {
 			userObject.EventLog.Add(`conn`, `Disconnected`)
 
-			if c.Network.ZombieSeconds > 0 {
-				connDetails.SetState(connections.Zombie)
-				worldManager.SendSetZombie(userObject.UserId, true)
+			if c.Network.LinkDeadSeconds > 0 {
+				connDetails.SetState(connections.LinkDead)
+				worldManager.SendSetLinkDead(userObject.UserId, true)
 			} else {
 				worldManager.SendLeaveWorld(userObject.UserId)
 				worldManager.SendLogoutConnectionId(connDetails.ConnectionId())
@@ -695,15 +695,15 @@ func handleTelnetConnection(connDetails *connections.ConnectionDetails, wg *sync
 		n, err := connDetails.Read(inputBuffer)
 		if err != nil {
 
-			// If failed to read from the connection, switch to zombie state
+			// If failed to read from the connection, switch to linkdead state
 			if userObject != nil {
 
 				userObject.EventLog.Add(`conn`, `Disconnected`)
 
-				if c.Network.ZombieSeconds > 0 {
+				if c.Network.LinkDeadSeconds > 0 {
 
-					connDetails.SetState(connections.Zombie)
-					worldManager.SendSetZombie(userObject.UserId, true)
+					connDetails.SetState(connections.LinkDead)
+					worldManager.SendSetLinkDead(userObject.UserId, true)
 
 				} else {
 
@@ -992,15 +992,15 @@ func HandleWebSocketConnection(conn *websocket.Conn) {
 
 		if err != nil {
 
-			// If failed to read from the connection, switch to zombie state
+			// If failed to read from the connection, switch to linkdead state
 			if userObject != nil {
 
 				userObject.EventLog.Add(`conn`, `Disconnected`)
 
-				if c.Network.ZombieSeconds > 0 {
+				if c.Network.LinkDeadSeconds > 0 {
 
-					connDetails.SetState(connections.Zombie)
-					worldManager.SendSetZombie(userObject.UserId, true)
+					connDetails.SetState(connections.LinkDead)
+					worldManager.SendSetLinkDead(userObject.UserId, true)
 
 				} else {
 
@@ -1379,9 +1379,9 @@ func handleSSHConnection(connDetails *connections.ConnectionDetails, reqs <-chan
 		if err != nil {
 			if userObject != nil {
 				userObject.EventLog.Add(`conn`, `Disconnected`)
-				if c.Network.ZombieSeconds > 0 {
-					connDetails.SetState(connections.Zombie)
-					worldManager.SendSetZombie(userObject.UserId, true)
+				if c.Network.LinkDeadSeconds > 0 {
+					connDetails.SetState(connections.LinkDead)
+					worldManager.SendSetLinkDead(userObject.UserId, true)
 				} else {
 					worldManager.SendLeaveWorld(userObject.UserId)
 					worldManager.SendLogoutConnectionId(connDetails.ConnectionId())

--- a/modules/all-modules.go
+++ b/modules/all-modules.go
@@ -14,4 +14,5 @@ import (
 	_ "github.com/GoMudEngine/GoMud/modules/leaderboards"
 	_ "github.com/GoMudEngine/GoMud/modules/time"
 	_ "github.com/GoMudEngine/GoMud/modules/webhelp"
+	_ "github.com/GoMudEngine/GoMud/modules/zombiemode"
 )

--- a/modules/context.md
+++ b/modules/context.md
@@ -157,22 +157,7 @@ import (
 //go:embed files/*
 var files embed.FS
 
-func init() {
-    plugin := plugins.New("mymodule", "1.0")
-    
-    // Attach file system
-    plugin.AttachFileSystem(files)
-    
-    // Register commands
-    plugin.AddUserCommand("mycommand", myCommand, false, false)
-    
-    // Register event listeners
-    events.RegisterListener(events.NewRound{}, handleNewRound)
-    
-    // Set up callbacks
-    plugin.Callbacks.SetOnLoad(onLoad)
-    plugin.Callbacks.SetOnSave(onSave)
-}
+func init()
 ```
 
 ### **State Management**
@@ -181,27 +166,13 @@ type ModuleData struct {
     SomeState map[string]interface{} `json:"somestate"`
 }
 
-func (m *MyModule) save() {
-    data := ModuleData{SomeState: m.state}
-    m.plugin.WriteBytes("state.json", data)
-}
-
-func (m *MyModule) load() {
-    var data ModuleData
-    m.plugin.ReadBytes("state.json", &data)
-    m.state = data.SomeState
-}
+func (m *MyModule) save()
+func (m *MyModule) load()
 ```
 
 ### **Event Handling**
 ```go
-func (m *MyModule) handleNewRound(e events.Event) events.ListenerReturn {
-    if evt, ok := e.(events.NewRound); ok {
-        // Process round-based logic
-        m.processRoundLogic(evt.RoundNumber)
-    }
-    return events.Continue
-}
+func (m *MyModule) handleNewRound(e events.Event) events.ListenerReturn
 ```
 
 ## Integration Points

--- a/modules/zombiemode/command.zombie.go
+++ b/modules/zombiemode/command.zombie.go
@@ -1,0 +1,316 @@
+package zombiemode
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+func (m *ZombieModule) zombieCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+
+	args := util.SplitButRespectQuotes(strings.ToLower(strings.TrimSpace(rest)))
+
+	cfg, hasCfg := m.configs[user.UserId]
+	if !hasCfg {
+		cfg = ZombieConfig{Profiles: make(map[string]ZombieConfig)}
+		m.configs[user.UserId] = cfg
+	}
+
+	if len(args) == 0 {
+		m.showConfig(user, cfg)
+		return true, nil
+	}
+
+	switch args[0] {
+
+	case `start`:
+		if enabled, ok := m.plug.Config.Get(`Enabled`).(bool); ok && !enabled {
+			user.SendText(`Zombie mode is disabled on this server.`)
+			return true, nil
+		}
+		if _, alreadyActive := m.active[user.UserId]; alreadyActive {
+			user.SendText(`Zombie mode is already active.`)
+			return true, nil
+		}
+		m.active[user.UserId] = zombieRuntime{HomeRoom: user.Character.RoomId}
+		user.Character.SetAdjective(`zombie`, true)
+		user.SendText(`<ansi fg="yellow">Zombie mode activated. Send any input to wake up.</ansi>`)
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi>'s eyes glaze over...`, user.Character.Name), user.UserId)
+		return true, nil
+
+	case `set`:
+		if len(args) < 3 {
+			user.SendText(`Usage: zombie set <combat|roam|rest|loot> <value>`)
+			return true, nil
+		}
+		return m.handleSet(args[1], args[2:], user, cfg)
+
+	case `unset`:
+		if len(args) < 2 {
+			user.SendText(`Usage: zombie unset <combat|roam|rest|loot> [name]`)
+			return true, nil
+		}
+		return m.handleUnset(args[1], args[2:], user, cfg)
+
+	case `save`:
+		if len(args) < 2 {
+			user.SendText(`Usage: zombie save <profile-name>`)
+			return true, nil
+		}
+		profileName := args[1]
+		if cfg.Profiles == nil {
+			cfg.Profiles = make(map[string]ZombieConfig)
+		}
+		if _, exists := cfg.Profiles[profileName]; !exists && len(cfg.Profiles) >= 5 {
+			user.SendText(`You cannot save more than 5 profiles. Delete one with <ansi fg="command">zombie delete <name></ansi>.`)
+			return true, nil
+		}
+		saved := ZombieConfig{
+			CombatTargets: append([]string{}, cfg.CombatTargets...),
+			RoamRadius:    cfg.RoamRadius,
+			RestThreshold: cfg.RestThreshold,
+			LootTargets:   append([]string{}, cfg.LootTargets...),
+		}
+		cfg.Profiles[profileName] = saved
+		m.configs[user.UserId] = cfg
+		user.SendText(fmt.Sprintf(`Profile <ansi fg="yellow">%s</ansi> saved.`, profileName))
+		return true, nil
+
+	case `load`:
+		if len(args) < 2 {
+			user.SendText(`Usage: zombie load <profile-name>`)
+			return true, nil
+		}
+		profileName := args[1]
+		if cfg.Profiles == nil {
+			user.SendText(`No profiles saved.`)
+			return true, nil
+		}
+		p, ok := cfg.Profiles[profileName]
+		if !ok {
+			user.SendText(fmt.Sprintf(`Profile <ansi fg="yellow">%s</ansi> not found.`, profileName))
+			return true, nil
+		}
+		cfg.CombatTargets = append([]string{}, p.CombatTargets...)
+		cfg.RoamRadius = p.RoamRadius
+		cfg.RestThreshold = p.RestThreshold
+		cfg.LootTargets = append([]string{}, p.LootTargets...)
+		m.configs[user.UserId] = cfg
+		user.SendText(fmt.Sprintf(`Profile <ansi fg="yellow">%s</ansi> loaded.`, profileName))
+		return true, nil
+
+	case `list`:
+		if len(cfg.Profiles) == 0 {
+			user.SendText(`No saved profiles.`)
+			return true, nil
+		}
+		names := make([]string, 0, len(cfg.Profiles))
+		for name := range cfg.Profiles {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		user.SendText(fmt.Sprintf(`<ansi fg="black-bold">.:.</ansi> <ansi fg="magenta">Zombie Profiles</ansi> [<ansi fg="yellow">%d/5</ansi>]`, len(cfg.Profiles)))
+		for _, name := range names {
+			p := cfg.Profiles[name]
+			user.SendText(``)
+			user.SendText(fmt.Sprintf(`  <ansi fg="yellow-bold">%s</ansi>`, name))
+			combatStr := `<ansi fg="red">none</ansi>`
+			if len(p.CombatTargets) > 0 {
+				combatStr = `<ansi fg="yellow">` + strings.Join(p.CombatTargets, `, `) + `</ansi>`
+			}
+			user.SendText(fmt.Sprintf(`    <ansi fg="white">Combat targets:</ansi> %s`, combatStr))
+			roamStr := `<ansi fg="red">disabled</ansi>`
+			if p.RoamRadius > 0 {
+				roamStr = fmt.Sprintf(`<ansi fg="yellow">%d</ansi>`, p.RoamRadius)
+			}
+			user.SendText(fmt.Sprintf(`    <ansi fg="white">Roam radius:   </ansi> %s`, roamStr))
+			restStr := `<ansi fg="red">disabled</ansi>`
+			if p.RestThreshold > 0 {
+				restStr = fmt.Sprintf(`<ansi fg="yellow">%d%%</ansi>`, p.RestThreshold)
+			}
+			user.SendText(fmt.Sprintf(`    <ansi fg="white">Rest threshold:</ansi> %s`, restStr))
+			lootStr := `<ansi fg="red">none</ansi>`
+			if len(p.LootTargets) > 0 {
+				lootStr = `<ansi fg="yellow">` + strings.Join(p.LootTargets, `, `) + `</ansi>`
+			}
+			user.SendText(fmt.Sprintf(`    <ansi fg="white">Loot targets:  </ansi> %s`, lootStr))
+		}
+		return true, nil
+
+	case `delete`:
+		if len(args) < 2 {
+			user.SendText(`Usage: zombie delete <profile-name>`)
+			return true, nil
+		}
+		profileName := args[1]
+		if _, ok := cfg.Profiles[profileName]; !ok {
+			user.SendText(fmt.Sprintf(`Profile <ansi fg="yellow">%s</ansi> not found.`, profileName))
+			return true, nil
+		}
+		delete(cfg.Profiles, profileName)
+		m.configs[user.UserId] = cfg
+		user.SendText(fmt.Sprintf(`Profile <ansi fg="yellow">%s</ansi> deleted.`, profileName))
+		return true, nil
+	}
+
+	user.SendText(`Unknown zombie subcommand. Type <ansi fg="command">help zombie</ansi> for usage.`)
+	return true, nil
+}
+
+func (m *ZombieModule) handleSet(field string, valueArgs []string, user *users.UserRecord, cfg ZombieConfig) (bool, error) {
+	value := strings.Join(valueArgs, ` `)
+
+	switch field {
+	case `combat`:
+		name := value
+		if name == `all` {
+			name = `*`
+		}
+		if !containsString(cfg.CombatTargets, name) {
+			cfg.CombatTargets = append(cfg.CombatTargets, name)
+		}
+		m.configs[user.UserId] = cfg
+		user.SendText(fmt.Sprintf(`Combat target <ansi fg="yellow">%s</ansi> added.`, name))
+
+	case `roam`:
+		radius, err := strconv.Atoi(value)
+		if err != nil || radius < 0 {
+			user.SendText(`Roam radius must be a non-negative integer.`)
+			return true, nil
+		}
+		cfg.RoamRadius = radius
+		m.configs[user.UserId] = cfg
+		user.SendText(fmt.Sprintf(`Roam radius set to <ansi fg="yellow">%d</ansi>.`, radius))
+
+	case `rest`:
+		pct, err := strconv.Atoi(value)
+		if err != nil || pct < 1 || pct > 99 {
+			user.SendText(`Rest threshold must be an integer between 1 and 99.`)
+			return true, nil
+		}
+		cfg.RestThreshold = pct
+		m.configs[user.UserId] = cfg
+		user.SendText(fmt.Sprintf(`Rest threshold set to <ansi fg="yellow">%d%%</ansi>.`, pct))
+
+	case `loot`:
+		name := value
+		if name == `all` {
+			name = `*`
+		}
+		if !containsString(cfg.LootTargets, name) {
+			cfg.LootTargets = append(cfg.LootTargets, name)
+		}
+		m.configs[user.UserId] = cfg
+		user.SendText(fmt.Sprintf(`Loot target <ansi fg="yellow">%s</ansi> added.`, name))
+
+	default:
+		user.SendText(`Unknown setting. Valid settings: combat, roam, rest, loot`)
+	}
+
+	return true, nil
+}
+
+func (m *ZombieModule) handleUnset(field string, valueArgs []string, user *users.UserRecord, cfg ZombieConfig) (bool, error) {
+	value := strings.Join(valueArgs, ` `)
+
+	switch field {
+	case `combat`:
+		if value == `` || value == `all` {
+			cfg.CombatTargets = nil
+			user.SendText(`All combat targets cleared.`)
+		} else {
+			cfg.CombatTargets = removeString(cfg.CombatTargets, value)
+			user.SendText(fmt.Sprintf(`Combat target <ansi fg="yellow">%s</ansi> removed.`, value))
+		}
+		m.configs[user.UserId] = cfg
+
+	case `roam`:
+		cfg.RoamRadius = 0
+		m.configs[user.UserId] = cfg
+		user.SendText(`Roaming disabled.`)
+
+	case `rest`:
+		cfg.RestThreshold = 0
+		m.configs[user.UserId] = cfg
+		user.SendText(`Rest threshold disabled.`)
+
+	case `loot`:
+		if value == `` || value == `all` {
+			cfg.LootTargets = nil
+			user.SendText(`All loot targets cleared.`)
+		} else {
+			cfg.LootTargets = removeString(cfg.LootTargets, value)
+			user.SendText(fmt.Sprintf(`Loot target <ansi fg="yellow">%s</ansi> removed.`, value))
+		}
+		m.configs[user.UserId] = cfg
+
+	default:
+		user.SendText(`Unknown setting. Valid settings: combat, roam, rest, loot`)
+	}
+
+	return true, nil
+}
+
+func (m *ZombieModule) showConfig(user *users.UserRecord, cfg ZombieConfig) {
+	_, isActive := m.active[user.UserId]
+
+	activeStr := `<ansi fg="red">inactive</ansi>`
+	if isActive {
+		activeStr = `<ansi fg="green">ACTIVE</ansi>`
+	}
+
+	user.SendText(fmt.Sprintf(`<ansi fg="black-bold">.:.</ansi> <ansi fg="magenta">Zombie Mode</ansi> [%s]`, activeStr))
+	user.SendText(``)
+
+	combatStr := `<ansi fg="red">none</ansi>`
+	if len(cfg.CombatTargets) > 0 {
+		combatStr = `<ansi fg="yellow">` + strings.Join(cfg.CombatTargets, `, `) + `</ansi>`
+	}
+	user.SendText(fmt.Sprintf(`  <ansi fg="white">Combat targets:</ansi> %s`, combatStr))
+
+	roamStr := `<ansi fg="red">disabled</ansi>`
+	if cfg.RoamRadius > 0 {
+		roamStr = fmt.Sprintf(`<ansi fg="yellow">%d</ansi>`, cfg.RoamRadius)
+	}
+	user.SendText(fmt.Sprintf(`  <ansi fg="white">Roam radius:   </ansi> %s`, roamStr))
+
+	restStr := `<ansi fg="red">disabled</ansi>`
+	if cfg.RestThreshold > 0 {
+		restStr = fmt.Sprintf(`<ansi fg="yellow">%d%%</ansi>`, cfg.RestThreshold)
+	}
+	user.SendText(fmt.Sprintf(`  <ansi fg="white">Rest threshold:</ansi> %s`, restStr))
+
+	lootStr := `<ansi fg="red">none</ansi>`
+	if len(cfg.LootTargets) > 0 {
+		lootStr = `<ansi fg="yellow">` + strings.Join(cfg.LootTargets, `, `) + `</ansi>`
+	}
+	user.SendText(fmt.Sprintf(`  <ansi fg="white">Loot targets:  </ansi> %s`, lootStr))
+
+	user.SendText(``)
+	user.SendText(`Type <ansi fg="command">help zombie</ansi> for usage.`)
+}
+
+func containsString(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(slice []string, s string) []string {
+	out := slice[:0]
+	for _, v := range slice {
+		if v != s {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/modules/zombiemode/files/data-overlays/config.yaml
+++ b/modules/zombiemode/files/data-overlays/config.yaml
@@ -1,0 +1,11 @@
+################################################################################
+# If modified, these settings will be copied into your config overrides
+# folder under `Modules.zombiemode`:
+#
+# Modules:
+#   zombiemode:
+#     Enabled: true
+################################################################################
+# - Enabled -
+#   Set to false to disable zombie mode server-wide.
+Enabled: true

--- a/modules/zombiemode/files/datafiles/templates/help/zombie.template
+++ b/modules/zombiemode/files/datafiles/templates/help/zombie.template
@@ -1,0 +1,57 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for the <ansi fg="command">zombie</ansi> command.</ansi>
+
+The <ansi fg="command">zombie</ansi> command lets you enter auto-play mode. While active, your character
+acts on its own according to your configured behaviors. Any input you send
+will immediately wake you up and execute that command normally.
+
+<ansi fg="yellow">Usage:</ansi>
+
+  <ansi fg="command">zombie</ansi>
+    Display your current zombie configuration and active status.
+
+  <ansi fg="command">zombie start</ansi>
+    Enter zombie mode. Your character will begin acting autonomously.
+
+  <ansi fg="command">zombie set combat <name></ansi>
+    Add a mob name to attack. Use <ansi fg="command">*</ansi> or <ansi fg="command">all</ansi> to attack any mob.
+
+  <ansi fg="command">zombie unset combat <name></ansi>
+    Remove a mob name. Omit the name or use <ansi fg="command">all</ansi> to clear all combat targets.
+
+  <ansi fg="command">zombie set roam <radius></ansi>
+    Set the roam radius (integer). The zombie will wander within this many
+    rooms of your starting position.
+
+  <ansi fg="command">zombie unset roam</ansi>
+    Disable roaming.
+
+  <ansi fg="command">zombie set rest <percent></ansi>
+    Set the HP percentage floor (1-99). When your HP drops below this
+    threshold, the zombie will stop acting (or flee if in combat).
+
+  <ansi fg="command">zombie unset rest</ansi>
+    Disable the rest threshold.
+
+  <ansi fg="command">zombie set loot <name></ansi>
+    Add an item name to pick up. Use <ansi fg="command">*</ansi> or <ansi fg="command">all</ansi> to loot everything.
+
+  <ansi fg="command">zombie unset loot <name></ansi>
+    Remove a loot target. Omit the name or use <ansi fg="command">all</ansi> to clear all loot targets.
+
+  <ansi fg="command">zombie save <name></ansi>
+    Save your current configuration as a named profile.
+
+  <ansi fg="command">zombie load <name></ansi>
+    Load a previously saved profile into your active configuration.
+
+  <ansi fg="command">zombie list</ansi>
+    List all saved profile names.
+
+<ansi fg="yellow">Behavior priority (each round):</ansi>
+
+  1. Rest check - stop (or flee) if HP is below threshold
+  2. Continue attacking current target
+  3. Attack a matching mob in the room
+  4. Loot matching items or gold from the floor
+  5. Roam to a random nearby room (within radius)
+  6. Idle - occasionally emote

--- a/modules/zombiemode/zombieact.go
+++ b/modules/zombiemode/zombieact.go
@@ -1,0 +1,241 @@
+package zombiemode
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/mapper"
+	"github.com/GoMudEngine/GoMud/internal/mobs"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+// zombieCommand enqueues a command on behalf of the zombie AI.
+// ReadyTurn is set to 0 so it bypasses the per-turn input tracker and
+// executes immediately in the same event loop pass.
+func zombieCommand(user *users.UserRecord, inputTxt string) {
+	events.AddToQueue(events.Input{
+		UserId:    user.UserId,
+		InputText: inputTxt,
+		ReadyTurn: 0,
+		Flags:     cmdZombieAI,
+	})
+}
+
+// zombieActCommand is the zombieact user command registered by this module.
+// It overrides the core stub for voluntary zombies and falls back to idle
+// flavor for disconnection-triggered zombies.
+func (m *ZombieModule) zombieActCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+
+	if !user.Character.HasAdjective(`zombie`) {
+		return false, nil
+	}
+
+	// Only apply AI behavior for voluntary zombies (those in m.active).
+	rt, isVoluntary := m.active[user.UserId]
+	if !isVoluntary {
+		// Disconnection-triggered zombie: emit idle flavor (original behavior).
+		if util.Rand(5) == 0 {
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> moans, groans and sways a bit...`, user.Character.Name), user.UserId)
+		}
+		return true, nil
+	}
+
+	// If the feature has been disabled server-side, exit any active zombies.
+	if enabled, ok := m.plug.Config.Get(`Enabled`).(bool); ok && !enabled {
+		m.exitZombieMode(user.UserId)
+		user.SendText(`Zombie mode has been disabled on this server.`)
+		return true, nil
+	}
+
+	cfg := m.configs[user.UserId]
+
+	// 1. Rest check: if HP% is below threshold, do nothing (or flee if in combat).
+	if cfg.RestThreshold > 0 && user.Character.HealthMax.Value > 0 {
+		hpPct := (user.Character.Health * 100) / user.Character.HealthMax.Value
+		if hpPct < cfg.RestThreshold {
+			if user.Character.Aggro != nil {
+				zombieCommand(user, `flee`)
+			}
+			return true, nil
+		}
+	}
+
+	// 2. Combat: if already in combat, keep attacking.
+	if user.Character.Aggro != nil {
+		if user.Character.Aggro.MobInstanceId > 0 {
+			zombieCommand(user, fmt.Sprintf(`attack #%d`, user.Character.Aggro.MobInstanceId))
+			return true, nil
+		}
+		if user.Character.Aggro.UserId > 0 {
+			zombieCommand(user, fmt.Sprintf(`attack @%d`, user.Character.Aggro.UserId))
+			return true, nil
+		}
+	}
+
+	// 3. Combat: scan room for matching mobs and attack.
+	if len(cfg.CombatTargets) > 0 {
+		for _, mobInstId := range room.GetMobs(rooms.FindNeutral, rooms.FindHostile) {
+			mob := mobs.GetInstance(mobInstId)
+			if mob == nil {
+				continue
+			}
+			if matchesCombatTarget(mob.Character.Name, cfg.CombatTargets) {
+				zombieCommand(user, fmt.Sprintf(`attack #%d`, mobInstId))
+				return true, nil
+			}
+		}
+	}
+
+	// 4. Loot: pick up matching items or gold from the floor.
+	if len(cfg.LootTargets) > 0 {
+		if room.Gold > 0 && matchesLootTarget(`gold`, cfg.LootTargets) {
+			zombieCommand(user, `get gold`)
+			return true, nil
+		}
+		if len(user.Character.Items) < user.Character.CarryCapacity() {
+			for _, item := range room.GetAllFloorItems(false) {
+				if matchesLootTarget(item.DisplayName(), cfg.LootTargets) {
+					zombieCommand(user, fmt.Sprintf(`get %s`, item.DisplayName()))
+					return true, nil
+				}
+			}
+		} else {
+			for _, item := range room.GetAllFloorItems(false) {
+				if matchesLootTarget(item.DisplayName(), cfg.LootTargets) {
+					user.SendText(`<ansi fg="yellow">You are carrying too much to pick up the ` + item.DisplayName() + `.</ansi>`)
+					break
+				}
+			}
+		}
+	}
+
+	// 5. Roam: pick a random exit within radius of the home room.
+	if cfg.RoamRadius > 0 && user.Character.Aggro == nil {
+		if exitName := m.pickRoamExit(user.Character.RoomId, rt.HomeRoom, cfg.RoamRadius); exitName != `` {
+			zombieCommand(user, fmt.Sprintf(`go %s`, exitName))
+			return true, nil
+		}
+	}
+
+	// 6. Idle: emit a flavor message occasionally.
+	if util.Rand(5) == 0 {
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> moans, groans and sways a bit...`, user.Character.Name), user.UserId)
+	}
+
+	return true, nil
+}
+
+// pickRoamExit returns a random exit name from the current room that keeps
+// the player within roamRadius rooms of homeRoomId, or "" if none found.
+func (m *ZombieModule) pickRoamExit(currentRoomId, homeRoomId, roamRadius int) string {
+
+	currentRoom := rooms.LoadRoom(currentRoomId)
+	if currentRoom == nil {
+		return ``
+	}
+
+	zMapper := mapper.GetMapper(currentRoomId)
+	if zMapper == nil {
+		// No mapper available; fall back to any random exit.
+		exitName, _ := currentRoom.GetRandomExit()
+		return exitName
+	}
+
+	// Collect exits whose destination is within radius of the home room.
+	validExits := []string{}
+	for exitName, exitInfo := range currentRoom.Exits {
+		if exitInfo.Secret || exitInfo.Lock.IsLocked() {
+			continue
+		}
+		destRooms := zMapper.FindRoomsInDistance(homeRoomId, roamRadius)
+		for _, rId := range destRooms {
+			if rId == exitInfo.RoomId {
+				validExits = append(validExits, exitName)
+				break
+			}
+		}
+		// Also allow staying within radius by checking the destination directly.
+		if exitInfo.RoomId == homeRoomId {
+			if !containsString(validExits, exitName) {
+				validExits = append(validExits, exitName)
+			}
+		}
+	}
+
+	if len(validExits) == 0 {
+		// Nowhere in radius; head back toward home.
+		return m.exitTowardHome(currentRoomId, homeRoomId)
+	}
+
+	return validExits[util.Rand(len(validExits))]
+}
+
+// exitTowardHome returns an exit name that moves toward homeRoomId, or "".
+func (m *ZombieModule) exitTowardHome(currentRoomId, homeRoomId int) string {
+	if currentRoomId == homeRoomId {
+		return ``
+	}
+
+	currentRoom := rooms.LoadRoom(currentRoomId)
+	if currentRoom == nil {
+		return ``
+	}
+
+	// Direct exit to home?
+	for exitName, exitInfo := range currentRoom.Exits {
+		if exitInfo.RoomId == homeRoomId {
+			return exitName
+		}
+	}
+
+	// Use mapper path if available.
+	zMapper := mapper.GetMapper(currentRoomId)
+	if zMapper == nil {
+		return ``
+	}
+
+	homeRooms := zMapper.FindRoomsInDistance(homeRoomId, 1)
+	for exitName, exitInfo := range currentRoom.Exits {
+		if exitInfo.Secret || exitInfo.Lock.IsLocked() {
+			continue
+		}
+		for _, rId := range homeRooms {
+			if rId == exitInfo.RoomId {
+				return exitName
+			}
+		}
+	}
+
+	return ``
+}
+
+// matchesCombatTarget returns true if the mob name matches any combat target.
+func matchesCombatTarget(mobName string, targets []string) bool {
+	mobLower := strings.ToLower(mobName)
+	for _, t := range targets {
+		if t == `*` {
+			return true
+		}
+		if strings.Contains(mobLower, strings.ToLower(t)) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesLootTarget returns true if the item name matches any loot target.
+func matchesLootTarget(itemName string, targets []string) bool {
+	itemLower := strings.ToLower(itemName)
+	for _, t := range targets {
+		if t == `*` {
+			return true
+		}
+		if strings.Contains(itemLower, strings.ToLower(t)) {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/zombiemode/zombiemode.go
+++ b/modules/zombiemode/zombiemode.go
@@ -1,0 +1,203 @@
+package zombiemode
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/mobs"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+var (
+	//go:embed files/*
+	files embed.FS
+)
+
+func init() {
+	m := &ZombieModule{
+		plug:    plugins.New(`zombiemode`, `1.0`),
+		configs: make(map[int]ZombieConfig),
+		active:  make(map[int]zombieRuntime),
+	}
+
+	if err := m.plug.AttachFileSystem(files); err != nil {
+		panic(err)
+	}
+
+	m.plug.AddUserCommand(`zombie`, m.zombieCommand, false, false)
+	m.plug.AddUserCommand(`zombieact`, m.zombieActCommand, true, false)
+
+	m.plug.Callbacks.SetOnSave(m.onSave)
+
+	events.RegisterListener(events.PlayerSpawn{}, m.onPlayerSpawn)
+	events.RegisterListener(events.PlayerDespawn{}, m.onPlayerDespawn)
+	events.RegisterListener(events.PlayerDrop{}, m.onPlayerDrop)
+	events.RegisterListener(events.AggroChanged{}, m.onAggroChanged)
+	events.RegisterListener(events.Input{}, m.onInput, events.First)
+}
+
+// ZombieConfig holds per-user zombie behavior configuration.
+// It is persisted to disk via the plugin file system.
+type ZombieConfig struct {
+	CombatTargets []string                `yaml:"combattargets,omitempty"`
+	RoamRadius    int                     `yaml:"roamradius,omitempty"`
+	RestThreshold int                     `yaml:"restthreshold,omitempty"`
+	LootTargets   []string                `yaml:"loottargets,omitempty"`
+	Profiles      map[string]ZombieConfig `yaml:"profiles,omitempty"`
+}
+
+// zombieRuntime holds transient state that is only valid while zombie mode is active.
+type zombieRuntime struct {
+	HomeRoom int
+}
+
+// cmdZombieAI is an EventFlag bit used to tag input events issued by the zombie
+// AI itself, so that onInput can distinguish them from real player input.
+const cmdZombieAI events.EventFlag = 0b00100000
+
+// ZombieModule is the module struct.
+type ZombieModule struct {
+	plug    *plugins.Plugin
+	configs map[int]ZombieConfig  // keyed by userId; loaded on PlayerSpawn, flushed on PlayerDespawn
+	active  map[int]zombieRuntime // keyed by userId; present only while voluntarily active
+}
+
+// exitZombieMode clears the zombie adjective and removes the active entry.
+func (m *ZombieModule) exitZombieMode(userId int) {
+	delete(m.active, userId)
+	if user := users.GetByUserId(userId); user != nil {
+		user.Character.SetAdjective(`zombie`, false)
+	}
+}
+
+// configKey returns the plugin storage identifier for a user's config.
+func configKey(userId int) string {
+	return fmt.Sprintf(`user-%d`, userId)
+}
+
+// onSave persists configs for all currently online players.
+func (m *ZombieModule) onSave() {
+	for userId, cfg := range m.configs {
+		m.plug.WriteStruct(configKey(userId), cfg)
+	}
+}
+
+// onPlayerSpawn loads the user's config and clears any stale active entry.
+func (m *ZombieModule) onPlayerSpawn(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerSpawn)
+	if !ok {
+		return events.Continue
+	}
+
+	// Safety guard: clear any stale active entry from a previous session.
+	if _, stale := m.active[evt.UserId]; stale {
+		m.exitZombieMode(evt.UserId)
+	}
+
+	var cfg ZombieConfig
+	m.plug.ReadIntoStruct(configKey(evt.UserId), &cfg)
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]ZombieConfig)
+	}
+	m.configs[evt.UserId] = cfg
+
+	return events.Continue
+}
+
+// onPlayerDespawn persists the user's config and exits zombie mode.
+func (m *ZombieModule) onPlayerDespawn(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerDespawn)
+	if !ok {
+		return events.Continue
+	}
+
+	if cfg, exists := m.configs[evt.UserId]; exists {
+		m.plug.WriteStruct(configKey(evt.UserId), cfg)
+		delete(m.configs, evt.UserId)
+	}
+
+	m.exitZombieMode(evt.UserId)
+
+	return events.Continue
+}
+
+// onPlayerDrop exits zombie mode on player death (config survives for the respawn).
+func (m *ZombieModule) onPlayerDrop(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerDrop)
+	if !ok {
+		return events.Continue
+	}
+
+	if _, isActive := m.active[evt.UserId]; isActive {
+		m.exitZombieMode(evt.UserId)
+		if user := users.GetByUserId(evt.UserId); user != nil {
+			user.SendText(`Zombie mode deactivated.`)
+		}
+	}
+
+	return events.Continue
+}
+
+// onAggroChanged fires whenever a mob or player enters/leaves aggro state.
+// If a mob has just targeted a voluntary zombie, issue an attack command so
+// the zombie fights back.
+func (m *ZombieModule) onAggroChanged(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.AggroChanged)
+	if !ok {
+		return events.Continue
+	}
+
+	if evt.MobInstanceId == 0 {
+		return events.Continue
+	}
+
+	mob := mobs.GetInstance(evt.MobInstanceId)
+	if mob == nil || mob.Character.Aggro == nil || mob.Character.Aggro.UserId == 0 {
+		return events.Continue
+	}
+
+	targetUserId := mob.Character.Aggro.UserId
+	if _, isActive := m.active[targetUserId]; !isActive {
+		return events.Continue
+	}
+
+	user := users.GetByUserId(targetUserId)
+	if user == nil || user.Character.Aggro != nil {
+		return events.Continue
+	}
+
+	zombieCommand(user, fmt.Sprintf(`attack #%d`, evt.MobInstanceId))
+
+	return events.Continue
+}
+
+// onInput intercepts player input while zombie mode is active.
+// Any input that did not originate from the zombie AI itself wakes the player.
+func (m *ZombieModule) onInput(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.Input)
+	if !ok {
+		return events.Continue
+	}
+
+	if evt.UserId == 0 {
+		return events.Continue
+	}
+
+	if _, isActive := m.active[evt.UserId]; !isActive {
+		return events.Continue
+	}
+
+	// Ignore the zombieact tick and any commands the AI issued (tagged with cmdZombieAI).
+	if evt.InputText == `zombieact` || evt.Flags.Has(cmdZombieAI) {
+		return events.Continue
+	}
+
+	m.exitZombieMode(evt.UserId)
+	if user := users.GetByUserId(evt.UserId); user != nil {
+		user.SendText(`You snap out of zombie mode.`)
+	}
+
+	return events.Continue
+}

--- a/world.go
+++ b/world.go
@@ -44,7 +44,7 @@ type World struct {
 	enterWorldUserId   chan [2]int
 	leaveWorldUserId   chan int
 	logoutConnectionId chan connections.ConnectionId
-	zombieFlag         chan [2]int
+	linkDeadFlag       chan [2]int
 	//
 	eventRequeue          []events.Event
 	userInputEventTracker map[int]struct{}
@@ -59,7 +59,7 @@ func NewWorld(osSignalChan chan os.Signal) *World {
 		enterWorldUserId:   make(chan [2]int),
 		leaveWorldUserId:   make(chan int),
 		logoutConnectionId: make(chan connections.ConnectionId),
-		zombieFlag:         make(chan [2]int),
+		linkDeadFlag:       make(chan [2]int),
 		//
 		eventRequeue:          []events.Event{},
 		userInputEventTracker: map[int]struct{}{},
@@ -257,11 +257,11 @@ func (w *World) SendLogoutConnectionId(connId connections.ConnectionId) {
 	w.logoutConnectionId <- connId
 }
 
-func (w *World) SendSetZombie(userId int, on bool) {
+func (w *World) SendSetLinkDead(userId int, on bool) {
 	if on {
-		w.zombieFlag <- [2]int{userId, 1}
+		w.linkDeadFlag <- [2]int{userId, 1}
 	} else {
-		w.zombieFlag <- [2]int{userId, 0}
+		w.linkDeadFlag <- [2]int{userId, 0}
 	}
 }
 
@@ -292,10 +292,10 @@ func (w *World) enterWorld(userId int, roomId int) {
 
 /*
 users can be:
-Disconnected	+ OutWorld (no presence)	No record in connections.netConnections or users.ZombieConnections	| user object in room
+Disconnected	+ OutWorld (no presence)	No record in connections.netConnections or users.LinkDeadConnections	| user object in room
 Connected		+ OutWorld (logging in) 	Has record in connections.netConnections 							| user object in room
-Connected		+ InWorld  (non-zombie) 	No record in users.ZombieConnections								| no zombie flag		| user object in room
-Disconnected	+ InWorld  (zombie)			Has record in users.ZombieConnections 								| has zombie flag		| user object in room
+Connected		+ InWorld  (non-link-dead)	No record in users.LinkDeadConnections								| no link-dead flag		| user object in room
+Disconnected	+ InWorld  (link-dead)			Has record in users.LinkDeadConnections 								| has link-dead flag		| user object in room
 */
 
 func (w *World) GetAutoComplete(userId int, inputText string) []string {
@@ -435,11 +435,11 @@ loop:
 			w.logOutUserByConnectionId(logoutConnectionId)
 			util.UnlockMud()
 
-		case zombieFlag := <-w.zombieFlag: //  [2]int
-			if zombieFlag[1] == 1 {
+		case linkDeadFlag := <-w.linkDeadFlag: //  [2]int
+			if linkDeadFlag[1] == 1 {
 
 				util.LockMud()
-				users.SetZombieUser(zombieFlag[0])
+				users.SetLinkDeadUser(linkDeadFlag[0])
 				util.UnlockMud()
 
 			}
@@ -663,7 +663,7 @@ func (w *World) UpdateStats() {
 	web.UpdateStats(s)
 }
 
-// Force disconnect a user (Makes them a zombie)
+// Force disconnect a user (Makes them linkdead)
 func (w *World) Kick(userId int, reason string) {
 
 	user := users.GetByUserId(userId)
@@ -671,7 +671,7 @@ func (w *World) Kick(userId int, reason string) {
 		return
 	}
 
-	users.SetZombieUser(userId)
+	users.SetLinkDeadUser(userId)
 	user.EventLog.Add(`conn`, fmt.Sprintf(`Kicked (%s)`, reason))
 
 	connections.Kick(user.ConnectionId(), reason)


### PR DESCRIPTION
# Description

This renames "Zombie" connections to "LinkDead", while keeping the "zombie" adjective that gets given to the character. Additionally a new module has been added (`zombiemode`) which is an optional module to allow characters to roam with behavior while a zombie. They can manually become a zombie while staying in game and not typing, and configure its behavior using the `zombie` command.

This also greatly simplifies many `context.md` files to remove function bodies from them.

## Changes

- Rename all connection "Zombie" references to "LinkDead"
- Config changed from "ZombieSeconds" to "LinkDeadSeconds" 
- `zombiemode` added as a module. It is enabled by default. This adds a special command and behavior for users to act while a zombie (or voluntarily become a zombie). They can configure things like wander distance, auto attack, auto loot, and so on.
- Removed function bodies from `context.md` files, now just has function signature.
