### PR TITLE
Webclient 3dmap improvements & zombie mode improvements

### DIFF
--- a/_datafiles/html/public/static/js/webclient-core.js
+++ b/_datafiles/html/public/static/js/webclient-core.js
@@ -1687,24 +1687,6 @@ const Client = (() => {
     }
 
     // -----------------------------------------------------------------------
-    // Terminal commands
-    //
-    // Window modules may call Client.registerCommand(name, description, fn)
-    // to add their own !commands processed before sending to the server.
-    // fn receives the full input string and returns true if it handled it.
-    // -----------------------------------------------------------------------
-    // -----------------------------------------------------------------------
-    // GMCP debug mode removed
-    // -----------------------------------------------------------------------
-
-    const specialCommands = {
-    };
-
-    function registerCommand(name, description, fn) {
-        specialCommands[name] = { description, fn };
-    }
-
-    // -----------------------------------------------------------------------
     // Tab-completion (web client autocomplete)
     // -----------------------------------------------------------------------
     const _tabSug = {
@@ -1862,14 +1844,6 @@ const Client = (() => {
                     }
                 }
 
-                const cmd = specialCommands[event.target.value];
-                if (cmd) {
-                    if (cmd.fn(event.target.value)) {
-                        event.target.value = '';
-                        return;
-                    }
-                }
-
                 if (sendData(event.target.value)) {
                     event.target.value = '';
                 } else {
@@ -1929,12 +1903,6 @@ const Client = (() => {
             muteIcon.textContent = '🔊';
         }
 
-        // Log available commands to console
-        console.log('%cterminal commands:', 'font-weight:bold;');
-        let longest = 0;
-        for (const k in specialCommands) { if (k.length > longest) { longest = k.length; } }
-        for (const k in specialCommands) { console.log('  ' + k.padEnd(longest) + ' - ' + specialCommands[k].description); }
-
         // Register GMCP handler for tab-completion responses
         VirtualWindows.register({
             gmcpHandlers: ['Suggestion'],
@@ -1981,7 +1949,6 @@ const Client = (() => {
         set debug(v)       { debugOutput = !!v; },
 
         // Extension points for window modules
-        registerCommand,
         registerShortcut,
 
         // Functions called from HTML event handlers

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -844,7 +844,7 @@
         var SPACING_MIN  = 0.6;  // Minimum spacing scale; lower values compress rooms closer together until tiles overlap
         var SPACING_MAX  = 4.0;  // Maximum spacing scale; higher values spread rooms and z-layers further apart
         var ALPHA_INACTIVE  = 0.15; // Opacity of rooms and edges on z-levels other than the active one; lower = more faded
-        var ALPHA_CONNECTED = 0.45; // Opacity of rooms on inactive z-levels that have a direct connection to the active layer; higher = more visible cross-z neighbours
+        var ALPHA_CONNECTED = 0.15; // Opacity of rooms on inactive z-levels that have a direct connection to the active layer; higher = more visible cross-z neighbours
         var LAYER_OFFSET_X  = 0;   // Screen pixels to shift each z-level horizontally per level away from the active layer; increase to spread layers apart left/right
         var LAYER_OFFSET_Y  = 0;   // Screen pixels to shift each z-level vertically per level away from the active layer; increase to spread layers apart up/down
 
@@ -1033,15 +1033,6 @@
             ctx.fillStyle = MAP_BG; ctx.fillRect(0, 0, canvas.width, canvas.height);
             if (rooms3d.size === 0) { return; }
 
-            var list = [];
-            rooms3d.forEach(function (room, id) {
-                list.push({ id: id, x: room.x, y: room.y, z: room.z,
-                            symbol: room.symbol, env: room.env });
-            });
-            list.sort(function (a, b) {
-                return (a.x + a.y - a.z * 2) - (b.x + b.y - b.z * 2);
-            });
-
             var playerZ = (currentRoomId !== null && rooms3d.has(currentRoomId))
                 ? rooms3d.get(currentRoomId).z : (camZ | 0);
             var drawZ = (activeZ !== null) ? activeZ : playerZ;
@@ -1057,39 +1048,96 @@
                 if (rA.z === drawZ && rB.z !== drawZ) { connectedToActive.add(parseInt(parts[1], 10)); }
                 if (rB.z === drawZ && rA.z !== drawZ) { connectedToActive.add(parseInt(parts[0], 10)); }
             });
-            ctx.lineWidth   = CONNECTION_WIDTH * zoomScale;
-            ctx.lineCap     = 'round';
 
+            // Group rooms and edges by z-level, sorted lowest to highest.
+            var zLevels = [];
+            rooms3d.forEach(function (room) {
+                if (zLevels.indexOf(room.z) === -1) { zLevels.push(room.z); }
+            });
+            zLevels.sort(function (a, b) { return a - b; });
+
+            // Pre-bucket rooms and edges by z-level for efficient per-layer access.
+            var roomsByZ = {};
+            var sameZEdgesByZ = {};
+            var crossZUpEdgesByZ = {};
+            zLevels.forEach(function (z) {
+                roomsByZ[z] = [];
+                sameZEdgesByZ[z] = [];
+                crossZUpEdgesByZ[z] = [];
+            });
+            rooms3d.forEach(function (room, id) {
+                roomsByZ[room.z].push({ id: id, x: room.x, y: room.y, z: room.z,
+                                        symbol: room.symbol, env: room.env });
+            });
+            // Sort rooms within each layer by painter's order.
+            zLevels.forEach(function (z) {
+                roomsByZ[z].sort(function (a, b) {
+                    return (a.x + a.y) - (b.x + b.y);
+                });
+            });
             edges3d.forEach(function (edge, key) {
                 var parts = key.split('-');
                 var rA = rooms3d.get(parseInt(parts[0], 10));
                 var rB = rooms3d.get(parseInt(parts[1], 10));
                 if (!rA || !rB) { return; }
-                var zDiff = Math.min(Math.abs(rA.z - drawZ), Math.abs(rB.z - drawZ));
-                ctx.globalAlpha = zDiff === 0 ? 1.0 : ALPHA_INACTIVE;
-                ctx.strokeStyle = edge.dz !== 0 ? CONNECTION_COLOR_CROSS_Z : CONNECTION_COLOR_SAME_Z;
-                var pA = isoProject(rA.x, rA.y, rA.z, drawZ);
-                var pB = isoProject(rB.x, rB.y, rB.z, drawZ);
+                if (edge.dz === 0) {
+                    // Same-z edge: bucket by its z-level.
+                    if (sameZEdgesByZ[rA.z]) { sameZEdgesByZ[rA.z].push({ edge: edge, rA: rA, rB: rB }); }
+                } else {
+                    // Cross-z edge: bucket by the lower z so it draws after the lower layer's tiles.
+                    var lowerZ = Math.min(rA.z, rB.z);
+                    if (crossZUpEdgesByZ[lowerZ]) { crossZUpEdgesByZ[lowerZ].push({ edge: edge, rA: rA, rB: rB }); }
+                }
+            });
+
+            ctx.lineWidth = CONNECTION_WIDTH * zoomScale;
+            ctx.lineCap   = 'round';
+
+            function drawEdge(e) {
+                var pA = isoProject(e.rA.x, e.rA.y, e.rA.z, drawZ);
+                var pB = isoProject(e.rB.x, e.rB.y, e.rB.z, drawZ);
                 var startPt, endPt;
-                if (edge.dz !== 0) {
+                if (e.edge.dz !== 0) {
                     startPt = { sx: pA.sx + CROSS_Z_OFFSET_X * zoomScale, sy: pA.sy + CROSS_Z_OFFSET_Y * zoomScale };
                     endPt   = { sx: pB.sx + CROSS_Z_OFFSET_X * zoomScale, sy: pB.sy + CROSS_Z_OFFSET_Y * zoomScale };
                 } else {
-                    startPt = tileAttachPoint(pA.sx, pA.sy,  edge.dx,  edge.dy);
-                    endPt   = tileAttachPoint(pB.sx, pB.sy, -edge.dx, -edge.dy);
+                    startPt = tileAttachPoint(pA.sx, pA.sy,  e.edge.dx,  e.edge.dy);
+                    endPt   = tileAttachPoint(pB.sx, pB.sy, -e.edge.dx, -e.edge.dy);
                 }
                 ctx.beginPath(); ctx.moveTo(startPt.sx, startPt.sy);
                 ctx.lineTo(endPt.sx, endPt.sy); ctx.stroke();
-            });
-            ctx.globalAlpha = 1.0;
+            }
 
-            list.forEach(function (item) {
-                var isCurrent = (item.id === currentRoomId);
-                var topColor  = isCurrent ? CURRENT_ROOM_COLOR : colorForSymbol(item.symbol, item.env);
-                var onActive  = Math.abs(item.z - drawZ) === 0;
-                ctx.globalAlpha = onActive ? 1.0 : (connectedToActive.has(item.id) ? ALPHA_CONNECTED : ALPHA_INACTIVE);
-                drawTile(item.x, item.y, item.z, topColor, isCurrent, item.symbol, drawZ);
+            // Draw each z-level in order: same-z edges, then tiles, then cross-z-up edges.
+            zLevels.forEach(function (z) {
+                var zDiffFromActive = Math.abs(z - drawZ);
+                var baseAlpha = zDiffFromActive === 0 ? 1.0 : ALPHA_INACTIVE;
+
+                // 1. Same-z edges for this layer.
+                ctx.strokeStyle = CONNECTION_COLOR_SAME_Z;
+                sameZEdgesByZ[z].forEach(function (e) {
+                    ctx.globalAlpha = baseAlpha;
+                    drawEdge(e);
+                });
+
+                // 2. Tiles for this layer.
+                roomsByZ[z].forEach(function (item) {
+                    var isCurrent = (item.id === currentRoomId);
+                    var topColor  = isCurrent ? CURRENT_ROOM_COLOR : colorForSymbol(item.symbol, item.env);
+                    var onActive  = zDiffFromActive === 0;
+                    ctx.globalAlpha = onActive ? 1.0 : (connectedToActive.has(item.id) ? ALPHA_CONNECTED : ALPHA_INACTIVE);
+                    drawTile(item.x, item.y, item.z, topColor, isCurrent, item.symbol, drawZ);
+                });
+
+                // 3. Cross-z-up edges leaving this layer (drawn over this layer's tiles, under the next).
+                ctx.strokeStyle = CONNECTION_COLOR_CROSS_Z;
+                crossZUpEdgesByZ[z].forEach(function (e) {
+                    var zDiff = Math.min(Math.abs(e.rA.z - drawZ), Math.abs(e.rB.z - drawZ));
+                    ctx.globalAlpha = zDiff === 0 ? 1.0 : ALPHA_INACTIVE;
+                    drawEdge(e);
+                });
             });
+
             ctx.globalAlpha = 1.0;
         }
 

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -831,6 +831,10 @@
         var GRID_STEP_XY     = 1.6;  // Spacing multiplier between adjacent XY grid positions relative to TILE_HW; increase to spread rooms apart horizontally, decrease to compress them
         var Z_STEP           = 50;   // Screen pixels of vertical separation per z-level at default spacing; increase to push layers further apart vertically
         var CONNECTION_WIDTH = 2;    // Stroke width of lines connecting rooms; thicker = more visible corridors
+        var CONNECTION_COLOR_SAME_Z  = '#7a4a1a'; // Color of lines connecting rooms on the same z-level; change to distinguish same-floor corridors
+        var CONNECTION_COLOR_CROSS_Z = '#3a6b8a'; // Color of lines connecting rooms on different z-levels; change to make vertical connections stand out
+        var CROSS_Z_OFFSET_X = 8;  // Horizontal pixel offset from tile center where cross-z connection lines attach; shift left/right to reposition the vertical passage indicator
+        var CROSS_Z_OFFSET_Y = 0; // Vertical pixel offset from tile center where cross-z connection lines attach; shift up/down to reposition the vertical passage indicator
         var MAP_BG           = '#111';    // Canvas fill color behind all tiles; change to adjust overall contrast
         var TILE_BORDER_COLOR = '#000000'; // Outline color drawn around each tile face; darker = crisper tile edges
         var TILE_BORDER_WIDTH = 0.8;  // Stroke width of tile outlines; higher = bolder edges, can obscure small tiles at low zoom
@@ -839,6 +843,10 @@
         var SPACING_STEP = 1.25; // Multiplier applied per spacing button click; higher = bigger jumps between spacing levels
         var SPACING_MIN  = 0.6;  // Minimum spacing scale; lower values compress rooms closer together until tiles overlap
         var SPACING_MAX  = 4.0;  // Maximum spacing scale; higher values spread rooms and z-layers further apart
+        var ALPHA_INACTIVE  = 0.15; // Opacity of rooms and edges on z-levels other than the active one; lower = more faded
+        var ALPHA_CONNECTED = 0.45; // Opacity of rooms on inactive z-levels that have a direct connection to the active layer; higher = more visible cross-z neighbours
+        var LAYER_OFFSET_X  = 0;   // Screen pixels to shift each z-level horizontally per level away from the active layer; increase to spread layers apart left/right
+        var LAYER_OFFSET_Y  = 0;   // Screen pixels to shift each z-level vertically per level away from the active layer; increase to spread layers apart up/down
 
         // -- State -------------------------------------------------------------
         var canvas    = null;
@@ -881,17 +889,18 @@
                          ('0' + b.toString(16)).slice(-2);
         }
 
-        function isoProject(gx, gy, gz) {
+        function isoProject(gx, gy, gz, drawZ) {
             var step = TILE_HW * GRID_STEP_XY * spacingScale * zoomScale;
-            var zs   = Z_STEP  * spacingScale * zoomScale;
+            var zs   = Z_STEP  * spacingScale * spacingScale * zoomScale;
             var midX = Math.floor(canvas.width  / 2);
             var midY = Math.floor(canvas.height / 2);
             var relX = gx - camX - panOffsetX;
             var relY = gy - camY - panOffsetY;
             var relZ = gz - camZ;
+            var layerDiff = (drawZ !== undefined) ? (gz - drawZ) : 0;
             return {
-                sx: midX + (relX - relY) * step,
-                sy: midY + (relX + relY) * (step / 2) - relZ * zs,
+                sx: midX + (relX - relY) * step + layerDiff * LAYER_OFFSET_X * zoomScale,
+                sy: midY + (relX + relY) * (step / 2) - relZ * zs + layerDiff * LAYER_OFFSET_Y * zoomScale,
             };
         }
 
@@ -981,12 +990,12 @@
         }
 
         // -- Rendering ---------------------------------------------------------
-        function drawTile(gx, gy, gz, topColor, isCurrent, symbol) {
+        function drawTile(gx, gy, gz, topColor, isCurrent, symbol, drawZ) {
             var hw  = TILE_HW    * zoomScale;
             var hh  = TILE_HH    * zoomScale;
             var dep = TILE_DEPTH * zoomScale;
             var bw  = TILE_BORDER_WIDTH * zoomScale;
-            var p   = isoProject(gx, gy, gz);
+            var p   = isoProject(gx, gy, gz, drawZ);
             var sx  = p.sx, sy = p.sy;
             var leftColor  = darkenColor(topColor, SIDE_DARKEN * 0.8);
             var rightColor = darkenColor(topColor, SIDE_DARKEN);
@@ -1037,7 +1046,17 @@
                 ? rooms3d.get(currentRoomId).z : (camZ | 0);
             var drawZ = (activeZ !== null) ? activeZ : playerZ;
 
-            ctx.strokeStyle = CONNECTION_COLOR;
+            // Build a set of room IDs on other z-levels that connect directly to the active layer.
+            var connectedToActive = new Set();
+            edges3d.forEach(function (edge, key) {
+                if (edge.dz === 0) { return; }
+                var parts = key.split('-');
+                var rA = rooms3d.get(parseInt(parts[0], 10));
+                var rB = rooms3d.get(parseInt(parts[1], 10));
+                if (!rA || !rB) { return; }
+                if (rA.z === drawZ && rB.z !== drawZ) { connectedToActive.add(parseInt(parts[1], 10)); }
+                if (rB.z === drawZ && rA.z !== drawZ) { connectedToActive.add(parseInt(parts[0], 10)); }
+            });
             ctx.lineWidth   = CONNECTION_WIDTH * zoomScale;
             ctx.lineCap     = 'round';
 
@@ -1047,12 +1066,14 @@
                 var rB = rooms3d.get(parseInt(parts[1], 10));
                 if (!rA || !rB) { return; }
                 var zDiff = Math.min(Math.abs(rA.z - drawZ), Math.abs(rB.z - drawZ));
-                ctx.globalAlpha = zDiff === 0 ? 1.0 : 0.25;
-                var pA = isoProject(rA.x, rA.y, rA.z);
-                var pB = isoProject(rB.x, rB.y, rB.z);
+                ctx.globalAlpha = zDiff === 0 ? 1.0 : ALPHA_INACTIVE;
+                ctx.strokeStyle = edge.dz !== 0 ? CONNECTION_COLOR_CROSS_Z : CONNECTION_COLOR_SAME_Z;
+                var pA = isoProject(rA.x, rA.y, rA.z, drawZ);
+                var pB = isoProject(rB.x, rB.y, rB.z, drawZ);
                 var startPt, endPt;
                 if (edge.dz !== 0) {
-                    startPt = pA; endPt = pB;
+                    startPt = { sx: pA.sx + CROSS_Z_OFFSET_X * zoomScale, sy: pA.sy + CROSS_Z_OFFSET_Y * zoomScale };
+                    endPt   = { sx: pB.sx + CROSS_Z_OFFSET_X * zoomScale, sy: pB.sy + CROSS_Z_OFFSET_Y * zoomScale };
                 } else {
                     startPt = tileAttachPoint(pA.sx, pA.sy,  edge.dx,  edge.dy);
                     endPt   = tileAttachPoint(pB.sx, pB.sy, -edge.dx, -edge.dy);
@@ -1065,8 +1086,9 @@
             list.forEach(function (item) {
                 var isCurrent = (item.id === currentRoomId);
                 var topColor  = isCurrent ? CURRENT_ROOM_COLOR : colorForSymbol(item.symbol, item.env);
-                ctx.globalAlpha = Math.abs(item.z - drawZ) === 0 ? 1.0 : 0.25;
-                drawTile(item.x, item.y, item.z, topColor, isCurrent, item.symbol);
+                var onActive  = Math.abs(item.z - drawZ) === 0;
+                ctx.globalAlpha = onActive ? 1.0 : (connectedToActive.has(item.id) ? ALPHA_CONNECTED : ALPHA_INACTIVE);
+                drawTile(item.x, item.y, item.z, topColor, isCurrent, item.symbol, drawZ);
             });
             ctx.globalAlpha = 1.0;
         }

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -20,16 +20,16 @@
     // Shared constants
     // =========================================================================
 
-    var ZOOM_STEP = 1.25;
-    var ZOOM_MIN  = 0.25;
-    var ZOOM_MAX  = 4.0;
+    var ZOOM_STEP = 1.25;  // How much each zoom button click scales the view; higher = bigger jumps per click
+    var ZOOM_MIN  = 0.25;  // Furthest out the user can zoom; lower = more of the map visible but smaller rooms
+    var ZOOM_MAX  = 4.0;   // Closest in the user can zoom; higher = larger rooms but less of the map visible
 
-    var CENTER_EASE_DURATION = 0.2;
+    var CENTER_EASE_DURATION = 0.2; // How long (seconds) the camera takes to pan to a new room; 0 = instant snap, higher = slower slide
 
-    var CONNECTION_COLOR        = '#7a4a1a';
-    var CURRENT_ROOM_COLOR      = '#c20000';
-    var CURRENT_ROOM_TEXT_COLOR = '#ffffff';
-    var SYMBOL_TEXT_COLOR       = '#e0e0e0';
+    var CONNECTION_COLOR        = '#7a4a1a'; // Color of the lines drawn between connected rooms; change to make corridors more or less visible
+    var CURRENT_ROOM_COLOR      = '#c20000'; // Fill color of the room the player is currently in; change to adjust how much it stands out
+    var CURRENT_ROOM_TEXT_COLOR = '#ffffff'; // Symbol character color inside the current room; should contrast with CURRENT_ROOM_COLOR
+    var SYMBOL_TEXT_COLOR       = '#e0e0e0'; // Symbol character color inside all non-current rooms; lower contrast = subtler symbols
 
     var SYMBOL_COLORS = {
         '~':  '#2a53f7',   // shore / water edge
@@ -421,14 +421,14 @@
     var view2d = (function () {
 
         // -- Constants ---------------------------------------------------------
-        var ROOM_SIZE        = 28;
-        var ROOM_GAP         = 14;
-        var BASE_STEP        = ROOM_SIZE + ROOM_GAP;
-        var CONNECTION_WIDTH = 4;
-        var ROOM_BORDER_WIDTH = 1.5;
-        var SYMBOL_FONT_SIZE  = 14;
-        var MAP_BACKGROUND    = '#111';
-        var ROOM_BORDER_COLOR = '#000000';
+        var ROOM_SIZE        = 28;   // Pixel side length of each room square; larger = bigger rooms, fewer fit on screen
+        var ROOM_GAP         = 14;   // Pixel gap between adjacent room squares; larger = more space between rooms, map spreads out
+        var BASE_STEP        = ROOM_SIZE + ROOM_GAP; // Derived: center-to-center grid distance; do not edit directly
+        var CONNECTION_WIDTH = 4;    // Stroke width of corridor lines; thicker = more visible connections, can obscure small rooms
+        var ROOM_BORDER_WIDTH = 1.5; // Stroke width of the outline drawn around each room square; higher = bolder room edges
+        var SYMBOL_FONT_SIZE  = 14;  // Font size of the symbol character drawn inside each room; larger = more readable but may overflow small rooms
+        var MAP_BACKGROUND    = '#111';    // Canvas fill color behind all rooms; change to adjust overall map contrast
+        var ROOM_BORDER_COLOR = '#000000'; // Outline color drawn around each room square; darker = crisper separation between rooms
 
         // -- State -------------------------------------------------------------
         var canvas        = null;
@@ -825,20 +825,20 @@
     var view3d = (function () {
 
         // -- Constants ---------------------------------------------------------
-        var TILE_HW         = 20;
-        var TILE_HH         = 10;
-        var TILE_DEPTH      = 7;
-        var GRID_STEP_XY    = 1.6;
-        var Z_STEP          = 120;
-        var CONNECTION_WIDTH = 2;
-        var MAP_BG           = '#111';
-        var TILE_BORDER_COLOR = '#000000';
-        var TILE_BORDER_WIDTH = 0.8;
-        var SIDE_DARKEN       = 0.55;
-        var SYMBOL_FONT_SIZE  = 10;
-        var SPACING_STEP = 1.25;
-        var SPACING_MIN  = 0.6;
-        var SPACING_MAX  = 4.0;
+        var TILE_HW          = 20;   // Half-width of a tile diamond in px; larger = wider tiles, more horizontal spread
+        var TILE_HH          = 10;   // Half-height of a tile diamond in px; larger = taller diamonds, more vertical compression
+        var TILE_DEPTH       = 7;    // Height of the visible block side below the tile face; larger = taller 3D extrusion
+        var GRID_STEP_XY     = 1.6;  // Spacing multiplier between adjacent XY grid positions relative to TILE_HW; increase to spread rooms apart horizontally, decrease to compress them
+        var Z_STEP           = 50;   // Screen pixels of vertical separation per z-level at default spacing; increase to push layers further apart vertically
+        var CONNECTION_WIDTH = 2;    // Stroke width of lines connecting rooms; thicker = more visible corridors
+        var MAP_BG           = '#111';    // Canvas fill color behind all tiles; change to adjust overall contrast
+        var TILE_BORDER_COLOR = '#000000'; // Outline color drawn around each tile face; darker = crisper tile edges
+        var TILE_BORDER_WIDTH = 0.8;  // Stroke width of tile outlines; higher = bolder edges, can obscure small tiles at low zoom
+        var SIDE_DARKEN       = 0.55; // Brightness multiplier for the left and right block faces; lower = darker sides, stronger 3D illusion
+        var SYMBOL_FONT_SIZE  = 10;   // Font size of the symbol character on each tile; larger = more readable but may overflow the tile face
+        var SPACING_STEP = 1.25; // Multiplier applied per spacing button click; higher = bigger jumps between spacing levels
+        var SPACING_MIN  = 0.6;  // Minimum spacing scale; lower values compress rooms closer together until tiles overlap
+        var SPACING_MAX  = 4.0;  // Maximum spacing scale; higher values spread rooms and z-layers further apart
 
         // -- State -------------------------------------------------------------
         var canvas    = null;
@@ -883,7 +883,7 @@
 
         function isoProject(gx, gy, gz) {
             var step = TILE_HW * GRID_STEP_XY * spacingScale * zoomScale;
-            var zs   = Z_STEP  * spacingScale * spacingScale * zoomScale;
+            var zs   = Z_STEP  * spacingScale * zoomScale;
             var midX = Math.floor(canvas.width  / 2);
             var midY = Math.floor(canvas.height / 2);
             var relX = gx - camX - panOffsetX;
@@ -1046,7 +1046,7 @@
                 var rA = rooms3d.get(parseInt(parts[0], 10));
                 var rB = rooms3d.get(parseInt(parts[1], 10));
                 if (!rA || !rB) { return; }
-                var zDiff = Math.max(Math.abs(rA.z - drawZ), Math.abs(rB.z - drawZ));
+                var zDiff = Math.min(Math.abs(rA.z - drawZ), Math.abs(rB.z - drawZ));
                 ctx.globalAlpha = zDiff === 0 ? 1.0 : 0.25;
                 var pA = isoProject(rA.x, rA.y, rA.z);
                 var pB = isoProject(rB.x, rB.y, rB.z);

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -856,6 +856,7 @@
         var container = null;
         var rooms3d   = new Map();
         var edges3d   = new Map();
+        var bucketCache = null;
         var currentRoomId  = null;
         var camX = 0, camY = 0, camZ = 0;
         var easeStartX = 0, easeStartY = 0, easeStartZ = 0;
@@ -883,9 +884,9 @@
         }
 
         function darkenColor(hex, factor) {
-            var r = Math.round(parseInt(hex.slice(1, 3), 16) * factor);
-            var g = Math.round(parseInt(hex.slice(3, 5), 16) * factor);
-            var b = Math.round(parseInt(hex.slice(5, 7), 16) * factor);
+            var r = Math.min(255, Math.round(parseInt(hex.slice(1, 3), 16) * factor));
+            var g = Math.min(255, Math.round(parseInt(hex.slice(3, 5), 16) * factor));
+            var b = Math.min(255, Math.round(parseInt(hex.slice(5, 7), 16) * factor));
             return '#' + ('0' + r.toString(16)).slice(-2) +
                          ('0' + g.toString(16)).slice(-2) +
                          ('0' + b.toString(16)).slice(-2);
@@ -943,6 +944,7 @@
 
         function addRoom3d(id, gx, gy, gz, symbol, env) {
             rooms3d.set(id, { x: gx, y: gy, z: gz, symbol: symbol || '\u2022', env: env || '' });
+            bucketCache = null;
         }
 
         function addEdge3d(idA, idB, rA, rB) {
@@ -954,15 +956,51 @@
                 key = idB + '-' + idA;
                 dx = rA.x - rB.x; dy = rA.y - rB.y; dz = rA.z - rB.z;
             }
-            if (!edges3d.has(key)) { edges3d.set(key, { dx: dx, dy: dy, dz: dz }); }
+            if (!edges3d.has(key)) { edges3d.set(key, { dx: dx, dy: dy, dz: dz }); bucketCache = null; }
         }
 
         function resetMap3d() {
             rooms3d.clear(); edges3d.clear();
+            bucketCache = null;
             currentRoomId = null;
             panOffsetX = 0; panOffsetY = 0;
             dragActive = false;
             if (easeRafId !== null) { cancelAnimationFrame(easeRafId); easeRafId = null; }
+        }
+
+        function buildBucketCache() {
+            var zSet = new Set();
+            rooms3d.forEach(function (room) { zSet.add(room.z); });
+            var zLevels = Array.from(zSet).sort(function (a, b) { return a - b; });
+            var roomsByZ = {};
+            var sameZEdgesByZ = {};
+            var crossZUpEdgesByZ = {};
+            zLevels.forEach(function (z) {
+                roomsByZ[z] = [];
+                sameZEdgesByZ[z] = [];
+                crossZUpEdgesByZ[z] = [];
+            });
+            rooms3d.forEach(function (room, id) {
+                roomsByZ[room.z].push({ id: id, x: room.x, y: room.y, z: room.z,
+                                        symbol: room.symbol, env: room.env });
+            });
+            zLevels.forEach(function (z) {
+                roomsByZ[z].sort(function (a, b) { return (a.x + a.y) - (b.x + b.y); });
+            });
+            edges3d.forEach(function (edge, key) {
+                var parts = key.split('-');
+                var rA = rooms3d.get(parseInt(parts[0], 10));
+                var rB = rooms3d.get(parseInt(parts[1], 10));
+                if (!rA || !rB) { return; }
+                if (edge.dz === 0) {
+                    if (sameZEdgesByZ[rA.z]) { sameZEdgesByZ[rA.z].push({ edge: edge, rA: rA, rB: rB }); }
+                } else {
+                    var lowerZ = Math.min(rA.z, rB.z);
+                    if (crossZUpEdgesByZ[lowerZ]) { crossZUpEdgesByZ[lowerZ].push({ edge: edge, rA: rA, rB: rB }); }
+                }
+            });
+            bucketCache = { zLevels: zLevels, roomsByZ: roomsByZ,
+                            sameZEdgesByZ: sameZEdgesByZ, crossZUpEdgesByZ: crossZUpEdgesByZ };
         }
 
         function replayZone3d(startId) {
@@ -1051,44 +1089,11 @@
                 if (rB.z === drawZ && rA.z !== drawZ) { connectedToActive.add(parseInt(parts[0], 10)); }
             });
 
-            // Group rooms and edges by z-level, sorted lowest to highest.
-            var zSet = new Set();
-            rooms3d.forEach(function (room) { zSet.add(room.z); });
-            var zLevels = Array.from(zSet).sort(function (a, b) { return a - b; });
-
-            // Pre-bucket rooms and edges by z-level for efficient per-layer access.
-            var roomsByZ = {};
-            var sameZEdgesByZ = {};
-            var crossZUpEdgesByZ = {};
-            zLevels.forEach(function (z) {
-                roomsByZ[z] = [];
-                sameZEdgesByZ[z] = [];
-                crossZUpEdgesByZ[z] = [];
-            });
-            rooms3d.forEach(function (room, id) {
-                roomsByZ[room.z].push({ id: id, x: room.x, y: room.y, z: room.z,
-                                        symbol: room.symbol, env: room.env });
-            });
-            // Sort rooms within each layer by painter's order.
-            zLevels.forEach(function (z) {
-                roomsByZ[z].sort(function (a, b) {
-                    return (a.x + a.y) - (b.x + b.y);
-                });
-            });
-            edges3d.forEach(function (edge, key) {
-                var parts = key.split('-');
-                var rA = rooms3d.get(parseInt(parts[0], 10));
-                var rB = rooms3d.get(parseInt(parts[1], 10));
-                if (!rA || !rB) { return; }
-                if (edge.dz === 0) {
-                    // Same-z edge: bucket by its z-level.
-                    if (sameZEdgesByZ[rA.z]) { sameZEdgesByZ[rA.z].push({ edge: edge, rA: rA, rB: rB }); }
-                } else {
-                    // Cross-z edge: bucket by the lower z so it draws after the lower layer's tiles.
-                    var lowerZ = Math.min(rA.z, rB.z);
-                    if (crossZUpEdgesByZ[lowerZ]) { crossZUpEdgesByZ[lowerZ].push({ edge: edge, rA: rA, rB: rB }); }
-                }
-            });
+            if (!bucketCache) { buildBucketCache(); }
+            var zLevels         = bucketCache.zLevels;
+            var roomsByZ        = bucketCache.roomsByZ;
+            var sameZEdgesByZ   = bucketCache.sameZEdgesByZ;
+            var crossZUpEdgesByZ = bucketCache.crossZUpEdgesByZ;
 
             ctx.lineWidth = CONNECTION_WIDTH * zoomScale;
             ctx.lineCap   = 'round';

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -662,13 +662,13 @@
         }
 
         function roomAtPoint(cx, cy) {
-            var half = (ROOM_SIZE * zoomScale) / 2, found = null;
-            rooms.forEach(function (room, id) {
+            var half = (ROOM_SIZE * zoomScale) / 2;
+            for (var [id, room] of rooms) {
                 var p = gridToCanvas(room.x, room.y);
                 if (cx >= p.px - half && cx <= p.px + half &&
-                    cy >= p.py - half && cy <= p.py + half) { found = id; }
-            });
-            return found;
+                    cy >= p.py - half && cy <= p.py + half) { return id; }
+            }
+            return null;
         }
 
         // -- DOM ---------------------------------------------------------------

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -830,11 +830,8 @@
         var TILE_DEPTH       = 7;    // Height of the visible block side below the tile face; larger = taller 3D extrusion
         var GRID_STEP_XY     = 1.6;  // Spacing multiplier between adjacent XY grid positions relative to TILE_HW; increase to spread rooms apart horizontally, decrease to compress them
         var Z_STEP           = 50;   // Screen pixels of vertical separation per z-level at default spacing; increase to push layers further apart vertically
+        var Z_SPACING_EXPONENT = 1.5; // Controls how aggressively z-layer separation grows as spacing increases; 1.0 = linear with spacing, 2.0 = quadratic (very dramatic), lower = subtler
         var CONNECTION_WIDTH = 2;    // Stroke width of lines connecting rooms; thicker = more visible corridors
-        var CONNECTION_COLOR_SAME_Z  = '#7a4a1a'; // Color of lines connecting rooms on the same z-level; change to distinguish same-floor corridors
-        var CONNECTION_COLOR_CROSS_Z = '#3a6b8a'; // Color of lines connecting rooms on different z-levels; change to make vertical connections stand out
-        var CROSS_Z_OFFSET_X = 8;  // Horizontal pixel offset from tile center where cross-z connection lines attach; shift left/right to reposition the vertical passage indicator
-        var CROSS_Z_OFFSET_Y = 0; // Vertical pixel offset from tile center where cross-z connection lines attach; shift up/down to reposition the vertical passage indicator
         var MAP_BG           = '#111';    // Canvas fill color behind all tiles; change to adjust overall contrast
         var TILE_BORDER_COLOR = '#000000'; // Outline color drawn around each tile face; darker = crisper tile edges
         var TILE_BORDER_WIDTH = 0.8;  // Stroke width of tile outlines; higher = bolder edges, can obscure small tiles at low zoom
@@ -843,10 +840,15 @@
         var SPACING_STEP = 1.25; // Multiplier applied per spacing button click; higher = bigger jumps between spacing levels
         var SPACING_MIN  = 0.6;  // Minimum spacing scale; lower values compress rooms closer together until tiles overlap
         var SPACING_MAX  = 4.0;  // Maximum spacing scale; higher values spread rooms and z-layers further apart
-        var ALPHA_INACTIVE  = 0.15; // Opacity of rooms and edges on z-levels other than the active one; lower = more faded
-        var ALPHA_CONNECTED = 0.15; // Opacity of rooms on inactive z-levels that have a direct connection to the active layer; higher = more visible cross-z neighbours
+        var ALPHA_INACTIVE  = 0.0; // Opacity of rooms and edges on z-levels other than the active one; lower = more faded
+        var ALPHA_CONNECTED = 0.30; // Opacity of rooms on inactive z-levels that have a direct connection to the active layer; higher = more visible cross-z neighbours
         var LAYER_OFFSET_X  = 0;   // Screen pixels to shift each z-level horizontally per level away from the active layer; increase to spread layers apart left/right
         var LAYER_OFFSET_Y  = 0;   // Screen pixels to shift each z-level vertically per level away from the active layer; increase to spread layers apart up/down
+        var CONNECTION_COLOR_SAME_Z  = '#7a4a1a'; // Color of lines connecting rooms on the same z-level; change to distinguish same-floor corridors
+        var CONNECTION_COLOR_CROSS_Z = '#3a6b8a'; // Color of lines connecting rooms on different z-levels; change to make vertical connections stand out
+        var CROSS_Z_OFFSET_X = 8;   // Horizontal pixel offset from tile center where cross-z connection lines attach; shift left/right to reposition the vertical passage indicator
+        var CROSS_Z_OFFSET_Y = 0;   // Vertical pixel offset from tile center where cross-z connection lines attach; shift up/down to reposition the vertical passage indicator
+        var CROSS_Z_ARROW_SIZE = 6; // Size of the arrowhead drawn on cross-z connection lines in px at zoom 1; larger = more prominent direction indicator
 
         // -- State -------------------------------------------------------------
         var canvas    = null;
@@ -891,7 +893,7 @@
 
         function isoProject(gx, gy, gz, drawZ) {
             var step = TILE_HW * GRID_STEP_XY * spacingScale * zoomScale;
-            var zs   = Z_STEP  * spacingScale * spacingScale * zoomScale;
+            var zs   = Z_STEP  * Math.pow(spacingScale, Z_SPACING_EXPONENT) * zoomScale;
             var midX = Math.floor(canvas.width  / 2);
             var midY = Math.floor(canvas.height / 2);
             var relX = gx - camX - panOffsetX;
@@ -1106,6 +1108,29 @@
                 }
                 ctx.beginPath(); ctx.moveTo(startPt.sx, startPt.sy);
                 ctx.lineTo(endPt.sx, endPt.sy); ctx.stroke();
+
+                if (e.edge.dz !== 0) {
+                    var dx = endPt.sx - startPt.sx;
+                    var dy = endPt.sy - startPt.sy;
+                    var len = Math.sqrt(dx * dx + dy * dy);
+                    if (len > 0) {
+                        var ux = dx / len, uy = dy / len;
+                        var as = CROSS_Z_ARROW_SIZE * zoomScale;
+                        ctx.fillStyle = ctx.strokeStyle;
+                        // Arrowhead at endPt pointing away from startPt.
+                        ctx.beginPath();
+                        ctx.moveTo(endPt.sx, endPt.sy);
+                        ctx.lineTo(endPt.sx - ux * as - uy * as, endPt.sy - uy * as + ux * as);
+                        ctx.lineTo(endPt.sx - ux * as + uy * as, endPt.sy - uy * as - ux * as);
+                        ctx.closePath(); ctx.fill();
+                        // Arrowhead at startPt pointing away from endPt.
+                        ctx.beginPath();
+                        ctx.moveTo(startPt.sx, startPt.sy);
+                        ctx.lineTo(startPt.sx + ux * as - uy * as, startPt.sy + uy * as + ux * as);
+                        ctx.lineTo(startPt.sx + ux * as + uy * as, startPt.sy + uy * as - ux * as);
+                        ctx.closePath(); ctx.fill();
+                    }
+                }
             }
 
             // Draw each z-level in order: same-z edges, then tiles, then cross-z-up edges.

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -288,7 +288,7 @@
         '    flex-direction: column;',
         '    width: 100%;',
         '    height: 100%;',
-        '    background: #1e1e1e;',
+        '    background: #111;',
         '}',
         '#map-tab-bar {',
         '    display: flex;',
@@ -387,6 +387,31 @@
         '    cursor: pointer;',
         '}',
         '.map-controls button:hover { background: rgba(0,0,0,0.8); color: #fff; }',
+        '.map-controls button.active { background: rgba(28,107,96,0.7); color: #dffbd1; border-color: #1c6b60; }',
+        '.map-z-levels {',
+        '    position: absolute;',
+        '    top: 34px;',
+        '    right: 6px;',
+        '    display: flex;',
+        '    flex-direction: column;',
+        '    align-items: center;',
+        '    gap: 2px;',
+        '    z-index: 10;',
+        '}',
+        '.map-z-levels button {',
+        '    width: 22px; height: 22px;',
+        '    padding: 0;',
+        '    font-size: 10px;',
+        '    line-height: 1;',
+        '    background: rgba(0,0,0,0.55);',
+        '    color: #ccc;',
+        '    border: 1px solid #555;',
+        '    border-radius: 3px;',
+        '    cursor: pointer;',
+        '    font-family: monospace;',
+        '}',
+        '.map-z-levels button:hover { background: rgba(0,0,0,0.8); color: #fff; }',
+        '.map-z-levels button.active { background: rgba(28,107,96,0.7); color: #dffbd1; border-color: #1c6b60; }',
     ].join('\n'));
 
     // =========================================================================
@@ -402,7 +427,7 @@
         var CONNECTION_WIDTH = 4;
         var ROOM_BORDER_WIDTH = 1.5;
         var SYMBOL_FONT_SIZE  = 14;
-        var MAP_BACKGROUND    = '#2b2b2b';
+        var MAP_BACKGROUND    = '#111';
         var ROOM_BORDER_COLOR = '#000000';
 
         // -- State -------------------------------------------------------------
@@ -807,7 +832,7 @@
         var GRID_STEP_XY    = 1.6;
         var Z_STEP          = 120;
         var CONNECTION_WIDTH = 2;
-        var MAP_BG           = '#1e1e2e';
+        var MAP_BG           = '#111';
         var TILE_BORDER_COLOR = '#000000';
         var TILE_BORDER_WIDTH = 0.8;
         var SIDE_DARKEN       = 0.55;
@@ -832,8 +857,9 @@
         var dragStartPxX = 0, dragStartPxY = 0;
         var dragStartPanX = 0, dragStartPanY = 0;
         var zoomScale    = 1.0;
-        var hoveredZ     = null;
+        var activeZ       = null;
         var currentRoomKey = '';
+        var zLevelsEl    = null;
 
         var spacingScale = (function () {
             var saved = parseFloat(localStorage.getItem('map3d.spacingScale'));
@@ -1010,7 +1036,7 @@
 
             var playerZ = (currentRoomId !== null && rooms3d.has(currentRoomId))
                 ? rooms3d.get(currentRoomId).z : (camZ | 0);
-            var activeZ = (hoveredZ !== null) ? hoveredZ : playerZ;
+            var drawZ = (activeZ !== null) ? activeZ : playerZ;
 
             ctx.strokeStyle = CONNECTION_COLOR;
             ctx.lineWidth   = CONNECTION_WIDTH * zoomScale;
@@ -1021,7 +1047,7 @@
                 var rA = rooms3d.get(parseInt(parts[0], 10));
                 var rB = rooms3d.get(parseInt(parts[1], 10));
                 if (!rA || !rB) { return; }
-                var zDiff = Math.max(Math.abs(rA.z - activeZ), Math.abs(rB.z - activeZ));
+                var zDiff = Math.max(Math.abs(rA.z - drawZ), Math.abs(rB.z - drawZ));
                 ctx.globalAlpha = zDiff === 0 ? 1.0 : 0.25;
                 var pA = isoProject(rA.x, rA.y, rA.z);
                 var pB = isoProject(rB.x, rB.y, rB.z);
@@ -1040,17 +1066,26 @@
             list.forEach(function (item) {
                 var isCurrent = (item.id === currentRoomId);
                 var topColor  = isCurrent ? CURRENT_ROOM_COLOR : colorForSymbol(item.symbol, item.env);
-                ctx.globalAlpha = Math.abs(item.z - activeZ) === 0 ? 1.0 : 0.25;
+                ctx.globalAlpha = Math.abs(item.z - drawZ) === 0 ? 1.0 : 0.25;
                 drawTile(item.x, item.y, item.z, topColor, isCurrent, item.symbol);
             });
             ctx.globalAlpha = 1.0;
         }
 
+        function getActiveZ() {
+            if (activeZ !== null) { return activeZ; }
+            return (currentRoomId !== null && rooms3d.has(currentRoomId))
+                ? rooms3d.get(currentRoomId).z : (camZ | 0);
+        }
+
         function roomAtPoint(cx, cy) {
             var step = TILE_HW * GRID_STEP_XY * spacingScale * zoomScale;
             var hw = step, hh = step / 2, found = null;
+            var targetZ = getActiveZ();
             var list = [];
-            rooms3d.forEach(function (room, id) { list.push({ id: id, x: room.x, y: room.y, z: room.z }); });
+            rooms3d.forEach(function (room, id) {
+                if (room.z === targetZ) { list.push({ id: id, x: room.x, y: room.y, z: room.z }); }
+            });
             list.sort(function (a, b) { return (b.x + b.y - b.z * 2) - (a.x + a.y - a.z * 2); });
             for (var i = 0; i < list.length; i++) {
                 var item = list[i];
@@ -1074,7 +1109,6 @@
 
             canvas.addEventListener('mouseleave', function () {
                 hideTooltip();
-                if (hoveredZ !== null) { hoveredZ = null; render(); }
                 if (dragActive) { dragActive = false; canvas.style.cursor = ''; }
             });
             canvas.addEventListener('mousedown', function (e) {
@@ -1098,12 +1132,8 @@
                 if (info) {
                     clearTimeout(tooltipHideTimer);
                     showTooltip(e.clientX, e.clientY, info, true);
-                    var hRoom = rooms3d.get(id);
-                    var newZ  = (hRoom && hRoom.z !== null) ? hRoom.z : null;
-                    if (newZ !== hoveredZ) { hoveredZ = newZ; render(); }
                 } else {
                     hideTooltip();
-                    if (hoveredZ !== null) { hoveredZ = null; render(); }
                 }
             });
             canvas.addEventListener('mouseup', function (e) {
@@ -1134,6 +1164,20 @@
             var controls = document.createElement('div');
             controls.className = 'map-controls';
 
+            var btnSpacingDown = document.createElement('button');
+            btnSpacingDown.textContent = '\u2193'; btnSpacingDown.title = 'Decrease spacing';
+            btnSpacingDown.addEventListener('click', function () {
+                spacingScale = Math.max(SPACING_MIN, spacingScale / SPACING_STEP);
+                localStorage.setItem('map3d.spacingScale', spacingScale); render();
+            });
+            var btnSpacingUp = document.createElement('button');
+            btnSpacingUp.textContent = '\u2191'; btnSpacingUp.title = 'Increase spacing';
+            btnSpacingUp.addEventListener('click', function () {
+                spacingScale = Math.min(SPACING_MAX, spacingScale * SPACING_STEP);
+                localStorage.setItem('map3d.spacingScale', spacingScale); render();
+            });
+            var sep = document.createElement('span');
+            sep.className = 'ctrl-sep';
             var btnZoomOut = document.createElement('button');
             btnZoomOut.textContent = '\u2212'; btnZoomOut.title = 'Zoom out';
             btnZoomOut.addEventListener('click', function () {
@@ -1144,30 +1188,52 @@
             btnZoomIn.addEventListener('click', function () {
                 zoomScale = Math.min(ZOOM_MAX, zoomScale * ZOOM_STEP); render();
             });
-            var sep = document.createElement('span');
-            sep.className = 'ctrl-sep';
-            var btnSpacingOut = document.createElement('button');
-            btnSpacingOut.textContent = '\u2212'; btnSpacingOut.title = 'Decrease spacing';
-            btnSpacingOut.addEventListener('click', function () {
-                spacingScale = Math.max(SPACING_MIN, spacingScale / SPACING_STEP);
-                localStorage.setItem('map3d.spacingScale', spacingScale); render();
-            });
-            var btnSpacingIn = document.createElement('button');
-            btnSpacingIn.textContent = '+'; btnSpacingIn.title = 'Increase spacing';
-            btnSpacingIn.addEventListener('click', function () {
-                spacingScale = Math.min(SPACING_MAX, spacingScale * SPACING_STEP);
-                localStorage.setItem('map3d.spacingScale', spacingScale); render();
-            });
 
+            controls.appendChild(btnSpacingDown);
+            controls.appendChild(btnSpacingUp);
+            controls.appendChild(sep);
             controls.appendChild(btnZoomOut);
             controls.appendChild(btnZoomIn);
-            controls.appendChild(sep);
-            controls.appendChild(btnSpacingOut);
-            controls.appendChild(btnSpacingIn);
             wrap.appendChild(controls);
+
+            zLevelsEl = document.createElement('div');
+            zLevelsEl.className = 'map-z-levels';
+            zLevelsEl.style.display = 'none';
+            wrap.appendChild(zLevelsEl);
 
             container = wrap;
             return wrap;
+        }
+
+        function updateZButtons() {
+            if (!zLevelsEl) { return; }
+            var levels = [];
+            rooms3d.forEach(function (room) {
+                if (levels.indexOf(room.z) === -1) { levels.push(room.z); }
+            });
+            levels.sort(function (a, b) { return b - a; });
+
+            zLevelsEl.innerHTML = '';
+            if (levels.length <= 1) { zLevelsEl.style.display = 'none'; return; }
+
+            var playerZ = (currentRoomId !== null && rooms3d.has(currentRoomId))
+                ? rooms3d.get(currentRoomId).z : null;
+            var currentActiveZ = (activeZ !== null) ? activeZ : playerZ;
+
+            levels.forEach(function (z) {
+                var btn = document.createElement('button');
+                btn.textContent = z;
+                btn.title = 'Z level ' + z;
+                if (z === currentActiveZ) { btn.classList.add('active'); }
+                btn.addEventListener('click', function () {
+                    activeZ = z;
+                    updateZButtons();
+                    render();
+                });
+                zLevelsEl.appendChild(btn);
+            });
+
+            zLevelsEl.style.display = 'flex';
         }
 
         function onActivate() {
@@ -1182,6 +1248,7 @@
                 replayZone3d(savedId);
                 currentRoomId = savedId;
             }
+            updateZButtons();
             render();
         }
 
@@ -1208,6 +1275,8 @@
                 }
             }
             currentRoomId = info.num;
+            activeZ = gz;
+            updateZButtons();
             setCameraTarget(gx, gy, gz);
         }
 
@@ -1224,6 +1293,7 @@
             onWorldMap:          onWorldMap,
             onRoomUpdate:        onRoomUpdate,
             setupResizeObserver: setupResizeObserver,
+            updateZButtons:      updateZButtons,
         };
 
     }());
@@ -1307,7 +1377,7 @@
             return {
                 title:      'Map',
                 mount:      el,
-                background: '#1e1e1e',
+                background: '#111',
                 border:     1,
                 x:          'right',
                 y:          66,

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -724,9 +724,8 @@
             });
             canvas.addEventListener('wheel', function (e) {
                 e.preventDefault();
-                zoomScale = e.deltaY < 0
-                    ? Math.min(ZOOM_MAX, zoomScale * ZOOM_STEP)
-                    : Math.max(ZOOM_MIN, zoomScale / ZOOM_STEP);
+                var factor = Math.pow(ZOOM_STEP, e.deltaY * 0.002);
+                zoomScale = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, zoomScale / factor));
                 render();
             }, { passive: false });
 
@@ -838,7 +837,7 @@
         var SIDE_DARKEN       = 0.55;
         var SYMBOL_FONT_SIZE  = 10;
         var SPACING_STEP = 1.25;
-        var SPACING_MIN  = 0.4;
+        var SPACING_MIN  = 0.6;
         var SPACING_MAX  = 4.0;
 
         // -- State -------------------------------------------------------------
@@ -863,7 +862,7 @@
 
         var spacingScale = (function () {
             var saved = parseFloat(localStorage.getItem('map3d.spacingScale'));
-            return (isFinite(saved) && saved >= SPACING_MIN && saved <= SPACING_MAX) ? saved : 1.0;
+            return (isFinite(saved) && saved >= SPACING_MIN && saved <= SPACING_MAX) ? saved : SPACING_MIN;
         }());
 
         // -- Helpers -----------------------------------------------------------
@@ -884,7 +883,7 @@
 
         function isoProject(gx, gy, gz) {
             var step = TILE_HW * GRID_STEP_XY * spacingScale * zoomScale;
-            var zs   = Z_STEP  * spacingScale * zoomScale;
+            var zs   = Z_STEP  * spacingScale * spacingScale * zoomScale;
             var midX = Math.floor(canvas.width  / 2);
             var midY = Math.floor(canvas.height / 2);
             var relX = gx - camX - panOffsetX;
@@ -1155,9 +1154,8 @@
             });
             canvas.addEventListener('wheel', function (e) {
                 e.preventDefault();
-                zoomScale = e.deltaY < 0
-                    ? Math.min(ZOOM_MAX, zoomScale * ZOOM_STEP)
-                    : Math.max(ZOOM_MIN, zoomScale / ZOOM_STEP);
+                var factor = Math.pow(ZOOM_STEP, e.deltaY * 0.002);
+                zoomScale = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, zoomScale / factor));
                 render();
             }, { passive: false });
 

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -844,7 +844,7 @@
         var ALPHA_CONNECTED = 0.30; // Opacity of rooms on inactive z-levels that have a direct connection to the active layer; higher = more visible cross-z neighbours
         var LAYER_OFFSET_X  = 0;   // Screen pixels to shift each z-level horizontally per level away from the active layer; increase to spread layers apart left/right
         var LAYER_OFFSET_Y  = 0;   // Screen pixels to shift each z-level vertically per level away from the active layer; increase to spread layers apart up/down
