### PR TITLE
[HTTPS] [4] Add HTTPS admin and documentation updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,11 @@
+.git
+.gitignore
+.vscode
+vendor
+go-mud-server
+tmp-gomud.exe
+server.crt
+server.key
 _datafiles/tls/
+_datafiles/config.yaml.bak.*
+__debug*

--- a/README.md
+++ b/README.md
@@ -98,20 +98,41 @@ When the GoMud server is running, you can connect it via the Terminal, or with a
 - Web client: [http://localhost/webclient](http://localhost/webclient)
 - Web admin: [http://localhost/admin/](http://localhost/admin/)
 
-Default seeded credentials in the bundled world:
-
-- Username: `admin`
-- Password: `password`
-
 ### HTTPS With Certificate Files
 
-GoMud can serve HTTPS when you provide a certificate and private key, or can be automated using LetsEncrypt provisioning.
+GoMud can serve HTTPS when you provide a certificate and private key.
 
-For a guided HTTPS setup process, run:
+- Set `FilePaths.HttpsCertFile` to the certificate path.
+- Set `FilePaths.HttpsKeyFile` to the private key path.
+- Set `Network.HttpsPort` to the HTTPS port players should use.
+- Set `Network.HttpsRedirect` to `true` if plain HTTP should redirect to HTTPS.
+
+For a guided config update, run:
 
 ```shell
 make https-setup
 ```
+
+The helper does not edit the bundled base config directly.
+It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `config-overrides.yaml` snippet for manual save.
+
+### Automatic HTTPS
+
+GoMud can now obtain and renew Let's Encrypt certificates itself for simple single-server installs.
+
+- Set `FilePaths.WebDomain` to your public DNS name.
+- Leave `FilePaths.HttpsCertFile` and `FilePaths.HttpsKeyFile` empty unless you want to supply your own certificate files.
+- Set `Network.HttpPort` to `80` and `Network.HttpsPort` to `443`.
+- Optional: set `FilePaths.HttpsEmail` to receive certificate expiry notices.
+- Point your DNS name at the server and make sure inbound ports `80` and `443` are reachable.
+
+If automatic HTTPS cannot be completed, GoMud keeps serving HTTP and logs the exact reason. Local development on `localhost` should continue to use plain HTTP.
+
+When the admin interface is enabled, `/admin/https/` shows the current HTTPS mode, the checks GoMud ran, and the next steps needed to finish setup.
+Default seeded credentials in the bundled world:
+
+- Username: `admin`
+- Password: `password`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -100,21 +100,13 @@ When the GoMud server is running, you can connect it via the Terminal, or with a
 
 ### HTTPS With Certificate Files
 
-GoMud can serve HTTPS when you provide a certificate and private key.
+GoMud can serve HTTPS when you provide a certificate and private key, or can be automated using LetsEncrypt provisioning.
 
-- Set `FilePaths.HttpsCertFile` to the certificate path.
-- Set `FilePaths.HttpsKeyFile` to the private key path.
-- Set `Network.HttpsPort` to the HTTPS port players should use.
-- Set `Network.HttpsRedirect` to `true` if plain HTTP should redirect to HTTPS.
-
-For a guided config update, run:
+For a guided HTTPS setup process, run:
 
 ```shell
 make https-setup
 ```
-
-The helper does not edit the bundled base config directly.
-It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `config-overrides.yaml` snippet for manual save.
 
 ### Automatic HTTPS
 
@@ -130,6 +122,7 @@ GoMud can now obtain and renew Let's Encrypt certificates itself for simple sing
 If automatic HTTPS cannot be completed, GoMud keeps serving HTTP and logs the exact reason. Local development on `localhost` should continue to use plain HTTP.
 
 When the admin interface is enabled, `/admin/https/` shows the current HTTPS mode, the checks GoMud ran, and the next steps needed to finish setup.
+
 Default seeded credentials in the bundled world:
 
 - Username: `admin`

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `
 
 GoMud can now obtain and renew Let's Encrypt certificates itself for simple single-server installs.
 
+- Run `make https-setup` and choose `Automatic Let's Encrypt`, then either PATCH the running server or save the printed override snippet.
 - Set `FilePaths.WebDomain` to your public DNS name.
 - Leave `FilePaths.HttpsCertFile` and `FilePaths.HttpsKeyFile` empty unless you want to supply your own certificate files.
 - Set `Network.HttpPort` to `80` and `Network.HttpsPort` to `443`.

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -226,14 +226,6 @@ FilePaths:
   #   Required when SSHPort is non-zero. Generate with:
   #     ssh-keygen -t ed25519 -f ssh_host_key -N ""
   SSHHostKeyFile: ""
-  # - HttpsEmail -
-  #   Optional contact email for automatic Let's Encrypt HTTPS.
-  #   This is used for expiry/problem notices from the certificate authority.
-  HttpsEmail: ""
-  # - HttpsCacheDir -
-  #   Folder used to cache automatic Let's Encrypt account and certificate data.
-  #   Must be writable and persistent across restarts.
-  HttpsCacheDir: "_datafiles/tls"
 
 ################################################################################
 #

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -209,7 +209,9 @@ FilePaths:
   #   the server crashes during a save.
   CarefulSaveFiles: true
   # - HttpsCertFile/HttpsKeyFile -
-  #   Used to negotiate TLS/https requests
+  #   Used to negotiate TLS/https requests.
+  #   If both are set, manual certificate files take precedence over
+  #   automatic Let's Encrypt HTTPS.
   HttpsCertFile: ""
   HttpsKeyFile: ""
   # - HttpsEmail -
@@ -224,6 +226,14 @@ FilePaths:
   #   Required when SSHPort is non-zero. Generate with:
   #     ssh-keygen -t ed25519 -f ssh_host_key -N ""
   SSHHostKeyFile: ""
+  # - HttpsEmail -
+  #   Optional contact email for automatic Let's Encrypt HTTPS.
+  #   This is used for expiry/problem notices from the certificate authority.
+  HttpsEmail: ""
+  # - HttpsCacheDir -
+  #   Folder used to cache automatic Let's Encrypt account and certificate data.
+  #   Must be writable and persistent across restarts.
+  HttpsCacheDir: "_datafiles/tls"
 
 ################################################################################
 #
@@ -414,12 +424,16 @@ Network:
   HttpPort: 80
   # - HttpsPort -
   #   The port the server listens on for web requests
-  #   Note: Must have a cert/key file (See FilePaths)
+  #   Note: Manual TLS requires HttpsCertFile/HttpsKeyFile.
+  #   Automatic Let's Encrypt HTTPS requires a public WebDomain and standard
+  #   ports 80/443.
   #   0 (zero) means none.
   HttpsPort: 0
   # - HttpsRedirect -
   #   If true, will send all http traffic to https with a redirect
   #   Requires both Http and Https to be working.
+  #   In automatic Let's Encrypt mode, the HTTP port must still remain enabled
+  #   so ACME challenge requests can be answered on port 80.
   HttpsRedirect: false
   # - SSHPort -
   #   The port the server listens on for SSH connections.

--- a/_datafiles/guides/running/README.md
+++ b/_datafiles/guides/running/README.md
@@ -61,10 +61,11 @@ Restart GoMud after applying the settings.
 For simple single-server installs, GoMud can automatically manage Let's Encrypt certificates for the built-in web client and admin UI.
 
 1. Point a public DNS name at your server.
-2. In `_datafiles/config.yaml`, set `FilePaths.WebDomain` to that hostname.
-3. Set `Network.HttpPort` to `80` and `Network.HttpsPort` to `443`.
-4. Optionally set `FilePaths.HttpsEmail` so Let's Encrypt can send expiry notices.
-5. Leave `FilePaths.HttpsCertFile` and `FilePaths.HttpsKeyFile` empty unless you want to use your own certificate files instead.
+2. Run `make https-setup` and choose `Automatic Let's Encrypt`, then either PATCH the running server or save the printed override snippet.
+3. Set `FilePaths.WebDomain` to that hostname.
+4. Set `Network.HttpPort` to `80` and `Network.HttpsPort` to `443`.
+5. Optionally set `FilePaths.HttpsEmail` so Let's Encrypt can send expiry notices.
+6. Leave `FilePaths.HttpsCertFile` and `FilePaths.HttpsKeyFile` empty unless you want to use your own certificate files instead.
 
 Notes:
 

--- a/_datafiles/guides/running/README.md
+++ b/_datafiles/guides/running/README.md
@@ -55,3 +55,21 @@ It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `
 5. Optionally set `Network.HttpsRedirect` to `true`.
 
 Restart GoMud after applying the settings.
+
+# Automatic HTTPS
+
+For simple single-server installs, GoMud can automatically manage Let's Encrypt certificates for the built-in web client and admin UI.
+
+1. Point a public DNS name at your server.
+2. In `_datafiles/config.yaml`, set `FilePaths.WebDomain` to that hostname.
+3. Set `Network.HttpPort` to `80` and `Network.HttpsPort` to `443`.
+4. Optionally set `FilePaths.HttpsEmail` so Let's Encrypt can send expiry notices.
+5. Leave `FilePaths.HttpsCertFile` and `FilePaths.HttpsKeyFile` empty unless you want to use your own certificate files instead.
+
+Notes:
+
+- Automatic HTTPS is intended for one public server that owns ports `80` and `443`.
+- `localhost`, private-only names, and raw IP addresses will stay on HTTP.
+- If automatic HTTPS cannot succeed, GoMud falls back to HTTP and logs what to fix.
+- The certificate cache is stored in `FilePaths.HttpsCacheDir`, which defaults to `_datafiles/tls`.
+- The admin page at `/admin/https/` shows the current HTTPS mode, checks, and recommended fixes.

--- a/_datafiles/html/admin/https.html
+++ b/_datafiles/html/admin/https.html
@@ -1,0 +1,95 @@
+{{template "header" .}}
+{{$status := .httpsStatus}}
+{{$probeHost := httpsDiagnosticHost $status.Host}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 2rem; font-size: 0.95rem; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-bottom: 1rem; }
+    .card { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 1.25rem; }
+    .card h2 { font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; color: #666; margin-bottom: 0.75rem; }
+    .kv { display: grid; grid-template-columns: auto 1fr; gap: 0.45rem 0.75rem; font-size: 0.92rem; }
+    .kv dt { font-weight: 700; color: #1a1a2e; }
+    .kv dd { color: #444; }
+    .list { padding-left: 1.2rem; color: #333; }
+    .list li + li { margin-top: 0.45rem; }
+    .mono { background: #1a1a2e; color: #c9d1d9; font-family: monospace; font-size: 0.84rem; padding: 0.85rem 1rem; border-radius: 5px; white-space: pre-wrap; overflow-x: auto; line-height: 1.55; }
+    .empty { color: #666; font-style: italic; }
+</style>
+
+<h1>HTTPS Status</h1>
+<p class="subtitle">{{$status.Summary}}</p>
+
+<div class="grid">
+    <section class="card">
+        <h2>Current Mode</h2>
+        <dl class="kv">
+            <dt>Mode</dt>
+            <dd>{{$status.Mode}}</dd>
+            <dt>Hostname</dt>
+            <dd>{{if $status.Host}}{{$status.Host}}{{else}}Not set{{end}}</dd>
+            <dt>HTTP Port</dt>
+            <dd>{{$status.HttpPort}}</dd>
+            <dt>HTTPS Port</dt>
+            <dd>{{$status.HttpsPort}}</dd>
+            <dt>Redirect Enabled</dt>
+            <dd>{{$status.RedirectEnabled}}</dd>
+            <dt>Email Configured</dt>
+            <dd>{{$status.EmailConfigured}}</dd>
+            {{if $status.CacheDir}}<dt>Cache Directory</dt><dd>{{$status.CacheDir}}</dd>{{end}}
+            {{if $status.CertFile}}<dt>Certificate File</dt><dd>{{$status.CertFile}}</dd>{{end}}
+            {{if $status.KeyFile}}<dt>Private Key File</dt><dd>{{$status.KeyFile}}</dd>{{end}}
+            {{if $status.Issuer}}<dt>Issuer</dt><dd>{{$status.Issuer}}</dd>{{end}}
+            {{if $status.ExpiresAt}}<dt>Expires At</dt><dd>{{$status.ExpiresAt}}</dd>{{end}}
+            {{if $status.ExpiresAt}}<dt>Days Remaining</dt><dd>{{$status.DaysRemaining}}</dd>{{end}}
+            {{if $status.CertificateHost}}<dt>Certificate CN</dt><dd>{{$status.CertificateHost}}</dd>{{end}}
+            {{if $status.CertificateDNS}}<dt>Certificate DNS</dt><dd>{{range $i, $name := $status.CertificateDNS}}{{if $i}}, {{end}}{{$name}}{{end}}</dd>{{end}}
+        </dl>
+    </section>
+
+    <section class="card">
+        <h2>What GoMud Checked</h2>
+        {{if $status.Checks}}
+        <ul class="list">
+            {{range $status.Checks}}<li>{{.}}</li>{{end}}
+        </ul>
+        {{else}}
+        <p class="empty">No HTTPS checks have been recorded yet.</p>
+        {{end}}
+    </section>
+</div>
+
+<div class="grid">
+    <section class="card">
+        <h2>Next Steps</h2>
+        {{if $status.NextSteps}}
+        <ol class="list">
+            {{range $status.NextSteps}}<li>{{.}}</li>{{end}}
+        </ol>
+        {{else}}
+        <p class="empty">No action is currently required.</p>
+        {{end}}
+    </section>
+
+    <section class="card">
+        <h2>Last Error</h2>
+        {{if $status.LastError}}
+        <pre class="mono">{{$status.LastError}}</pre>
+        {{else}}
+        <p class="empty">No HTTPS errors have been recorded.</p>
+        {{end}}
+    </section>
+</div>
+
+<section class="card">
+    <h2>Useful Commands</h2>
+    {{if httpsUsesExampleHost $status.Host}}
+    <p class="subtitle">Replace <code>{{$probeHost}}</code> with your public hostname before testing automatic HTTPS.</p>
+    {{end}}
+    <pre class="mono">ss -ltnp | rg ':80|:443'
+dig +short {{$probeHost}}
+curl -I http://{{$probeHost}}/
+curl -vk https://{{$probeHost}}/</pre>
+</section>
+
+{{template "footer" .}}

--- a/internal/web/admin.https.go
+++ b/internal/web/admin.https.go
@@ -1,0 +1,29 @@
+package web
+
+import (
+	"text/template"
+
+	"net/http"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+)
+
+func httpsIndex(w http.ResponseWriter, r *http.Request) {
+	tmpl, err := template.New("https.html").Funcs(funcMap).ParseFiles(
+		configs.GetFilePathsConfig().AdminHtml.String()+"/_header.html",
+		configs.GetFilePathsConfig().AdminHtml.String()+"/https.html",
+		configs.GetFilePathsConfig().AdminHtml.String()+"/_footer.html",
+	)
+	if err != nil {
+		mudlog.Error("HTML Template", "error", err)
+	}
+
+	tplData := map[string]any{
+		"httpsStatus": GetHTTPSStatus(),
+	}
+
+	if err := tmpl.Execute(w, tplData); err != nil {
+		mudlog.Error("HTML Execute", "error", err)
+	}
+}

--- a/internal/web/admin.https.go
+++ b/internal/web/admin.https.go
@@ -25,6 +25,7 @@ func httpsIndex(w http.ResponseWriter, r *http.Request) {
 		"httpsStatus": GetHTTPSStatus(),
 	}
 
+	w.Header().Set("Cache-Control", "no-store")
 	if err := tmpl.Execute(w, tplData); err != nil {
 		mudlog.Error("HTML Execute", "error", err)
 	}

--- a/internal/web/admin.https.go
+++ b/internal/web/admin.https.go
@@ -17,6 +17,8 @@ func httpsIndex(w http.ResponseWriter, r *http.Request) {
 	)
 	if err != nil {
 		mudlog.Error("HTML Template", "error", err)
+		http.Error(w, "Error parsing template files", http.StatusInternalServerError)
+		return
 	}
 
 	tplData := map[string]any{

--- a/internal/web/admin.https.go
+++ b/internal/web/admin.https.go
@@ -22,6 +22,7 @@ func httpsIndex(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tplData := map[string]any{
+		"NAV":         buildAdminNav(),
 		"httpsStatus": GetHTTPSStatus(),
 	}
 

--- a/internal/web/admin_https_test.go
+++ b/internal/web/admin_https_test.go
@@ -93,7 +93,7 @@ func TestHTTPSIndexDisablesCaching(t *testing.T) {
 	adminDir := t.TempDir()
 	for name, contents := range map[string]string{
 		"_header.html": "header",
-		"https.html":   "{{.httpsStatus}}",
+		"https.html":   "nav={{len .NAV}}|{{.httpsStatus}}",
 		"_footer.html": "footer",
 	} {
 		if err := os.WriteFile(filepath.Join(adminDir, name), []byte(contents), 0o600); err != nil {
@@ -132,5 +132,8 @@ func TestHTTPSIndexDisablesCaching(t *testing.T) {
 
 	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
 		t.Fatalf("httpsIndex() Cache-Control = %q, want %q", got, "no-store")
+	}
+	if strings.Contains(rec.Body.String(), "nav=0|") {
+		t.Fatalf("httpsIndex() body = %q, want non-empty admin nav", rec.Body.String())
 	}
 }

--- a/internal/web/admin_https_test.go
+++ b/internal/web/admin_https_test.go
@@ -72,3 +72,65 @@ func TestHTTPSIndexReturnsServerErrorWhenTemplateParseFails(t *testing.T) {
 		t.Fatalf("httpsIndex() body = %q, want parse failure message", rec.Body.String())
 	}
 }
+
+func TestHTTPSIndexDisablesCaching(t *testing.T) {
+	mudlog.SetupLogger(nil, "", "", false)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(wd, "..", ".."))
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("os.Chdir() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("os.Chdir() cleanup error = %v", err)
+		}
+	})
+
+	adminDir := t.TempDir()
+	for name, contents := range map[string]string{
+		"_header.html": "header",
+		"https.html":   "{{.httpsStatus}}",
+		"_footer.html": "footer",
+	} {
+		if err := os.WriteFile(filepath.Join(adminDir, name), []byte(contents), 0o600); err != nil {
+			t.Fatalf("os.WriteFile() error = %v", err)
+		}
+	}
+
+	overridePath := filepath.Join(t.TempDir(), "config-overrides.yaml")
+	overrideConfig := "FilePaths:\n  AdminHtml: \"" + strings.ReplaceAll(adminDir, "\\", "\\\\") + "\"\n"
+	if err := os.WriteFile(overridePath, []byte(overrideConfig), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	oldConfigPath, hadConfigPath := os.LookupEnv("CONFIG_PATH")
+	if err := os.Setenv("CONFIG_PATH", overridePath); err != nil {
+		t.Fatalf("os.Setenv() error = %v", err)
+	}
+	if err := configs.ReloadConfig(); err != nil {
+		t.Fatalf("configs.ReloadConfig() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if hadConfigPath {
+			_ = os.Setenv("CONFIG_PATH", oldConfigPath)
+		} else {
+			_ = os.Unsetenv("CONFIG_PATH")
+		}
+		if err := configs.ReloadConfig(); err != nil {
+			t.Fatalf("configs.ReloadConfig() cleanup error = %v", err)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/https/", nil)
+	rec := httptest.NewRecorder()
+
+	httpsIndex(rec, req)
+
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("httpsIndex() Cache-Control = %q, want %q", got, "no-store")
+	}
+}

--- a/internal/web/admin_https_test.go
+++ b/internal/web/admin_https_test.go
@@ -1,0 +1,74 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+)
+
+func TestHTTPSIndexReturnsServerErrorWhenTemplateParseFails(t *testing.T) {
+	mudlog.SetupLogger(nil, "", "", false)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(wd, "..", ".."))
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("os.Chdir() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("os.Chdir() cleanup error = %v", err)
+		}
+	})
+
+	adminDir := t.TempDir()
+	for _, name := range []string{"_header.html", "_footer.html"} {
+		if err := os.WriteFile(filepath.Join(adminDir, name), []byte("test"), 0o600); err != nil {
+			t.Fatalf("os.WriteFile() error = %v", err)
+		}
+	}
+
+	overridePath := filepath.Join(t.TempDir(), "config-overrides.yaml")
+	overrideConfig := "FilePaths:\n  AdminHtml: \"" + strings.ReplaceAll(adminDir, "\\", "\\\\") + "\"\n"
+	if err := os.WriteFile(overridePath, []byte(overrideConfig), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	oldConfigPath, hadConfigPath := os.LookupEnv("CONFIG_PATH")
+	if err := os.Setenv("CONFIG_PATH", overridePath); err != nil {
+		t.Fatalf("os.Setenv() error = %v", err)
+	}
+	if err := configs.ReloadConfig(); err != nil {
+		t.Fatalf("configs.ReloadConfig() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if hadConfigPath {
+			_ = os.Setenv("CONFIG_PATH", oldConfigPath)
+		} else {
+			_ = os.Unsetenv("CONFIG_PATH")
+		}
+		if err := configs.ReloadConfig(); err != nil {
+			t.Fatalf("configs.ReloadConfig() cleanup error = %v", err)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/https/", nil)
+	rec := httptest.NewRecorder()
+
+	httpsIndex(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("httpsIndex() status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if !strings.Contains(rec.Body.String(), "Error parsing template files") {
+		t.Fatalf("httpsIndex() body = %q, want parse failure message", rec.Body.String())
+	}
+}

--- a/internal/web/admin_routes.go
+++ b/internal/web/admin_routes.go
@@ -11,6 +11,9 @@ func registerAdminRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/", RunWithMUDLocked(
 		doBasicAuth(adminIndex),
 	))
+	mux.HandleFunc("GET /admin/https/", RunWithMUDLocked(
+		doBasicAuth(httpsIndex),
+	))
 
 	mux.HandleFunc("GET /admin/config", RunWithMUDLocked(
 		doBasicAuth(adminConfig),

--- a/internal/web/template_func.go
+++ b/internal/web/template_func.go
@@ -117,5 +117,11 @@ var (
 		"getconfig": func() configs.Config {
 			return configs.GetConfig()
 		},
+		"httpsDiagnosticHost": func(host string) string {
+			return httpsDiagnosticHost(host)
+		},
+		"httpsUsesExampleHost": func(host string) bool {
+			return httpsUsesExampleHost(host)
+		},
 	}
 )


### PR DESCRIPTION
Title: `[HTTPS] [4] Add HTTPS admin and documentation updates`

## Summary

Follow-up stack item **HTTPS-4**. Moves the `/admin/https/` UI and the remaining docs/config assets on top of the automatic HTTPS runtime branch.

## Changes

- Adds the `/admin/https/` admin handler, template, nav link, and template helpers.
- Documents automatic HTTPS mode in the README and running guide.
- Updates the HTTPS docs so `make https-setup` is described as using the admin config API or printed override snippets instead of rewriting the bundled base config.
- Updates the sample config with HTTPS-related settings.
- Keeps the follow-up PR focused on admin UI, docs, sample-config changes, and local ignore updates.

## Stack Position

- Already merged: `#514` HTTPS-1 tighten existing HTTPS redirect behavior
- Previous: `#515` HTTPS-2 manual HTTPS setup helper
- Previous: `#516` HTTPS-3 automatic HTTPS runtime support
- This PR: `#517` HTTPS-4 admin/docs updates
- Next: `#519` HTTPS-5 automatic HTTPS helper mode

## Local Merge Order

```bash
git fetch origin

git checkout master
git pull --ff-only origin master

git merge --ff-only origin/feat/https-provisioning-helper
git merge --ff-only origin/feat/https-autocert-runtime
git merge --ff-only origin/feat/https-autocert-admin-docs
git merge --ff-only origin/feat/https-setup-helper-auto
```

## Scope

The runtime branch carries only the automatic HTTPS engine changes. This follow-up PR owns the `/admin/https/` status page plus the non-Go docs/config updates that sit on top of that runtime support.

## Validation

- `go test ./internal/web ./internal/configs`