-        var CONNECTION_COLOR_SAME_Z  = '#7a4a1a'; // Color of lines connecting rooms on the same z-level; change to distinguish same-floor corridors
+        var CONNECTION_COLOR_SAME_Z  = '#ffffff'; // Color of lines connecting rooms on the same z-level; change to distinguish same-floor corridors
         var CONNECTION_COLOR_CROSS_Z = '#3a6b8a'; // Color of lines connecting rooms on different z-levels; change to make vertical connections stand out
         var CROSS_Z_OFFSET_X = 8;   // Horizontal pixel offset from tile center where cross-z connection lines attach; shift left/right to reposition the vertical passage indicator
         var CROSS_Z_OFFSET_Y = 0;   // Vertical pixel offset from tile center where cross-z connection lines attach; shift up/down to reposition the vertical passage indicator

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -832,11 +832,11 @@
         var Z_STEP           = 50;   // Screen pixels of vertical separation per z-level at default spacing; increase to push layers further apart vertically
         var Z_SPACING_EXPONENT = 1.5; // Controls how aggressively z-layer separation grows as spacing increases; 1.0 = linear with spacing, 2.0 = quadratic (very dramatic), lower = subtler
         var CONNECTION_WIDTH = 2;    // Stroke width of lines connecting rooms; thicker = more visible corridors
-        var MAP_BG           = '#111';    // Canvas fill color behind all tiles; change to adjust overall contrast
+        var MAP_BG           = '#000000';    // Canvas fill color behind all tiles; change to adjust overall contrast
         var TILE_BORDER_COLOR = '#000000'; // Outline color drawn around each tile face; darker = crisper tile edges
         var TILE_BORDER_WIDTH = 0.8;  // Stroke width of tile outlines; higher = bolder edges, can obscure small tiles at low zoom
         var SIDE_DARKEN       = 0.55; // Brightness multiplier for the left and right block faces; lower = darker sides, stronger 3D illusion
-        var SYMBOL_FONT_SIZE  = 10;   // Font size of the symbol character on each tile; larger = more readable but may overflow the tile face
+        var SYMBOL_FONT_SIZE  = 11;   // Font size of the symbol character on each tile; larger = more readable but may overflow the tile face
         var SPACING_STEP = 1.25; // Multiplier applied per spacing button click; higher = bigger jumps between spacing levels
         var SPACING_MIN  = 0.6;  // Minimum spacing scale; lower values compress rooms closer together until tiles overlap
         var SPACING_MAX  = 4.0;  // Maximum spacing scale; higher values spread rooms and z-layers further apart

--- a/_datafiles/html/public/static/js/windows/window-map.js
+++ b/_datafiles/html/public/static/js/windows/window-map.js
@@ -1052,11 +1052,9 @@
             });
 
             // Group rooms and edges by z-level, sorted lowest to highest.
-            var zLevels = [];
-            rooms3d.forEach(function (room) {
-                if (zLevels.indexOf(room.z) === -1) { zLevels.push(room.z); }
-            });
-            zLevels.sort(function (a, b) { return a - b; });
+            var zSet = new Set();
+            rooms3d.forEach(function (room) { zSet.add(room.z); });
+            var zLevels = Array.from(zSet).sort(function (a, b) { return a - b; });
 
             // Pre-bucket rooms and edges by z-level for efficient per-layer access.
             var roomsByZ = {};
@@ -1300,11 +1298,7 @@
 
         function updateZButtons() {
             if (!zLevelsEl) { return; }
-            var levels = [];
-            rooms3d.forEach(function (room) {
-                if (levels.indexOf(room.z) === -1) { levels.push(room.z); }
-            });
-            levels.sort(function (a, b) { return b - a; });
+            var levels = Array.from(new Set(Array.from(rooms3d.values()).map(function (r) { return r.z; }))).sort(function (a, b) { return b - a; });
 
             zLevelsEl.innerHTML = '';
             if (levels.length <= 1) { zLevelsEl.style.display = 'none'; return; }

--- a/_datafiles/html/public/webclient-context.md
+++ b/_datafiles/html/public/webclient-context.md
@@ -415,62 +415,28 @@ Every module is an IIFE to keep all state private. The pattern is:
 (function() {
 
     // -- Styles (injected once at script load time) --------------------------
-    injectStyles(`
-        #example-content {
-            color: #fff;
-            padding: 8px;
-            font-family: monospace;
-        }
-    `);
+    injectStyles(/* css string */);
 
     // -- DOM factory --------------------------------------------------------
     // Called once on first open. Must append to document.body.
-    function createDOM() {
-        const el = document.createElement('div');
-        el.id = 'example-content';
-        el.textContent = 'Waiting for data...';
-        document.body.appendChild(el);
-        return el;
-    }
+    function createDOM() { /* ... */ }
 
     // -- VirtualWindow instance ---------------------------------------------
     const win = new VirtualWindow('Example', {
         dock:          'right',   // 'left' | 'right' — enables docking
         defaultDocked: true,      // start docked on page load
         dockedHeight:  200,       // preferred height (px) when docked
-        factory() {
-            const el = createDOM();
-            return {
-                title:      'Example',
-                mount:      el,
-                background: '#1c6b60',
-                border:     1,
-                x:          'right',
-                y:          0,
-                width:      363,
-                height:     220,
-                header:     20,
-                bottom:     60,
-            };
-        },
+        factory() { /* ... */ },
     });
 
     // -- Update logic -------------------------------------------------------
-    function update() {
-        const data = Client.GMCPStructs.Some && Client.GMCPStructs.Some.Namespace;
-        if (!data) { return; }
-
-        win.open();
-        if (!win.isOpen()) { return; }
-
-        document.getElementById('example-content').textContent = data.someField;
-    }
+    function update() { /* ... */ }
 
     // -- Registration -------------------------------------------------------
     VirtualWindows.register({
         window:       win,
         gmcpHandlers: ['Some.Namespace', 'Some'],
-        onGMCP() { update(); },
+        onGMCP() { /* ... */ },
     });
 
 })();
@@ -574,10 +540,7 @@ module involvement.
 ### Adding a terminal command
 
 ```js
-Client.registerCommand('!example', 'Print example info', (input) => {
-    Client.term.writeln('Example command ran.');
-    return true;  // return true to consume the input (clears the field)
-});
+Client.registerCommand('!example', 'Print example info', (input) => { /* ... */ });
 ```
 
 Commands are matched against the exact input string before it is sent to the

--- a/_datafiles/html/public/webclient-pure.html
+++ b/_datafiles/html/public/webclient-pure.html
@@ -898,7 +898,7 @@
     <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/xterm.4.19.0.js"></script>
     <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/xterm-addon-fit.js"></script>
     <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/mp3.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/fx.js?v=2"></script>
+    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/fx.js"></script>
     <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/winbox.bundle.min.js"></script>
     <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/webclient-core.js"></script>
     <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/triggers.js"></script>

--- a/internal/usercommands/look.go
+++ b/internal/usercommands/look.go
@@ -313,6 +313,12 @@ func Look(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 	foundNoun, foundDesc := room.FindNoun(lookAt)
 	if len(foundNoun) > 0 {
 
+		// Nouns may be multi-line
+		finalNounDesc := []string{}
+		for _, descLine := range strings.Split(foundDesc, "\n") {
+			finalNounDesc = append(finalNounDesc, descLine)
+		}
+
 		user.SendText(``)
 
 		user.SendText(
@@ -329,8 +335,10 @@ func Look(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 			}
 
 			if renderNouns && len(room.Nouns) > 0 {
-				for noun, _ := range room.Nouns {
-					foundDesc = strings.Replace(foundDesc, noun, `<ansi fg="noun">`+noun+`</ansi>`, 1)
+				for idx, descLine := range finalNounDesc {
+					for noun, _ := range room.Nouns {
+						finalNounDesc[idx] = strings.Replace(descLine, noun, `<ansi fg="noun">`+noun+`</ansi>`, 1)
+					}
 				}
 			}
 
@@ -340,7 +348,9 @@ func Look(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 			)
 		}
 
-		user.SendText(foundDesc)
+		for _, outLine := range finalNounDesc {
+			user.SendText(outLine)
+		}
 
 		user.SendText(``)
 

--- a/modules/gambling/claw.go
+++ b/modules/gambling/claw.go
@@ -2,11 +2,14 @@ package gambling
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/GoMudEngine/GoMud/internal/buffs"
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/items"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/term"
 	"github.com/GoMudEngine/GoMud/internal/users"
 	"github.com/GoMudEngine/GoMud/internal/util"
 )
@@ -89,6 +92,8 @@ func (g *GamblingModule) onRoomLookClaw(d rooms.RoomTemplateDetails) rooms.RoomT
 // playClaw executes one claw machine attempt for the user.
 func (g *GamblingModule) playClaw(user *users.UserRecord, room *rooms.Room) {
 
+	user.Character.CancelBuffsWithFlag(buffs.Hidden) // No longer sneaking
+
 	cost := defaultClawCost
 	if v, ok := g.plug.Config.Get(`ClawCost`).(int); ok && v > 0 {
 		cost = v
@@ -113,15 +118,22 @@ func (g *GamblingModule) playClaw(user *users.UserRecord, room *rooms.Room) {
 		GoldChange: -cost,
 	})
 
+	user.SendText(term.CRLFStr)
+	user.SendText("You put your money in and grip the joystick...")
+
 	room.SendText(
 		fmt.Sprintf(`<ansi fg="username">%s</ansi> feeds coins into the claw machine and grips the joystick...`,
 			user.Character.Name),
 		user.UserId,
 	)
 
+	user.SendText(term.CRLFStr)
+
 	if util.Rand(100) >= winChance {
 		user.SendText(`<ansi fg="cyan">The claw descends...</ansi> hovers tantalizingly over a prize...`)
+		user.SendText(term.CRLFStr)
 		user.SendText(`<ansi fg="8">...and drops it at the last moment. Better luck next time!</ansi>`)
+		user.SendText(term.CRLFStr)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="8">The claw drops its prize just before the chute. <ansi fg="username">%s</ansi> walks away empty-handed.</ansi>`,
 				user.Character.Name),
@@ -133,20 +145,32 @@ func (g *GamblingModule) playClaw(user *users.UserRecord, room *rooms.Room) {
 	selected := g.pickClawPrize()
 	if selected == nil {
 		user.SendText(`<ansi fg="8">The claw machine whirs but the prize pool is empty. (All prize weights are zero.)</ansi>`)
+		user.SendText(term.CRLFStr)
 		return
 	}
 
 	prize := items.New(selected.itemId)
 	if !prize.IsValid() {
 		user.SendText(`<ansi fg="8">The claw machine whirs but produces nothing. (Something went wrong internally.)</ansi>`)
+		user.SendText(term.CRLFStr)
 		return
 	}
 
 	if !user.Character.StoreItem(prize) {
 		user.SendText(fmt.Sprintf(
-			`<ansi fg="cyan">The claw snatches up a <ansi fg="item">%s</ansi>!</ansi> <ansi fg="214">But your backpack is full — it tumbles back into the machine.</ansi>`,
+			`<ansi fg="cyan">The claw snatches up a <ansi fg="item">%s</ansi>!</ansi> <ansi fg="214">But your backpack is full — it tumbles to the floor.</ansi>`,
 			selected.name,
 		))
+
+		room.SendText(
+			fmt.Sprintf(`<ansi fg="username">%s</ansi> wins a <ansi fg="item">%s</ansi> but it falls to the floor!`,
+				user.Character.Name,
+				selected.name),
+			user.UserId,
+		)
+
+		room.AddItem(prize, false)
+		user.SendText(term.CRLFStr)
 		return
 	}
 
@@ -157,10 +181,16 @@ func (g *GamblingModule) playClaw(user *users.UserRecord, room *rooms.Room) {
 	})
 
 	user.SendText(`<ansi fg="cyan-bold">The claw descends with purpose...</ansi>`)
+
+	user.SendText(term.CRLFStr)
+
 	user.SendText(fmt.Sprintf(
 		`<ansi fg="green-bold">...and snatches up a <ansi fg="item">%s</ansi>!</ansi> It drops neatly into the prize chute. <ansi fg="yellow-bold">Congratulations!</ansi>`,
 		selected.name,
 	))
+
+	user.SendText(term.CRLFStr)
+
 	room.SendText(
 		fmt.Sprintf(`<ansi fg="cyan-bold">The claw machine rattles!</ansi> <ansi fg="username">%s</ansi> <ansi fg="green">wins a prize!</ansi>`,
 			user.Character.Name),
@@ -171,6 +201,7 @@ func (g *GamblingModule) playClaw(user *users.UserRecord, room *rooms.Room) {
 // clawMachineNounDesc returns the noun description shown when a player types
 // "look claw machine" in a room with the claw machine tag.
 func (g *GamblingModule) clawMachineNounDesc(room *rooms.Room) string {
+
 	cost := defaultClawCost
 	if v, ok := g.plug.Config.Get(`ClawCost`).(int); ok && v > 0 {
 		cost = v
@@ -179,66 +210,45 @@ func (g *GamblingModule) clawMachineNounDesc(room *rooms.Room) string {
 	if v, ok := g.plug.Config.Get(`ClawWinChance`).(int); ok && v > 0 {
 		winChance = v
 	}
-	return fmt.Sprintf(
-		`A tall glass cabinet filled with prizes, lit from within by a warm glow. A mechanical claw hangs from a gantry inside. Cost to play: <ansi fg="gold">%d gold</ansi>. Chance to win: <ansi fg="cyan-bold">%d%%</ansi>. Type <ansi fg="command">play claw machine</ansi> to try your luck.`,
-		cost, winChance,
-	)
-}
 
-func (g *GamblingModule) lookClawMachine(user *users.UserRecord, room *rooms.Room) {
-
-	cost := defaultClawCost
-	if v, ok := g.plug.Config.Get(`ClawCost`).(int); ok && v > 0 {
-		cost = v
-	}
-
-	winChance := defaultClawWinChance
-	if v, ok := g.plug.Config.Get(`ClawWinChance`).(int); ok && v > 0 {
-		winChance = v
-	}
-
-	// Compute total weight for percentage display.
 	totalWeight := 0
 	for i := range clawPrizes {
 		totalWeight += g.clawPrizeWeight(clawPrizes[i])
 	}
 
-	user.SendText(``)
-	user.SendText(`<ansi fg="cyan">╔════════════════════════════════╗</ansi>`)
-	user.SendText(`<ansi fg="cyan">║</ansi>      <ansi fg="cyan-bold">C L A W  M A C H I N E</ansi>      <ansi fg="cyan">║</ansi>`)
-	user.SendText(`<ansi fg="cyan">╚════════════════════════════════╝</ansi>`)
-	user.SendText(``)
-	user.SendText(`A tall glass cabinet filled with small prizes, lit from within by a warm glow.`)
-	user.SendText(`A mechanical claw hangs from a gantry inside, waiting to be guided by a brave soul.`)
-	user.SendText(`A placard on the front reads:`)
-	user.SendText(``)
-	user.SendText(fmt.Sprintf(`    Cost to play:  <ansi fg="gold">%d gold</ansi>`, cost))
-	user.SendText(fmt.Sprintf(`    Chance to win: <ansi fg="cyan-bold">%d%%</ansi>`, winChance))
-	user.SendText(``)
-	user.SendText(`<ansi fg="cyan">Prizes</ansi> <ansi fg="8">(chance on win):</ansi>`)
-
+	type weightedPrize struct {
+		prize clawPrize
+		wt    int
+	}
+	sorted := make([]weightedPrize, 0, len(clawPrizes))
 	for i := range clawPrizes {
-		p := clawPrizes[i]
-		wt := g.clawPrizeWeight(p)
-		if wt <= 0 {
-			continue
+		wt := g.clawPrizeWeight(clawPrizes[i])
+		if wt > 0 {
+			sorted = append(sorted, weightedPrize{clawPrizes[i], wt})
 		}
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].wt > sorted[j].wt })
+
+	var sb strings.Builder
+	sb.WriteString(`<ansi fg="cyan">╔════════════════════════════════╗</ansi>` + "\n")
+	sb.WriteString(`<ansi fg="cyan">║</ansi>     <ansi fg="cyan-bold">C L A W  M A C H I N E</ansi>     <ansi fg="cyan">║</ansi>` + "\n")
+	sb.WriteString(`<ansi fg="cyan">╚════════════════════════════════╝</ansi>` + "\n")
+	sb.WriteString("\n")
+	sb.WriteString("A tall glass cabinet filled with small prizes, lit from within by a warm glow.\n")
+	sb.WriteString("A mechanical claw hangs from a gantry inside, waiting to be guided by a brave soul.\n")
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("    Cost to play:  <ansi fg=\"gold\">%d gold</ansi>\n", cost))
+	sb.WriteString(fmt.Sprintf("    Chance to win: <ansi fg=\"cyan-bold\">%d%%</ansi>\n", winChance))
+	sb.WriteString("\n")
+	sb.WriteString(`<ansi fg="cyan">Prizes</ansi> <ansi fg="8">(chance on win):</ansi>` + "\n")
+	for _, wp := range sorted {
 		pct := 0
 		if totalWeight > 0 {
-			pct = wt * 100 / totalWeight
+			pct = wp.wt * 100 / totalWeight
 		}
-		user.SendText(fmt.Sprintf(
-			`    <ansi fg="item">%-16s</ansi>  <ansi fg="cyan">%d%%</ansi>`,
-			p.name, pct,
-		))
+		sb.WriteString(fmt.Sprintf("    <ansi fg=\"item\">%-16s</ansi>  <ansi fg=\"cyan\">%d%%</ansi>\n", wp.prize.name, pct))
 	}
-
-	user.SendText(``)
-	user.SendText(`Type <ansi fg="command">play claw machine</ansi> to try your luck.`)
-	user.SendText(``)
-
-	room.SendText(
-		fmt.Sprintf(`<ansi fg="username">%s</ansi> examines the claw machine.`, user.Character.Name),
-		user.UserId,
-	)
+	sb.WriteString("\n")
+	sb.WriteString(`Type <ansi fg="command">play claw machine</ansi> to try your luck.`)
+	return sb.String()
 }

--- a/modules/gambling/gambling.go
+++ b/modules/gambling/gambling.go
@@ -77,6 +77,14 @@ func init() {
 	events.RegisterListener(events.PlayerSpawn{}, g.onPlayerSpawn)
 }
 
+// refreshRoomNouns evicts the room from the cache and immediately re-injects
+// updated noun descriptions, so changes (e.g. jackpot) are visible without
+// requiring players to leave and re-enter the room.
+func (g *GamblingModule) refreshRoomNouns(room *rooms.Room) {
+	g.roomCache.Remove(room.RoomId)
+	g.ensureRoomNouns(room)
+}
+
 // ensureRoomNouns injects gambling fixture nouns into the room's Nouns map so
 // that "look slot machine", "look slots", and "look claw machine" are handled
 // synchronously by the core look command rather than falling through to

--- a/modules/gambling/slots.go
+++ b/modules/gambling/slots.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/GoMudEngine/GoMud/internal/buffs"
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/term"
 	"github.com/GoMudEngine/GoMud/internal/users"
 	"github.com/GoMudEngine/GoMud/internal/util"
 )
@@ -52,7 +54,14 @@ var (
 
 // SlotState holds the persistent jackpot pool.
 type SlotState struct {
-	Jackpot int `yaml:"Jackpot"`
+	Jackpot        int    `yaml:"Jackpot"`
+	BiggestWin     int    `yaml:"BiggestWin"`
+	BiggestWinName string `yaml:"BiggestWinName"`
+}
+
+// minJackpot returns the minimum jackpot value (20x the cost to play).
+func minJackpot(cost int) int {
+	return cost * 160
 }
 
 // roomHasSlots returns true when the room carries a "slots" or "slot machine" tag.
@@ -151,17 +160,27 @@ func (g *GamblingModule) playSlots(user *users.UserRecord, room *rooms.Room) {
 		return
 	}
 
+	user.Character.CancelBuffsWithFlag(buffs.Hidden) // No longer sneaking
+
 	// Deduct cost and add to jackpot pool.
 	user.Character.Gold -= cost
 
 	slotMu.Lock()
 	g.state.Jackpot += cost / 2 // half of each play feeds the jackpot
+	if g.state.Jackpot < minJackpot(cost) {
+		g.state.Jackpot = minJackpot(cost)
+	}
 	slotMu.Unlock()
+	g.refreshRoomNouns(room)
 
 	events.AddToQueue(events.EquipmentChange{
 		UserId:     user.UserId,
 		GoldChange: -cost,
 	})
+
+	user.SendText(term.CRLFStr)
+	user.SendText("You put in your money and pull the lever...")
+	user.SendText(term.CRLFStr)
 
 	a, b, c := spinReel(), spinReel(), spinReel()
 
@@ -181,8 +200,12 @@ func (g *GamblingModule) playSlots(user *users.UserRecord, room *rooms.Room) {
 	if outcome.label == `JACKPOT` {
 		slotMu.Lock()
 		prize := g.state.Jackpot
+		if prize < minJackpot(cost) {
+			prize = minJackpot(cost)
+		}
 		g.state.Jackpot = 0
 		slotMu.Unlock()
+		g.refreshRoomNouns(room)
 
 		user.Character.Gold += prize
 		events.AddToQueue(events.EquipmentChange{
@@ -190,12 +213,14 @@ func (g *GamblingModule) playSlots(user *users.UserRecord, room *rooms.Room) {
 			GoldChange: prize,
 		})
 
+		g.maybeUpdateBiggestWin(prize, user.Character.Name, room)
+
 		banner := jackpotBanner()
-		user.SendText(" ")
+
 		user.SendText(reelLine)
-		user.SendText(" ")
+		user.SendText(term.CRLFStr)
 		user.SendText(fmt.Sprintf(`%s <ansi fg="gold">You win %d gold!</ansi>`, banner, prize))
-		user.SendText(" ")
+		user.SendText(term.CRLFStr)
 		room.SendText(
 			fmt.Sprintf(`%s <ansi fg="username">%s</ansi> <ansi fg="yellow-bold">has hit the JACKPOT!!!</ansi>`,
 				banner, user.Character.Name),
@@ -224,13 +249,15 @@ func (g *GamblingModule) playSlots(user *users.UserRecord, room *rooms.Room) {
 			GoldChange: prize,
 		})
 
+		g.maybeUpdateBiggestWin(prize, user.Character.Name, room)
+
 		user.SendText(reelLine)
-		user.SendText(" ")
+		user.SendText(term.CRLFStr)
 		user.SendText(fmt.Sprintf(
 			`<ansi fg="%s">%s!</ansi> You win <ansi fg="gold">%d gold</ansi>!`,
 			labelColor, outcome.label, prize,
 		))
-		user.SendText(" ")
+		user.SendText(term.CRLFStr)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> <ansi fg="green">wins</ansi> on the slot machine!`, user.Character.Name),
 			user.UserId,
@@ -246,6 +273,47 @@ func (g *GamblingModule) playSlots(user *users.UserRecord, room *rooms.Room) {
 	)
 }
 
+// slotPayoutTable returns the formatted payout table lines.
+func slotPayoutTable() string {
+	var sb strings.Builder
+	rows := []struct {
+		label  string
+		desc   string
+		color  string
+		payout string
+	}{
+		{`JACKPOT`, `seven  seven  seven`, `gold`, `entire jackpot`},
+		{`TRIPLE BAR`, `bar    bar    bar`, `cyan-bold`, `20x cost`},
+		{`TRIPLE BELL`, `bell   bell   bell`, `green-bold`, `10x cost`},
+		{`TRIPLE <any>`, `X      X      X`, `green-bold`, `5x cost`},
+		{`PAIR`, `X      X      -`, `green-bold`, `2x cost`},
+		{`CHERRIES`, `cherry cherry -`, `green-bold`, `2x cost`},
+	}
+	sb.WriteString(`<ansi fg="magenta">Payout table:</ansi>` + "\n")
+	for _, r := range rows {
+		sb.WriteString(fmt.Sprintf(
+			"    <ansi fg=\"%s\">%-14s</ansi>  <ansi fg=\"8\">%-22s</ansi>  <ansi fg=\"gold\">%s</ansi>\n",
+			r.color, r.label, r.desc, r.payout,
+		))
+	}
+	return sb.String()
+}
+
+// maybeUpdateBiggestWin records a new biggest win if prize exceeds the current record,
+// then clears the room cache so the noun description is refreshed.
+func (g *GamblingModule) maybeUpdateBiggestWin(prize int, name string, room *rooms.Room) {
+	slotMu.Lock()
+	updated := prize > g.state.BiggestWin
+	if updated {
+		g.state.BiggestWin = prize
+		g.state.BiggestWinName = name
+	}
+	slotMu.Unlock()
+	if updated {
+		g.refreshRoomNouns(room)
+	}
+}
+
 // slotMachineNounDesc returns the noun description shown when a player types
 // "look slot machine" in a room with the slots tag.
 func (g *GamblingModule) slotMachineNounDesc(room *rooms.Room) string {
@@ -255,47 +323,33 @@ func (g *GamblingModule) slotMachineNounDesc(room *rooms.Room) string {
 	}
 	slotMu.Lock()
 	jackpot := g.state.Jackpot
+	biggestWin := g.state.BiggestWin
+	biggestWinName := g.state.BiggestWinName
 	slotMu.Unlock()
-	return fmt.Sprintf(
-		`A gleaming mechanical contraption adorned with spinning reels and flashing lights. A worn lever protrudes from its side. Cost to play: <ansi fg="gold">%d gold</ansi>. Current jackpot: <ansi fg="220">%d gold</ansi>. Type <ansi fg="command">play slots</ansi> to try your luck.`,
-		cost, jackpot,
-	)
-}
-
-func (g *GamblingModule) lookSlotMachine(user *users.UserRecord, room *rooms.Room) {
-
-	cost := defaultCost
-	if v, ok := g.plug.Config.Get(`SlotCost`).(int); ok && v > 0 {
-		cost = v
+	if jackpot < minJackpot(cost) {
+		jackpot = minJackpot(cost)
 	}
 
-	slotMu.Lock()
-	jackpot := g.state.Jackpot
-	slotMu.Unlock()
+	biggestWinLine := "    Biggest winner: <ansi fg=\"8\">none yet</ansi>\n"
+	if biggestWin > 0 {
+		biggestWinLine = fmt.Sprintf("\n    Biggest winner:  <ansi fg=\"username\">%s</ansi> with <ansi fg=\"gold\">%d gold</ansi>\n", biggestWinName, biggestWin)
+	}
 
-	user.SendText(``)
-	user.SendText(`<ansi fg="220">╔════════════════════════════════╗</ansi>`)
-	user.SendText(`<ansi fg="220">║</ansi>     <ansi fg="yellow-bold">S L O T  M A C H I N E</ansi>     <ansi fg="220">║</ansi>`)
-	user.SendText(`<ansi fg="220">╚════════════════════════════════╝</ansi>`)
-	user.SendText(``)
-	user.SendText(`A gleaming mechanical contraption adorned with spinning reels and flashing lights.`)
-	user.SendText(`A worn lever protrudes from its side, inviting the bold and foolish alike.`)
-	user.SendText(`A placard on the front reads:`)
-	user.SendText(``)
-	user.SendText(fmt.Sprintf(
-		`    Cost to play:    <ansi fg="gold">%d gold</ansi>`,
-		cost,
-	))
-	user.SendText(fmt.Sprintf(
-		`    Current jackpot: <ansi fg="gold">%d gold</ansi>`,
-		jackpot,
-	))
-	user.SendText(``)
-	user.SendText(`Type <ansi fg="command">play slots</ansi> to try your luck.`)
-	user.SendText(``)
-
-	room.SendText(
-		fmt.Sprintf(`<ansi fg="username">%s</ansi> examines the slot machine.`, user.Character.Name),
-		user.UserId,
+	return fmt.Sprintf(
+		"<ansi fg=\"220\">╔════════════════════════════════╗</ansi>\n"+
+			"<ansi fg=\"220\">║</ansi>     <ansi fg=\"yellow-bold\">S L O T  M A C H I N E</ansi>     <ansi fg=\"220\">║</ansi>\n"+
+			"<ansi fg=\"220\">╚════════════════════════════════╝</ansi>\n"+
+			"\n"+
+			"A gleaming mechanical contraption adorned with spinning reels and flashing lights.\n"+
+			"A worn lever protrudes from its side.\n"+
+			"\n"+
+			"    Cost to play:    <ansi fg=\"gold\">%d gold</ansi>\n"+
+			"    Current jackpot: <ansi fg=\"gold\">%d gold</ansi>\n"+
+			"%s"+
+			"\n"+
+			"%s"+
+			"\n"+
+			"Type <ansi fg=\"command\">play slots</ansi> to try your luck.",
+		cost, jackpot, biggestWinLine, slotPayoutTable(),
 	)
 }

--- a/modules/gmcp/gmcp.Game.go
+++ b/modules/gmcp/gmcp.Game.go
@@ -29,12 +29,65 @@ func init() {
 	events.RegisterListener(events.PlayerDespawn{}, g.onJoinLeave)
 	events.RegisterListener(events.PlayerSpawn{}, g.onJoinLeave)
 	events.RegisterListener(events.PlayerChanged{}, g.onJoinLeave)
+	events.RegisterListener(GMCPGameRequest{}, g.onGameRequest)
 
 }
 
 type GMCPGameModule struct {
 	// Keep a reference to the plugin when we create it so that we can call ReadBytes() and WriteBytes() on it.
 	plug *plugins.Plugin
+}
+
+type GMCPGameRequest struct {
+	UserId int
+}
+
+func (g GMCPGameRequest) Type() string { return `GMCPGameRequest` }
+
+func (g *GMCPGameModule) onGameRequest(e events.Event) events.ListenerReturn {
+
+	evt, typeOk := e.(GMCPGameRequest)
+	if !typeOk {
+		return events.Cancel
+	}
+
+	g.sendGamePayload(evt.UserId)
+	return events.Continue
+}
+
+func (g *GMCPGameModule) sendGamePayload(targetUserId int) {
+
+	c := configs.GetConfig()
+	tFormat := string(c.TextFormats.Time)
+
+	whoPayload := `"Who": { "Players": [`
+
+	var infoStr string
+	pCt := 0
+	for _, user := range users.GetAllActiveUsers() {
+
+		if user.UserId == targetUserId {
+			infoStr = `"Info": { "logintime": "` + user.GetConnectTime().Format(tFormat) + `", "name": "` + string(c.Server.MudName) + `" }`
+		}
+
+		if pCt > 0 {
+			whoPayload += `, `
+		}
+		pCt++
+
+		whoPayload += `{ "level": ` + strconv.Itoa(user.Character.Level) + `, "name": "` + user.Character.Name + `", "title": "` + user.Role + `"}`
+	}
+	whoPayload += `] }`
+
+	if infoStr == `` {
+		return
+	}
+
+	events.AddToQueue(GMCPOut{
+		UserId:  targetUserId,
+		Module:  `Game`,
+		Payload: `{ ` + infoStr + `, ` + whoPayload + ` }`,
+	})
 }
 
 func (g *GMCPGameModule) onJoinLeave(e events.Event) events.ListenerReturn {

--- a/modules/gmcp/gmcp.go
+++ b/modules/gmcp/gmcp.go
@@ -296,6 +296,18 @@ func (g *GMCPModule) HandleWebGMCP(connectionId uint64, webGMCP []byte) bool {
 			return true
 		}
 
+		if strings.HasPrefix(identifier, `Game`) {
+			for _, user := range users.GetAllActiveUsers() {
+				if user.ConnectionId() == connectionId {
+					events.AddToQueue(GMCPGameRequest{
+						UserId: user.UserId,
+					})
+					break
+				}
+			}
+			return true
+		}
+
 		if identifier == `Suggestion` {
 			for _, user := range users.GetAllActiveUsers() {
 				if user.ConnectionId() == connectionId {

--- a/modules/zombiemode/command.zombie.go
+++ b/modules/zombiemode/command.zombie.go
@@ -38,7 +38,7 @@ func (m *ZombieModule) zombieCommand(rest string, user *users.UserRecord, room *
 			user.SendText(`Zombie mode is already active.`)
 			return true, nil
 		}
-		m.active[user.UserId] = zombieRuntime{HomeRoom: user.Character.RoomId}
+		m.active[user.UserId] = zombieRuntime{HomeRoom: user.Character.RoomId, Stats: newZombieStats()}
 		user.Character.SetAdjective(`zombie`, true)
 		user.SendText(`<ansi fg="yellow">Zombie mode activated. Send any input to wake up.</ansi>`)
 		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi>'s eyes glaze over...`, user.Character.Name), user.UserId)

--- a/modules/zombiemode/zombiemode.go
+++ b/modules/zombiemode/zombiemode.go
@@ -41,6 +41,9 @@ func init() {
 	events.RegisterListener(events.MobDeath{}, m.onMobDeath)
 	events.RegisterListener(events.EquipmentChange{}, m.onEquipmentChange)
 	events.RegisterListener(events.ItemOwnership{}, m.onItemOwnership)
+	events.RegisterListener(events.GainExperience{}, m.onGainExperience)
+	events.RegisterListener(events.LevelUp{}, m.onLevelUp)
+	events.RegisterListener(zombieSummary{}, m.onZombieSummary)
 }
 
 // ZombieConfig holds per-user zombie behavior configuration.
@@ -55,9 +58,11 @@ type ZombieConfig struct {
 
 // zombieStats tracks activity counters for a single zombie session.
 type zombieStats struct {
-	MobKills    map[string]int
-	GoldGained  int
-	ItemsLooted map[string]int
+	MobKills         map[string]int
+	GoldGained       int
+	ItemsLooted      map[string]int
+	ExperienceGained int
+	LevelsGained     int
 }
 
 func newZombieStats() zombieStats {
@@ -72,6 +77,16 @@ type zombieRuntime struct {
 	HomeRoom int
 	Stats    zombieStats
 }
+
+// zombieSummary is a module-local event that carries a completed session's stats
+// to be displayed to the player. Enqueuing it defers rendering until after the
+// current command has finished processing.
+type zombieSummary struct {
+	UserId int
+	Stats  zombieStats
+}
+
+func (z zombieSummary) Type() string { return `ZombieSummary` }
 
 // cmdZombieAI is an EventFlag bit used to tag input events issued by the zombie
 // AI itself, so that onInput can distinguish them from real player input.
@@ -151,8 +166,8 @@ func (m *ZombieModule) onPlayerDrop(e events.Event) events.ListenerReturn {
 	}
 
 	if rt, isActive := m.active[evt.UserId]; isActive {
+		events.AddToQueue(zombieSummary{UserId: evt.UserId, Stats: rt.Stats})
 		if user := users.GetByUserId(evt.UserId); user != nil {
-			m.sendSummary(user, rt.Stats)
 			user.SendText(`Zombie mode deactivated.`)
 		}
 		m.exitZombieMode(evt.UserId)
@@ -217,8 +232,8 @@ func (m *ZombieModule) onInput(e events.Event) events.ListenerReturn {
 
 	rt := m.active[evt.UserId]
 	m.exitZombieMode(evt.UserId)
+	events.AddToQueue(zombieSummary{UserId: evt.UserId, Stats: rt.Stats})
 	if user := users.GetByUserId(evt.UserId); user != nil {
-		m.sendSummary(user, rt.Stats)
 		user.SendText(`You snap out of zombie mode.`)
 	}
 
@@ -288,49 +303,113 @@ func (m *ZombieModule) onItemOwnership(e events.Event) events.ListenerReturn {
 	return events.Continue
 }
 
+// onZombieSummary handles the deferred summary event and sends the report to the player.
+func (m *ZombieModule) onZombieSummary(e events.Event) events.ListenerReturn {
+	evt, ok := e.(zombieSummary)
+	if !ok {
+		return events.Continue
+	}
+
+	if user := users.GetByUserId(evt.UserId); user != nil {
+		m.sendSummary(user, evt.Stats)
+	}
+
+	return events.Continue
+}
+
+// onGainExperience records experience gained by a zombie player.
+func (m *ZombieModule) onGainExperience(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.GainExperience)
+	if !ok {
+		return events.Continue
+	}
+
+	if evt.UserId == 0 {
+		return events.Continue
+	}
+
+	rt, isActive := m.active[evt.UserId]
+	if !isActive {
+		return events.Continue
+	}
+
+	rt.Stats.ExperienceGained += evt.Experience
+	m.active[evt.UserId] = rt
+
+	return events.Continue
+}
+
+// onLevelUp records levels gained by a zombie player.
+func (m *ZombieModule) onLevelUp(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.LevelUp)
+	if !ok {
+		return events.Continue
+	}
+
+	if evt.UserId == 0 {
+		return events.Continue
+	}
+
+	rt, isActive := m.active[evt.UserId]
+	if !isActive {
+		return events.Continue
+	}
+
+	rt.Stats.LevelsGained += evt.LevelsGained
+	m.active[evt.UserId] = rt
+
+	return events.Continue
+}
+
 // sendSummary sends the zombie session summary to the player.
 func (m *ZombieModule) sendSummary(user *users.UserRecord, stats zombieStats) {
-	hasAnything := stats.GoldGained > 0 || len(stats.MobKills) > 0 || len(stats.ItemsLooted) > 0
-	if !hasAnything {
-		return
-	}
+	border := `<ansi fg="black-bold">+--------------------------------------------------+</ansi>`
 
 	lines := []string{
 		``,
-		`<ansi fg="black-bold">.:.</ansi> <ansi fg="magenta">Zombie Mode Summary</ansi>`,
+		border,
+		`<ansi fg="black-bold">|</ansi>           <ansi fg="yellow">*** Zombie Mode Summary ***</ansi>            <ansi fg="black-bold">|</ansi>`,
+		border,
 		``,
 	}
 
-	if len(stats.MobKills) > 0 {
-		lines = append(lines, `  <ansi fg="white">Mobs killed:</ansi>`)
+	lines = append(lines, `  <ansi fg="white">Mobs killed:</ansi>`)
+	if len(stats.MobKills) == 0 {
+		lines = append(lines, `    <ansi fg="black-bold">(none)</ansi>`)
+	} else {
 		names := make([]string, 0, len(stats.MobKills))
 		for name := range stats.MobKills {
 			names = append(names, name)
 		}
 		sort.Strings(names)
 		for _, name := range names {
-			lines = append(lines, fmt.Sprintf(`    <ansi fg="yellow">%s</ansi> x%d`, name, stats.MobKills[name]))
+			lines = append(lines, fmt.Sprintf(`    <ansi fg="mobname">%s</ansi> x%d`, name, stats.MobKills[name]))
 		}
-		lines = append(lines, ``)
 	}
 
-	if stats.GoldGained > 0 {
-		lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Gold collected:</ansi> <ansi fg="yellow">%d</ansi>`, stats.GoldGained))
-		lines = append(lines, ``)
-	}
+	lines = append(lines, ``)
+	lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Gold collected:</ansi>    <ansi fg="gold">%d</ansi>`, stats.GoldGained))
+	lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Experience gained:</ansi> <ansi fg="experience">%d</ansi>`, stats.ExperienceGained))
+	lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Levels gained:</ansi>     <ansi fg="stat">%d</ansi>`, stats.LevelsGained))
 
-	if len(stats.ItemsLooted) > 0 {
-		lines = append(lines, `  <ansi fg="white">Items looted:</ansi>`)
+	lines = append(lines, ``)
+	lines = append(lines, `  <ansi fg="white">Items looted:</ansi>`)
+	if len(stats.ItemsLooted) == 0 {
+		lines = append(lines, `    <ansi fg="black-bold">(none)</ansi>`)
+	} else {
 		names := make([]string, 0, len(stats.ItemsLooted))
 		for name := range stats.ItemsLooted {
 			names = append(names, name)
 		}
 		sort.Strings(names)
 		for _, name := range names {
-			lines = append(lines, fmt.Sprintf(`    <ansi fg="yellow">%s</ansi> x%d`, name, stats.ItemsLooted[name]))
+			lines = append(lines, fmt.Sprintf(`    <ansi fg="itemname">%s</ansi> x%d`, name, stats.ItemsLooted[name]))
 		}
-		lines = append(lines, ``)
 	}
+
+	lines = append(lines, ``)
+	lines = append(lines, border)
+	lines = append(lines, ``)
 
 	user.SendText(strings.Join(lines, "\n"))
 }

--- a/modules/zombiemode/zombiemode.go
+++ b/modules/zombiemode/zombiemode.go
@@ -3,6 +3,8 @@ package zombiemode
 import (
 	"embed"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/mobs"
@@ -36,6 +38,9 @@ func init() {
 	events.RegisterListener(events.PlayerDrop{}, m.onPlayerDrop)
 	events.RegisterListener(events.AggroChanged{}, m.onAggroChanged)
 	events.RegisterListener(events.Input{}, m.onInput, events.First)
+	events.RegisterListener(events.MobDeath{}, m.onMobDeath)
+	events.RegisterListener(events.EquipmentChange{}, m.onEquipmentChange)
+	events.RegisterListener(events.ItemOwnership{}, m.onItemOwnership)
 }
 
 // ZombieConfig holds per-user zombie behavior configuration.
@@ -48,9 +53,24 @@ type ZombieConfig struct {
 	Profiles      map[string]ZombieConfig `yaml:"profiles,omitempty"`
 }
 
+// zombieStats tracks activity counters for a single zombie session.
+type zombieStats struct {
+	MobKills    map[string]int
+	GoldGained  int
+	ItemsLooted map[string]int
+}
+
+func newZombieStats() zombieStats {
+	return zombieStats{
+		MobKills:    make(map[string]int),
+		ItemsLooted: make(map[string]int),
+	}
+}
+
 // zombieRuntime holds transient state that is only valid while zombie mode is active.
 type zombieRuntime struct {
 	HomeRoom int
+	Stats    zombieStats
 }
 
 // cmdZombieAI is an EventFlag bit used to tag input events issued by the zombie
@@ -130,11 +150,12 @@ func (m *ZombieModule) onPlayerDrop(e events.Event) events.ListenerReturn {
 		return events.Continue
 	}
 
-	if _, isActive := m.active[evt.UserId]; isActive {
-		m.exitZombieMode(evt.UserId)
+	if rt, isActive := m.active[evt.UserId]; isActive {
 		if user := users.GetByUserId(evt.UserId); user != nil {
+			m.sendSummary(user, rt.Stats)
 			user.SendText(`Zombie mode deactivated.`)
 		}
+		m.exitZombieMode(evt.UserId)
 	}
 
 	return events.Continue
@@ -194,10 +215,122 @@ func (m *ZombieModule) onInput(e events.Event) events.ListenerReturn {
 		return events.Continue
 	}
 
+	rt := m.active[evt.UserId]
 	m.exitZombieMode(evt.UserId)
 	if user := users.GetByUserId(evt.UserId); user != nil {
+		m.sendSummary(user, rt.Stats)
 		user.SendText(`You snap out of zombie mode.`)
 	}
 
 	return events.Continue
+}
+
+// onMobDeath records a mob kill for any zombie player who contributed damage.
+func (m *ZombieModule) onMobDeath(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.MobDeath)
+	if !ok {
+		return events.Continue
+	}
+
+	for _, userId := range evt.KilledByUsers {
+		rt, isActive := m.active[userId]
+		if !isActive {
+			continue
+		}
+		rt.Stats.MobKills[evt.CharacterName]++
+		m.active[userId] = rt
+	}
+
+	return events.Continue
+}
+
+// onEquipmentChange records gold gained by a zombie player.
+func (m *ZombieModule) onEquipmentChange(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.EquipmentChange)
+	if !ok {
+		return events.Continue
+	}
+
+	if evt.GoldChange <= 0 || evt.UserId == 0 {
+		return events.Continue
+	}
+
+	rt, isActive := m.active[evt.UserId]
+	if !isActive {
+		return events.Continue
+	}
+
+	rt.Stats.GoldGained += evt.GoldChange
+	m.active[evt.UserId] = rt
+
+	return events.Continue
+}
+
+// onItemOwnership records items picked up by a zombie player.
+func (m *ZombieModule) onItemOwnership(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.ItemOwnership)
+	if !ok {
+		return events.Continue
+	}
+
+	if !evt.Gained || evt.UserId == 0 {
+		return events.Continue
+	}
+
+	rt, isActive := m.active[evt.UserId]
+	if !isActive {
+		return events.Continue
+	}
+
+	rt.Stats.ItemsLooted[evt.Item.DisplayName()]++
+	m.active[evt.UserId] = rt
+
+	return events.Continue
+}
+
+// sendSummary sends the zombie session summary to the player.
+func (m *ZombieModule) sendSummary(user *users.UserRecord, stats zombieStats) {
+	hasAnything := stats.GoldGained > 0 || len(stats.MobKills) > 0 || len(stats.ItemsLooted) > 0
+	if !hasAnything {
+		return
+	}
+
+	lines := []string{
+		``,
+		`<ansi fg="black-bold">.:.</ansi> <ansi fg="magenta">Zombie Mode Summary</ansi>`,
+		``,
+	}
+
+	if len(stats.MobKills) > 0 {
+		lines = append(lines, `  <ansi fg="white">Mobs killed:</ansi>`)
+		names := make([]string, 0, len(stats.MobKills))
+		for name := range stats.MobKills {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			lines = append(lines, fmt.Sprintf(`    <ansi fg="yellow">%s</ansi> x%d`, name, stats.MobKills[name]))
+		}
+		lines = append(lines, ``)
+	}
+
+	if stats.GoldGained > 0 {
+		lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Gold collected:</ansi> <ansi fg="yellow">%d</ansi>`, stats.GoldGained))
+		lines = append(lines, ``)
+	}
+
+	if len(stats.ItemsLooted) > 0 {
+		lines = append(lines, `  <ansi fg="white">Items looted:</ansi>`)
+		names := make([]string, 0, len(stats.ItemsLooted))
+		for name := range stats.ItemsLooted {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			lines = append(lines, fmt.Sprintf(`    <ansi fg="yellow">%s</ansi> x%d`, name, stats.ItemsLooted[name]))
+		}
+		lines = append(lines, ``)
+	}
+
+	user.SendText(strings.Join(lines, "\n"))
 }


### PR DESCRIPTION
# Description

This fixes some UX issues with the 3D map and improves the zombie mode experience a bit.

## Changes

- Tracking gains during zombie mode (if any) (levels, experience, mobs killed, loot gained, gold gained)
- Added a "depth" selector to the 3D map
- Removing rendering other depths that you aren't currently viewing, unless the room is connected.
- Fixed missing handling of `!!(Game)` webclient request
- Fixed zoom effect in maps when using mouse wheel
- Color changes on 3d map.
- 3d map draw order fixes
- various optimizations
- zombie mode summary shows AFTER the command you entered that ended it instead of before.
- Fixes to gambling game feedback
- slots track biggest winner
- Fixed jackpot not quite updating right in slots.