### PR TITLE
[HTTPS] [5] Add automatic HTTPS mode to https-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,13 @@ make https-setup
 
 The helper does not edit the bundled base config directly.
 It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `config-overrides.yaml` snippet for manual save, and it offers manual certificate, automatic Let's Encrypt, or HTTP-only modes.
+Either path still requires a GoMud restart before listener changes take effect.
 ### Automatic HTTPS
 
 GoMud can now obtain and renew Let's Encrypt certificates itself for simple single-server installs.
 
 - Run `make https-setup` and choose `Automatic Let's Encrypt`, then either PATCH the running server or save the printed override snippet.
+- Restart GoMud after applying the settings so the updated HTTP/HTTPS listeners are created.
 - Set `FilePaths.WebDomain` to your public DNS name.
 - Leave `FilePaths.HttpsCertFile` and `FilePaths.HttpsKeyFile` empty unless you want to supply your own certificate files.
 - Set `Network.HttpPort` to `80` and `Network.HttpsPort` to `443`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Playable online demo: **http://www.gomud.net**
   - [Requirements](#requirements)
   - [Usage](#usage)
 - [Connecting](#connecting)
+- [Configuration](#configuration)
+  - [Configuration Files](#configuration-files)
+  - [Enable Server HTTPS Support](#enable-server-https-support)
 - [User Support](#user-support)
 - [Development Notes](#development-notes)
   - [Contributor Guide](#contributor-guide)
@@ -98,7 +101,32 @@ When the GoMud server is running, you can connect it via the Terminal, or with a
 - Web client: [http://localhost/webclient](http://localhost/webclient)
 - Web admin: [http://localhost/admin/](http://localhost/admin/)
 
-### HTTPS With Certificate Files
+Default seeded credentials in the bundled world:
+
+- Username: `admin`
+- Password: `password`
+
+## Configuration
+
+### Configuration Files
+
+GoMud loads configuration in layers so you can keep your own world-specific changes separate from the bundled defaults:
+
+```text
+_datafiles/config.yaml
+  -> FilePaths.DataFiles (defaults to _datafiles/world/default)
+      -> {DataFiles}/config-overrides.yaml
+          -> environment variables such as CONFIG_PATH, LOG_PATH, LOG_LEVEL, LOG_NOCOLOR
+```
+
+- `_datafiles/config.yaml` is the bundled base config that ships with the repo, and shouldn't be edited or changed.
+- `FilePaths.DataFiles` points at the active world data directory. By default that is `_datafiles/world/default`.
+- `{DataFiles}/config-overrides.yaml` is the normal place to save local overrides for a world.
+- `CONFIG_PATH=/path/to/config.yaml` can point GoMud at a different override file when you want to keep it outside the repo or maintain separate deploy-specific settings.
+
+For upgrades, treat `_datafiles/config.yaml` as a reference file, not your day-to-day edit target. Keep your custom changes in `config-overrides.yaml` or a separate file selected with `CONFIG_PATH` so pulling new code does not overwrite your local settings.
+
+### Enable Server HTTPS Support
 
 GoMud can serve HTTPS when you provide a certificate and private key, or can be automated using LetsEncrypt provisioning.
 
@@ -108,29 +136,7 @@ For a guided HTTPS setup process, run:
 make https-setup
 ```
 
-The helper does not edit the bundled base config directly.
-It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `config-overrides.yaml` snippet for manual save, and it offers manual certificate, automatic Let's Encrypt, or HTTP-only modes.
-Either path still requires a GoMud restart before listener changes take effect.
-### Automatic HTTPS
-
-GoMud can now obtain and renew Let's Encrypt certificates itself for simple single-server installs.
-
-- Run `make https-setup` and choose `Automatic Let's Encrypt`, then either PATCH the running server or save the printed override snippet.
-- Restart GoMud after applying the settings so the updated HTTP/HTTPS listeners are created.
-- Set `FilePaths.WebDomain` to your public DNS name.
-- Leave `FilePaths.HttpsCertFile` and `FilePaths.HttpsKeyFile` empty unless you want to supply your own certificate files.
-- Set `Network.HttpPort` to `80` and `Network.HttpsPort` to `443`.
-- Optional: set `FilePaths.HttpsEmail` to receive certificate expiry notices.
-- Point your DNS name at the server and make sure inbound ports `80` and `443` are reachable.
-
-If automatic HTTPS cannot be completed, GoMud keeps serving HTTP and logs the exact reason. Local development on `localhost` should continue to use plain HTTP.
-
 When the admin interface is enabled, `/admin/https/` shows the current HTTPS mode, the checks GoMud ran, and the next steps needed to finish setup.
-
-Default seeded credentials in the bundled world:
-
-- Username: `admin`
-- Password: `password`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ For a guided HTTPS setup process, run:
 make https-setup
 ```
 
+The helper does not edit the bundled base config directly.
+It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `config-overrides.yaml` snippet for manual save, and it offers manual certificate, automatic Let's Encrypt, or HTTP-only modes.
 ### Automatic HTTPS
 
 GoMud can now obtain and renew Let's Encrypt certificates itself for simple single-server installs.

--- a/_datafiles/guides/running/README.md
+++ b/_datafiles/guides/running/README.md
@@ -47,6 +47,7 @@ For a guided config update, run:
 
 The helper does not edit the bundled base config directly.
 It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `config-overrides.yaml` snippet for manual save.
+It can configure manual certificate files, automatic Let's Encrypt, or HTTP-only mode.
 
 1. Get a certificate and private key for the hostname players will use.
 2. Set `FilePaths.HttpsCertFile` to the certificate path.

--- a/_datafiles/guides/running/README.md
+++ b/_datafiles/guides/running/README.md
@@ -48,6 +48,7 @@ For a guided config update, run:
 The helper does not edit the bundled base config directly.
 It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `config-overrides.yaml` snippet for manual save.
 It can configure manual certificate files, automatic Let's Encrypt, or HTTP-only mode.
+Either path still requires a GoMud restart before listener changes take effect.
 
 1. Get a certificate and private key for the hostname players will use.
 2. Set `FilePaths.HttpsCertFile` to the certificate path.

--- a/_datafiles/guides/running/README.md
+++ b/_datafiles/guides/running/README.md
@@ -47,7 +47,7 @@ For a guided config update, run:
 
 The helper does not edit the bundled base config directly.
 It can PATCH a running GoMud server through `/admin/api/v1/config`, or print a `config-overrides.yaml` snippet for manual save.
-It can configure manual certificate files, automatic Let's Encrypt, or HTTP-only mode.
+It can configure manual certificate files, automatic Let's Encrypt, or disable HTTPS and return to HTTP-only mode.
 Either path still requires a GoMud restart before listener changes take effect.
 
 1. Get a certificate and private key for the hostname players will use.
@@ -68,6 +68,8 @@ For simple single-server installs, GoMud can automatically manage Let's Encrypt 
 4. Set `Network.HttpPort` to `80` and `Network.HttpsPort` to `443`.
 5. Optionally set `FilePaths.HttpsEmail` so Let's Encrypt can send expiry notices.
 6. Leave `FilePaths.HttpsCertFile` and `FilePaths.HttpsKeyFile` empty unless you want to use your own certificate files instead.
+
+If HTTPS is not working and you need to roll back quickly, run `make https-setup`, choose `Disable HTTPS and use HTTP only`, apply the change, and restart GoMud so it rebinds the listeners.
 
 Notes:
 

--- a/scripts/https-setup.sh
+++ b/scripts/https-setup.sh
@@ -24,6 +24,18 @@ read_yaml_value_from_file() {
 	' "$1"
 }
 
+yaml_key_exists_in_file() {
+	awk -F': ' -v key="$2" '
+		$1 ~ "^[[:space:]]*" key "$" {
+			found = 1
+			exit
+		}
+		END {
+			exit(found ? 0 : 1)
+		}
+	' "$1"
+}
+
 canonicalize_path() {
 	path=$1
 	path_dir=$(dirname "$path")
@@ -98,8 +110,8 @@ fi
 
 read_effective_yaml_value() {
 	if [ -f "$override_file" ]; then
-		override_value=$(read_yaml_value_from_file "$override_file" "$1")
-		if [ -n "$override_value" ]; then
+		if yaml_key_exists_in_file "$override_file" "$1"; then
+			override_value=$(read_yaml_value_from_file "$override_file" "$1")
 			printf '%s' "$override_value"
 			return 0
 		fi
@@ -360,12 +372,14 @@ case "$apply_selection" in
 	IFS= read -r admin_password
 
 	printf '\nPATCH %s/admin/api/v1/config\n' "$admin_base_url"
-	if ! "$CURL_BIN" --fail --silent --show-error \
+	curl_status=0
+	curl_http_code=$("$CURL_BIN" --silent --show-error --output /dev/null --write-out '%{http_code}' \
 		-u "$admin_username:$admin_password" \
 		-H 'Content-Type: application/json' \
 		-X PATCH \
 		--data "{$config_updates}" \
-		"$admin_base_url/admin/api/v1/config"; then
+		"$admin_base_url/admin/api/v1/config") || curl_status=$?
+	if [ "$curl_status" -ne 0 ]; then
 		printf '\nFailed to apply settings through the admin API.\n' >&2
 		printf 'GoMud is not reachable at %s.\n' "$admin_base_url" >&2
 		printf 'If the server is already running, enter its current admin URL and try again.\n' >&2
@@ -374,6 +388,26 @@ case "$apply_selection" in
 		printf '%s\n' "$override_snippet" >&2
 		exit 1
 	fi
+	case "$curl_http_code" in
+	2??)
+		;;
+	401 | 403)
+		printf '\nFailed to apply settings through the admin API.\n' >&2
+		printf 'GoMud responded with HTTP %s.\n' "$curl_http_code" >&2
+		printf 'Check that the admin username and password are correct and that the account has admin access.\n\n' >&2
+		printf 'Fallback: save the following override snippet to %s and restart GoMud:\n\n' "$override_file" >&2
+		printf '%s\n' "$override_snippet" >&2
+		exit 1
+		;;
+	*)
+		printf '\nFailed to apply settings through the admin API.\n' >&2
+		printf 'GoMud responded with HTTP %s.\n' "$curl_http_code" >&2
+		printf 'Check the server logs or save the override snippet below and restart GoMud manually.\n\n' >&2
+		printf 'Fallback: save the following override snippet to %s and restart GoMud:\n\n' "$override_file" >&2
+		printf '%s\n' "$override_snippet" >&2
+		exit 1
+		;;
+	esac
 
 	printf '\nHTTPS setup applied through the admin API.\n'
 	printf 'Next steps:\n'

--- a/scripts/https-setup.sh
+++ b/scripts/https-setup.sh
@@ -11,22 +11,13 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 read_yaml_value() {
-	read_yaml_value_from_file "$CONFIG_FILE" "$1"
-}
-
-read_yaml_value_from_file() {
-	file_path=$1
-	key=$2
-	if [ ! -f "$file_path" ]; then
-		return 0
-	fi
-	awk -F': ' -v key="$key" '
+	awk -F': ' -v key="$1" '
 		$1 ~ "^[[:space:]]*" key "$" {
-			gsub(/^["'\'']|["'\'']$/, "", $2)
+			gsub(/^"|"$/, "", $2)
 			print $2
 			exit
 		}
-	' "$file_path"
+	' "$CONFIG_FILE"
 }
 
 canonicalize_path() {
@@ -44,10 +35,6 @@ json_escape() {
 	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
 
-yaml_single_quote() {
-	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/''/g")"
-}
-
 base_url_without_trailing_slash() {
 	url=$1
 	while [ "${url%/}" != "$url" ]; do
@@ -56,7 +43,53 @@ base_url_without_trailing_slash() {
 	printf '%s' "$url"
 }
 
+normalize_hostname() {
+	host=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+	host=${host#http://}
+	host=${host#https://}
+	host=${host%/}
+	printf '%s' "$host"
+}
+
+is_public_hostname() {
+	host=$(normalize_hostname "$1")
+
+	case "$host" in
+	"" | localhost | localhost.localdomain)
+		return 1
+		;;
+	*:* | *" "* | */*)
+		return 1
+		;;
+	*.local | *.internal | *.localhost)
+		return 1
+		;;
+	esac
+
+	case "$host" in
+	*.*)
+		;;
+	*)
+		return 1
+		;;
+	esac
+
+	if printf '%s' "$host" | grep -Eq '^[0-9.]+$'; then
+		return 1
+	fi
+
+	return 0
+}
+
 current_data_files=$(read_yaml_value DataFiles)
+current_https_cert=$(read_yaml_value HttpsCertFile)
+current_https_key=$(read_yaml_value HttpsKeyFile)
+current_web_domain=$(read_yaml_value WebDomain)
+current_http_port=$(read_yaml_value HttpPort)
+current_https_port=$(read_yaml_value HttpsPort)
+current_https_redirect=$(read_yaml_value HttpsRedirect)
+current_https_email=$(read_yaml_value HttpsEmail)
+
 default_override_file="${current_data_files:-_datafiles/world/default}/config-overrides.yaml"
 override_file="${CONFIG_PATH:-$default_override_file}"
 bundled_config_path=$(canonicalize_path "$CONFIG_FILE")
@@ -67,27 +100,13 @@ if [ "$override_path" = "$bundled_config_path" ]; then
 	override_file=$default_override_file
 fi
 
-read_effective_yaml_value() {
-	key=$1
-	value=$(read_yaml_value_from_file "$override_file" "$key")
-	if [ -n "$value" ]; then
-		printf '%s\n' "$value"
-		return 0
-	fi
-	read_yaml_value "$key"
-}
-
-current_https_cert=$(read_effective_yaml_value HttpsCertFile)
-current_https_key=$(read_effective_yaml_value HttpsKeyFile)
-current_http_port=$(read_effective_yaml_value HttpPort)
-current_https_port=$(read_effective_yaml_value HttpsPort)
-current_https_redirect=$(read_effective_yaml_value HttpsRedirect)
-
 https_cert_file=$current_https_cert
 https_key_file=$current_https_key
+web_domain=$current_web_domain
 http_port=$current_http_port
 https_port=$current_https_port
 https_redirect=$current_https_redirect
+https_email=$current_https_email
 config_updates=""
 override_snippet=""
 
@@ -97,7 +116,8 @@ printf 'Override target: %s\n\n' "$override_file"
 
 printf 'Choose HTTPS mode:\n'
 printf '  1) Manual certificate files\n'
-printf '  2) HTTP only\n'
+printf '  2) Automatic Let'\''s Encrypt\n'
+printf '  3) HTTP only\n'
 printf 'Selection [1]: '
 IFS= read -r mode_selection
 mode_selection=${mode_selection:-1}
@@ -143,8 +163,86 @@ case "$mode_selection" in
 	else
 		https_redirect=${current_https_redirect:-true}
 	fi
+
+	config_updates=$(
+		cat <<EOF
+"FilePaths.HttpsCertFile":"$(json_escape "$https_cert_file")"
+,"FilePaths.HttpsKeyFile":"$(json_escape "$https_key_file")"
+,"Network.HttpPort":"$(json_escape "$http_port")"
+,"Network.HttpsPort":"$(json_escape "$https_port")"
+,"Network.HttpsRedirect":"$(json_escape "$https_redirect")"
+EOF
+	)
+
+	override_snippet=$(
+		cat <<EOF
+FilePaths:
+  HttpsCertFile: "$(json_escape "$https_cert_file")"
+  HttpsKeyFile: "$(json_escape "$https_key_file")"
+Network:
+  HttpPort: $http_port
+  HttpsPort: $https_port
+  HttpsRedirect: $https_redirect
+EOF
+	)
 	;;
 2)
+	if is_public_hostname "$current_web_domain"; then
+		printf 'Public hostname [%s]: ' "$current_web_domain"
+	else
+		printf 'Public hostname (for example play.example.com): '
+	fi
+	IFS= read -r web_domain_input
+	if [ -n "$web_domain_input" ]; then
+		web_domain=$(normalize_hostname "$web_domain_input")
+	fi
+
+	if ! is_public_hostname "$web_domain"; then
+		echo "Automatic HTTPS requires a public hostname like play.example.com, not localhost, a private-only name, or a raw IP address." >&2
+		exit 1
+	fi
+
+	printf 'Contact email for Let'\''s Encrypt notices [%s]: ' "${current_https_email:-optional}"
+	IFS= read -r https_email_input
+	if [ -n "$https_email_input" ]; then
+		https_email=$https_email_input
+	elif [ -z "${https_email:-}" ]; then
+		https_email=""
+	fi
+
+	http_port=80
+	https_port=443
+	https_redirect=true
+	https_cert_file=""
+	https_key_file=""
+
+	config_updates=$(
+		cat <<EOF
+"FilePaths.WebDomain":"$(json_escape "$web_domain")"
+,"FilePaths.HttpsEmail":"$(json_escape "$https_email")"
+,"FilePaths.HttpsCertFile":""
+,"FilePaths.HttpsKeyFile":""
+,"Network.HttpPort":"80"
+,"Network.HttpsPort":"443"
+,"Network.HttpsRedirect":"true"
+EOF
+	)
+
+	override_snippet=$(
+		cat <<EOF
+FilePaths:
+  WebDomain: "$(json_escape "$web_domain")"
+  HttpsEmail: "$(json_escape "$https_email")"
+  HttpsCertFile: ""
+  HttpsKeyFile: ""
+Network:
+  HttpPort: 80
+  HttpsPort: 443
+  HttpsRedirect: true
+EOF
+	)
+	;;
+3)
 	printf 'HTTP port [%s]: ' "${current_http_port:-80}"
 	IFS= read -r http_port_input
 	if [ -n "$http_port_input" ]; then
@@ -157,6 +255,28 @@ case "$mode_selection" in
 	https_redirect=false
 	https_cert_file=""
 	https_key_file=""
+
+	config_updates=$(
+		cat <<EOF
+"FilePaths.HttpsCertFile":""
+,"FilePaths.HttpsKeyFile":""
+,"Network.HttpPort":"$(json_escape "$http_port")"
+,"Network.HttpsPort":"0"
+,"Network.HttpsRedirect":"false"
+EOF
+	)
+
+	override_snippet=$(
+		cat <<EOF
+FilePaths:
+  HttpsCertFile: ""
+  HttpsKeyFile: ""
+Network:
+  HttpPort: $http_port
+  HttpsPort: 0
+  HttpsRedirect: false
+EOF
+	)
 	;;
 *)
 	echo "Unknown selection: $mode_selection" >&2
@@ -164,29 +284,11 @@ case "$mode_selection" in
 	;;
 esac
 
-config_updates=$(
-	cat <<EOF
-"FilePaths.HttpsCertFile":"$(json_escape "$https_cert_file")"
-,"FilePaths.HttpsKeyFile":"$(json_escape "$https_key_file")"
-,"Network.HttpPort":"$(json_escape "$http_port")"
-,"Network.HttpsPort":"$(json_escape "$https_port")"
-,"Network.HttpsRedirect":"$(json_escape "$https_redirect")"
-EOF
-)
-
-override_snippet=$(
-	cat <<EOF
-FilePaths:
-  HttpsCertFile: $(yaml_single_quote "$https_cert_file")
-  HttpsKeyFile: $(yaml_single_quote "$https_key_file")
-Network:
-  HttpPort: $http_port
-  HttpsPort: $https_port
-  HttpsRedirect: $https_redirect
-EOF
-)
-
 printf '\nPlanned settings:\n'
+if [ "$mode_selection" = "2" ]; then
+	printf '  WebDomain: %s\n' "${web_domain:-<empty>}"
+	printf '  HttpsEmail: %s\n' "${https_email:-<empty>}"
+fi
 printf '  HttpsCertFile: %s\n' "${https_cert_file:-<empty>}"
 printf '  HttpsKeyFile: %s\n' "${https_key_file:-<empty>}"
 printf '  HttpPort: %s\n' "$http_port"
@@ -197,6 +299,11 @@ if [ "$mode_selection" = "1" ]; then
 	printf '\nBefore applying these settings:\n'
 	printf '  - Make sure %s and %s exist and are readable by the server.\n' "$https_cert_file" "$https_key_file"
 	printf '  - Open inbound TCP port %s if players should use HTTPS from the internet.\n' "$https_port"
+elif [ "$mode_selection" = "2" ]; then
+	printf '\nBefore applying these settings:\n'
+	printf '  - Point DNS for %s at this server or forwarded public endpoint.\n' "$web_domain"
+	printf '  - Make sure inbound TCP ports 80 and 443 reach GoMud.\n'
+	printf '  - Leave HttpsCertFile and HttpsKeyFile empty so GoMud can request a certificate.\n'
 fi
 
 printf '\nChoose how to apply these changes:\n'
@@ -226,7 +333,8 @@ case "$apply_selection" in
 		-H 'Content-Type: application/json' \
 		-X PATCH \
 		--data "{$config_updates}" \
-		"$admin_base_url/admin/api/v1/config"; then
+		"$admin_base_url/admin/api/v1/config"
+	then
 		printf '\nFailed to apply settings through the admin API.\n' >&2
 		printf 'Fallback: save the following override snippet to %s and restart GoMud:\n\n' "$override_file" >&2
 		printf '%s\n' "$override_snippet" >&2
@@ -235,25 +343,40 @@ case "$apply_selection" in
 
 	printf '\nHTTPS setup applied through the admin API.\n'
 	printf 'Next steps:\n'
-	if [ "$mode_selection" = "1" ]; then
+	case "$mode_selection" in
+	1)
 		printf '  1. Confirm %s and %s exist and are readable.\n' "$https_cert_file" "$https_key_file"
 		printf '  2. Restart GoMud only if your deployment requires it, then open https://your-domain:%s/.\n' "$https_port"
-	else
+		;;
+	2)
+		printf '  1. Confirm %s resolves to this server and ports 80/443 are reachable.\n' "$web_domain"
+		printf '  2. Review /admin/https/ if certificate issuance needs troubleshooting.\n'
+		;;
+	3)
 		printf '  1. Restart GoMud only if your deployment requires it, then connect over plain HTTP on port %s.\n' "$http_port"
-	fi
+		;;
+	esac
 	;;
 2)
 	printf '\nSave the following override snippet to %s:\n\n' "$override_file"
 	printf '%s\n' "$override_snippet"
 	printf '\nNext steps:\n'
-	if [ "$mode_selection" = "1" ]; then
+	case "$mode_selection" in
+	1)
 		printf '  1. Save the snippet to %s or set the same keys through the admin API.\n' "$override_file"
 		printf '  2. Confirm %s and %s exist and are readable.\n' "$https_cert_file" "$https_key_file"
 		printf '  3. Restart GoMud and open https://your-domain:%s/.\n' "$https_port"
-	else
+		;;
+	2)
+		printf '  1. Save the snippet to %s or set the same keys through the admin API.\n' "$override_file"
+		printf '  2. Confirm %s resolves to this server and ports 80/443 are reachable.\n' "$web_domain"
+		printf '  3. Restart GoMud and review /admin/https/ if certificate issuance needs troubleshooting.\n'
+		;;
+	3)
 		printf '  1. Save the snippet to %s or set the same keys through the admin API.\n' "$override_file"
 		printf '  2. Restart GoMud and connect over plain HTTP on port %s.\n' "$http_port"
-	fi
+		;;
+	esac
 	;;
 *)
 	echo "Unknown selection: $apply_selection" >&2

--- a/scripts/https-setup.sh
+++ b/scripts/https-setup.sh
@@ -117,7 +117,7 @@ printf 'Override target: %s\n\n' "$override_file"
 printf 'Choose HTTPS mode:\n'
 printf '  1) Manual certificate files\n'
 printf '  2) Automatic Let'\''s Encrypt\n'
-printf '  3) HTTP only\n'
+printf '  3) Disable HTTPS and use HTTP only\n'
 printf 'Selection [1]: '
 IFS= read -r mode_selection
 mode_selection=${mode_selection:-1}
@@ -263,11 +263,13 @@ EOF
 	https_redirect=false
 	https_cert_file=""
 	https_key_file=""
+	https_email=""
 
 	config_updates=$(
 		cat <<EOF
 "FilePaths.HttpsCertFile":""
 ,"FilePaths.HttpsKeyFile":""
+,"FilePaths.HttpsEmail":""
 ,"Network.HttpPort":"$(json_escape "$http_port")"
 ,"Network.HttpsPort":"0"
 ,"Network.HttpsRedirect":"false"
@@ -279,6 +281,7 @@ EOF
 FilePaths:
   HttpsCertFile: ""
   HttpsKeyFile: ""
+  HttpsEmail: ""
 Network:
   HttpPort: $http_port
   HttpsPort: 0
@@ -312,6 +315,10 @@ elif [ "$mode_selection" = "2" ]; then
 	printf '  - Point DNS for %s at this server or forwarded public endpoint.\n' "$web_domain"
 	printf '  - Make sure inbound TCP ports 80 and 443 reach GoMud.\n'
 	printf '  - Leave HttpsCertFile and HttpsKeyFile empty so GoMud can request a certificate.\n'
+elif [ "$mode_selection" = "3" ]; then
+	printf '\nBefore applying these settings:\n'
+	printf '  - This turns HTTPS off and clears certificate and Let'\''s Encrypt email settings.\n'
+	printf '  - Plain HTTP will continue on port %s until you re-enable HTTPS.\n' "$http_port"
 fi
 
 printf '\nChoose how to apply these changes:\n'

--- a/scripts/https-setup.sh
+++ b/scripts/https-setup.sh
@@ -17,7 +17,7 @@ read_yaml_value() {
 read_yaml_value_from_file() {
 	awk -F': ' -v key="$2" '
 		$1 ~ "^[[:space:]]*" key "$" {
-			gsub(/^"|"$/, "", $2)
+			gsub(/^["'\'']|["'\'']$/, "", $2)
 			print $2
 			exit
 		}
@@ -49,6 +49,10 @@ canonicalize_path() {
 
 json_escape() {
 	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+yaml_single_quote() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/''/g")"
 }
 
 base_url_without_trailing_slash() {
@@ -214,8 +218,8 @@ EOF
 	override_snippet=$(
 		cat <<EOF
 FilePaths:
-  HttpsCertFile: "$(json_escape "$https_cert_file")"
-  HttpsKeyFile: "$(json_escape "$https_key_file")"
+  HttpsCertFile: $(yaml_single_quote "$https_cert_file")
+  HttpsKeyFile: $(yaml_single_quote "$https_key_file")
 Network:
   HttpPort: $http_port
   HttpsPort: $https_port
@@ -270,8 +274,8 @@ EOF
 FilePaths:
   WebDomain: "$(json_escape "$web_domain")"
   HttpsEmail: "$(json_escape "$https_email")"
-  HttpsCertFile: ""
-  HttpsKeyFile: ""
+  HttpsCertFile: ''
+  HttpsKeyFile: ''
 Network:
   HttpPort: 80
   HttpsPort: 443
@@ -308,9 +312,9 @@ EOF
 	override_snippet=$(
 		cat <<EOF
 FilePaths:
-  HttpsCertFile: ""
-  HttpsKeyFile: ""
-  HttpsEmail: ""
+  HttpsCertFile: ''
+  HttpsKeyFile: ''
+  HttpsEmail: ''
 Network:
   HttpPort: $http_port
   HttpsPort: 0

--- a/scripts/https-setup.sh
+++ b/scripts/https-setup.sh
@@ -11,13 +11,17 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 read_yaml_value() {
-	awk -F': ' -v key="$1" '
+	read_yaml_value_from_file "$CONFIG_FILE" "$1"
+}
+
+read_yaml_value_from_file() {
+	awk -F': ' -v key="$2" '
 		$1 ~ "^[[:space:]]*" key "$" {
 			gsub(/^"|"$/, "", $2)
 			print $2
 			exit
 		}
-	' "$CONFIG_FILE"
+	' "$1"
 }
 
 canonicalize_path() {
@@ -82,23 +86,36 @@ is_public_hostname() {
 }
 
 current_data_files=$(read_yaml_value DataFiles)
-current_https_cert=$(read_yaml_value HttpsCertFile)
-current_https_key=$(read_yaml_value HttpsKeyFile)
-current_web_domain=$(read_yaml_value WebDomain)
-current_http_port=$(read_yaml_value HttpPort)
-current_https_port=$(read_yaml_value HttpsPort)
-current_https_redirect=$(read_yaml_value HttpsRedirect)
-current_https_email=$(read_yaml_value HttpsEmail)
-
+bundled_config_path=$(canonicalize_path "$CONFIG_FILE")
 default_override_file="${current_data_files:-_datafiles/world/default}/config-overrides.yaml"
 override_file="${CONFIG_PATH:-$default_override_file}"
-bundled_config_path=$(canonicalize_path "$CONFIG_FILE")
 override_path=$(canonicalize_path "$override_file")
 
 if [ "$override_path" = "$bundled_config_path" ]; then
 	printf 'Ignoring CONFIG_PATH=%s because https-setup must not target the bundled base config.\n' "$override_file" >&2
 	override_file=$default_override_file
 fi
+
+read_effective_yaml_value() {
+	if [ -f "$override_file" ]; then
+		override_value=$(read_yaml_value_from_file "$override_file" "$1")
+		if [ -n "$override_value" ]; then
+			printf '%s' "$override_value"
+			return 0
+		fi
+	fi
+
+	read_yaml_value "$1"
+}
+
+current_data_files=$(read_effective_yaml_value DataFiles)
+current_https_cert=$(read_effective_yaml_value HttpsCertFile)
+current_https_key=$(read_effective_yaml_value HttpsKeyFile)
+current_web_domain=$(read_effective_yaml_value WebDomain)
+current_http_port=$(read_effective_yaml_value HttpPort)
+current_https_port=$(read_effective_yaml_value HttpsPort)
+current_https_redirect=$(read_effective_yaml_value HttpsRedirect)
+current_https_email=$(read_effective_yaml_value HttpsEmail)
 
 https_cert_file=$current_https_cert
 https_key_file=$current_https_key

--- a/scripts/https-setup.sh
+++ b/scripts/https-setup.sh
@@ -113,9 +113,6 @@ override_snippet=""
 printf 'Interactive HTTPS setup\n'
 printf 'Bundled base config: %s\n' "$CONFIG_FILE"
 printf 'Override target: %s\n\n' "$override_file"
-printf 'This helper no longer edits the bundled base config directly.\n'
-printf 'It can PATCH a running GoMud server or print a config-overrides snippet for manual save.\n'
-printf 'Either path still requires a GoMud restart before listener changes take effect.\n\n'
 
 printf 'Choose HTTPS mode:\n'
 printf '  1) Manual certificate files\n'
@@ -124,6 +121,14 @@ printf '  3) HTTP only\n'
 printf 'Selection [1]: '
 IFS= read -r mode_selection
 mode_selection=${mode_selection:-1}
+default_admin_base_url="http://localhost"
+
+if [ "$mode_selection" = "2" ]; then
+	default_admin_base_url="http://127.0.0.1"
+	if [ -n "${current_http_port:-}" ] && [ "$current_http_port" != "80" ]; then
+		default_admin_base_url="http://127.0.0.1:$current_http_port"
+	fi
+fi
 
 case "$mode_selection" in
 1)
@@ -310,17 +315,17 @@ elif [ "$mode_selection" = "2" ]; then
 fi
 
 printf '\nChoose how to apply these changes:\n'
-printf '  1) PATCH a running GoMud server via /admin/api/v1/config\n'
+printf '  1) PATCH a running GoMud server via /admin/api/v1/config (recommended)\n'
 printf '  2) Print a config-overrides snippet for manual save\n'
-printf 'Selection [2]: '
+printf 'Selection [1]: '
 IFS= read -r apply_selection
-apply_selection=${apply_selection:-2}
+apply_selection=${apply_selection:-1}
 
 case "$apply_selection" in
 1)
-	printf 'Admin base URL [http://localhost]: '
+	printf 'Admin base URL [%s]: ' "$default_admin_base_url"
 	IFS= read -r admin_base_url
-	admin_base_url=${admin_base_url:-http://localhost}
+	admin_base_url=${admin_base_url:-$default_admin_base_url}
 	admin_base_url=$(base_url_without_trailing_slash "$admin_base_url")
 
 	printf 'Admin username [admin]: '

--- a/scripts/https-setup.sh
+++ b/scripts/https-setup.sh
@@ -343,6 +343,9 @@ case "$apply_selection" in
 		--data "{$config_updates}" \
 		"$admin_base_url/admin/api/v1/config"; then
 		printf '\nFailed to apply settings through the admin API.\n' >&2
+		printf 'GoMud is not reachable at %s.\n' "$admin_base_url" >&2
+		printf 'If the server is already running, enter its current admin URL and try again.\n' >&2
+		printf 'Otherwise, save the override snippet below and restart GoMud.\n\n' >&2
 		printf 'Fallback: save the following override snippet to %s and restart GoMud:\n\n' "$override_file" >&2
 		printf '%s\n' "$override_snippet" >&2
 		exit 1

--- a/scripts/https-setup.sh
+++ b/scripts/https-setup.sh
@@ -113,6 +113,9 @@ override_snippet=""
 printf 'Interactive HTTPS setup\n'
 printf 'Bundled base config: %s\n' "$CONFIG_FILE"
 printf 'Override target: %s\n\n' "$override_file"
+printf 'This helper no longer edits the bundled base config directly.\n'
+printf 'It can PATCH a running GoMud server or print a config-overrides snippet for manual save.\n'
+printf 'Either path still requires a GoMud restart before listener changes take effect.\n\n'
 
 printf 'Choose HTTPS mode:\n'
 printf '  1) Manual certificate files\n'
@@ -333,8 +336,7 @@ case "$apply_selection" in
 		-H 'Content-Type: application/json' \
 		-X PATCH \
 		--data "{$config_updates}" \
-		"$admin_base_url/admin/api/v1/config"
-	then
+		"$admin_base_url/admin/api/v1/config"; then
 		printf '\nFailed to apply settings through the admin API.\n' >&2
 		printf 'Fallback: save the following override snippet to %s and restart GoMud:\n\n' "$override_file" >&2
 		printf '%s\n' "$override_snippet" >&2
@@ -346,14 +348,17 @@ case "$apply_selection" in
 	case "$mode_selection" in
 	1)
 		printf '  1. Confirm %s and %s exist and are readable.\n' "$https_cert_file" "$https_key_file"
-		printf '  2. Restart GoMud only if your deployment requires it, then open https://your-domain:%s/.\n' "$https_port"
+		printf '  2. Restart GoMud so it rebinds the updated HTTP/HTTPS listeners.\n'
+		printf '  3. Open https://your-domain:%s/.\n' "$https_port"
 		;;
 	2)
 		printf '  1. Confirm %s resolves to this server and ports 80/443 are reachable.\n' "$web_domain"
-		printf '  2. Review /admin/https/ if certificate issuance needs troubleshooting.\n'
+		printf '  2. Restart GoMud so it rebinds the updated HTTP/HTTPS listeners.\n'
+		printf '  3. Review /admin/https/ if certificate issuance needs troubleshooting.\n'
 		;;
 	3)
-		printf '  1. Restart GoMud only if your deployment requires it, then connect over plain HTTP on port %s.\n' "$http_port"
+		printf '  1. Restart GoMud so it rebinds the updated HTTP/HTTPS listeners.\n'
+		printf '  2. Connect over plain HTTP on port %s.\n' "$http_port"
 		;;
 	esac
 	;;

--- a/scripts/https_setup_test.go
+++ b/scripts/https_setup_test.go
@@ -39,6 +39,12 @@ func TestHTTPSSetupManualModePrintsOverrideSnippet(t *testing.T) {
 	if !strings.Contains(output, "Override target: _datafiles/world/default/config-overrides.yaml") {
 		t.Fatalf("https-setup output did not show override target:\n%s", output)
 	}
+	if !strings.Contains(output, "PATCH a running GoMud server via /admin/api/v1/config (recommended)") {
+		t.Fatalf("https-setup output did not mark PATCH as recommended:\n%s", output)
+	}
+	if strings.Contains(output, "This helper no longer edits the bundled base config directly.") {
+		t.Fatalf("https-setup output still showed removed intro text:\n%s", output)
+	}
 	if !strings.Contains(output, "Save the following override snippet") {
 		t.Fatalf("https-setup output did not switch to snippet mode:\n%s", output)
 	}
@@ -253,6 +259,12 @@ func TestHTTPSSetupAutoModeAPIApplyRequiresRestart(t *testing.T) {
 	output := runHTTPSSetup(t, configPath, input, map[string]string{
 		"CURL_BIN": curlStub,
 	})
+	if strings.Contains(output, "Admin base URL [http://localhost]") {
+		t.Fatalf("https-setup auto API output still showed localhost helper text:\n%s", output)
+	}
+	if !strings.Contains(output, "Admin base URL [http://127.0.0.1:8080]") {
+		t.Fatalf("https-setup auto API output did not show loopback helper text based on current HTTP port:\n%s", output)
+	}
 	if !strings.Contains(output, "Restart GoMud so it rebinds the updated HTTP/HTTPS listeners.") {
 		t.Fatalf("https-setup auto API output did not require restart:\n%s", output)
 	}
@@ -287,6 +299,9 @@ func TestHTTPSSetupAutoModePrintsLetsEncryptOverrideSnippet(t *testing.T) {
 	}
 	if !strings.Contains(output, "HttpsRedirect: true") {
 		t.Fatalf("https-setup output did not enable redirect for auto mode:\n%s", output)
+	}
+	if !strings.Contains(output, "HttpsCertFile: <empty>") || !strings.Contains(output, "HttpsKeyFile: <empty>") {
+		t.Fatalf("https-setup output did not automatically blank manual cert paths for auto mode:\n%s", output)
 	}
 }
 

--- a/scripts/https_setup_test.go
+++ b/scripts/https_setup_test.go
@@ -207,6 +207,9 @@ func TestHTTPSSetupCanPatchRunningServer(t *testing.T) {
 	if !strings.Contains(output, "HTTPS setup applied through the admin API.") {
 		t.Fatalf("https-setup output did not confirm API patch:\n%s", output)
 	}
+	if !strings.Contains(output, "Restart GoMud so it rebinds the updated HTTP/HTTPS listeners.") {
+		t.Fatalf("https-setup output did not require restart after API patch:\n%s", output)
+	}
 
 	logBytes, err := os.ReadFile(curlLog)
 	if err != nil {
@@ -223,6 +226,38 @@ func TestHTTPSSetupCanPatchRunningServer(t *testing.T) {
 	updated := readHTTPSSetupConfig(t, configPath)
 	if updated != sampleHTTPSConfig {
 		t.Fatalf("https-setup changed bundled config unexpectedly:\n%s", updated)
+	}
+}
+
+func TestHTTPSSetupAutoModeAPIApplyRequiresRestart(t *testing.T) {
+	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
+	curlDir := t.TempDir()
+	curlLog := filepath.Join(curlDir, "curl.log")
+	curlStub := filepath.Join(curlDir, "curl-stub.sh")
+	curlScript := "#!/usr/bin/env sh\nprintf '%s\\n' \"$@\" >\"" + curlLog + "\"\nexit 0\n"
+	if err := os.WriteFile(curlStub, []byte(curlScript), 0o755); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := strings.Join([]string{
+		"2",
+		"play.example.com",
+		"ops@example.com",
+		"1",
+		"http://localhost/",
+		"admin",
+		"password",
+		"",
+	}, "\n")
+
+	output := runHTTPSSetup(t, configPath, input, map[string]string{
+		"CURL_BIN": curlStub,
+	})
+	if !strings.Contains(output, "Restart GoMud so it rebinds the updated HTTP/HTTPS listeners.") {
+		t.Fatalf("https-setup auto API output did not require restart:\n%s", output)
+	}
+	if !strings.Contains(output, "Review /admin/https/ if certificate issuance needs troubleshooting.") {
+		t.Fatalf("https-setup auto API output did not keep HTTPS troubleshooting guidance:\n%s", output)
 	}
 }
 

--- a/scripts/https_setup_test.go
+++ b/scripts/https_setup_test.go
@@ -11,8 +11,10 @@ import (
 
 const sampleHTTPSConfig = `FilePaths:
   DataFiles: _datafiles/world/default
+  WebDomain: "localhost"
   HttpsCertFile: "server.crt"
   HttpsKeyFile: "server.key"
+  HttpsEmail: ""
 Network:
   HttpPort: 8080
   HttpsPort: 8443
@@ -54,7 +56,7 @@ func TestHTTPSSetupHTTPOnlySnippetClearsHTTPS(t *testing.T) {
 	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
 
 	input := strings.Join([]string{
-		"2",
+		"3",
 		"8080",
 		"2",
 		"",
@@ -74,7 +76,7 @@ func TestHTTPSSetupUsesConfigPathAsOverrideTarget(t *testing.T) {
 	overridePath := filepath.Join(t.TempDir(), "custom-overrides.yaml")
 
 	input := strings.Join([]string{
-		"2",
+		"3",
 		"8080",
 		"2",
 		"",
@@ -158,7 +160,7 @@ func TestHTTPSSetupIgnoresConfigPathWhenItTargetsBundledConfig(t *testing.T) {
 	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
 
 	input := strings.Join([]string{
-		"2",
+		"3",
 		"8080",
 		"2",
 		"",
@@ -224,6 +226,75 @@ func TestHTTPSSetupCanPatchRunningServer(t *testing.T) {
 	}
 }
 
+func TestHTTPSSetupAutoModePrintsLetsEncryptOverrideSnippet(t *testing.T) {
+	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
+
+	input := strings.Join([]string{
+		"2",
+		"play.example.com",
+		"ops@example.com",
+		"2",
+		"",
+	}, "\n")
+
+	output := runHTTPSSetup(t, configPath, input, nil)
+	if !strings.Contains(output, "WebDomain: play.example.com") {
+		t.Fatalf("https-setup output did not show selected hostname:\n%s", output)
+	}
+	if !strings.Contains(output, "HttpsEmail: ops@example.com") {
+		t.Fatalf("https-setup output did not show selected email:\n%s", output)
+	}
+	if !strings.Contains(output, "WebDomain: \"play.example.com\"") {
+		t.Fatalf("https-setup output did not include WebDomain override:\n%s", output)
+	}
+	if !strings.Contains(output, "HttpPort: 80") || !strings.Contains(output, "HttpsPort: 443") {
+		t.Fatalf("https-setup output did not set standard ports for auto mode:\n%s", output)
+	}
+	if !strings.Contains(output, "HttpsRedirect: true") {
+		t.Fatalf("https-setup output did not enable redirect for auto mode:\n%s", output)
+	}
+}
+
+func TestHTTPSSetupAutoModeRejectsLocalhost(t *testing.T) {
+	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
+
+	input := strings.Join([]string{
+		"2",
+		"localhost",
+		"",
+	}, "\n")
+
+	output, err := runHTTPSSetupExpectError(t, configPath, input, nil)
+	if err == nil {
+		t.Fatalf("https-setup.sh unexpectedly succeeded for localhost")
+	}
+	if !strings.Contains(output, "Automatic HTTPS requires a public hostname") {
+		t.Fatalf("https-setup.sh output did not explain invalid hostname:\n%s", output)
+	}
+
+	updated := readHTTPSSetupConfig(t, configPath)
+	if updated != sampleHTTPSConfig {
+		t.Fatalf("https-setup config changed after invalid auto mode input:\n%s", updated)
+	}
+}
+
+func TestHTTPSSetupAutoModeNormalizesPastedHostname(t *testing.T) {
+	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
+
+	input := strings.Join([]string{
+		"2",
+		"https://Play.Example.com/",
+		"",
+		"2",
+		"",
+	}, "\n")
+
+	output := runHTTPSSetup(t, configPath, input, nil)
+	if !strings.Contains(output, "WebDomain: \"play.example.com\"") {
+		t.Fatalf("https-setup output did not normalize pasted hostname:\n%s", output)
+	}
+}
+
 func TestHTTPSSetupPreservesBundledConfigPermissions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX file modes are not stable on Windows")
@@ -235,7 +306,7 @@ func TestHTTPSSetupPreservesBundledConfigPermissions(t *testing.T) {
 	}
 
 	input := strings.Join([]string{
-		"2",
+		"3",
 		"8080",
 		"2",
 		"",
@@ -278,6 +349,23 @@ func readHTTPSSetupConfig(t *testing.T, configPath string) string {
 func runHTTPSSetup(t *testing.T, configPath string, input string, extraEnv map[string]string) string {
 	t.Helper()
 
+	output, err := runHTTPSSetupCommand(t, configPath, input, extraEnv)
+	if err != nil {
+		t.Fatalf("https-setup.sh failed: %v\n%s", err, output)
+	}
+
+	return output
+}
+
+func runHTTPSSetupExpectError(t *testing.T, configPath string, input string, extraEnv map[string]string) (string, error) {
+	t.Helper()
+
+	return runHTTPSSetupCommand(t, configPath, input, extraEnv)
+}
+
+func runHTTPSSetupCommand(t *testing.T, configPath string, input string, extraEnv map[string]string) (string, error) {
+	t.Helper()
+
 	scriptDir, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("os.Getwd() error = %v", err)
@@ -296,9 +384,5 @@ func runHTTPSSetup(t *testing.T, configPath string, input string, extraEnv map[s
 	cmd.Stdin = strings.NewReader(input)
 
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("https-setup.sh failed: %v\n%s", err, output)
-	}
-
-	return string(output)
+	return string(output), err
 }

--- a/scripts/https_setup_test.go
+++ b/scripts/https_setup_test.go
@@ -273,6 +273,51 @@ func TestHTTPSSetupAutoModeAPIApplyRequiresRestart(t *testing.T) {
 	}
 }
 
+func TestHTTPSSetupAutoModeLoadsDefaultAdminURLFromActiveOverride(t *testing.T) {
+	overrideDir := t.TempDir()
+	configPath := writeHTTPSSetupTempConfig(t, "FilePaths:\n  DataFiles: "+overrideDir+"\nNetwork:\n  HttpPort: 8080\n")
+	overridePath := filepath.Join(overrideDir, "config-overrides.yaml")
+	overrideConfig := `FilePaths:
+  WebDomain: "play.example.com"
+Network:
+  HttpPort: 9090
+`
+	if err := os.WriteFile(overridePath, []byte(overrideConfig), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	curlDir := t.TempDir()
+	curlStub := filepath.Join(curlDir, "curl-stub.sh")
+	curlScript := "#!/usr/bin/env sh\nexit 0\n"
+	if err := os.WriteFile(curlStub, []byte(curlScript), 0o755); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := strings.Join([]string{
+		"2",
+		"",
+		"",
+		"1",
+		"",
+		"",
+		"password",
+		"",
+	}, "\n")
+
+	output := runHTTPSSetup(t, configPath, input, map[string]string{
+		"CURL_BIN": curlStub,
+	})
+	if !strings.Contains(output, "Override target: "+overridePath) {
+		t.Fatalf("https-setup output did not show the active override target:\n%s", output)
+	}
+	if !strings.Contains(output, "Admin base URL [http://127.0.0.1:9090]") {
+		t.Fatalf("https-setup output did not derive the admin URL from the active override:\n%s", output)
+	}
+	if !strings.Contains(output, "WebDomain: play.example.com") {
+		t.Fatalf("https-setup output did not load hostname from the active override:\n%s", output)
+	}
+}
+
 func TestHTTPSSetupAPIApplyFailureExplainsRetryAndFallback(t *testing.T) {
 	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
 	curlDir := t.TempDir()

--- a/scripts/https_setup_test.go
+++ b/scripts/https_setup_test.go
@@ -188,7 +188,7 @@ func TestHTTPSSetupCanPatchRunningServer(t *testing.T) {
 	curlDir := t.TempDir()
 	curlLog := filepath.Join(curlDir, "curl.log")
 	curlStub := filepath.Join(curlDir, "curl-stub.sh")
-	curlScript := "#!/usr/bin/env sh\nprintf '%s\\n' \"$@\" >\"" + curlLog + "\"\nexit 0\n"
+	curlScript := "#!/usr/bin/env sh\nprintf '%s\\n' \"$@\" >\"" + curlLog + "\"\nprintf '200'\n"
 	if err := os.WriteFile(curlStub, []byte(curlScript), 0o755); err != nil {
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
@@ -240,7 +240,7 @@ func TestHTTPSSetupAutoModeAPIApplyRequiresRestart(t *testing.T) {
 	curlDir := t.TempDir()
 	curlLog := filepath.Join(curlDir, "curl.log")
 	curlStub := filepath.Join(curlDir, "curl-stub.sh")
-	curlScript := "#!/usr/bin/env sh\nprintf '%s\\n' \"$@\" >\"" + curlLog + "\"\nexit 0\n"
+	curlScript := "#!/usr/bin/env sh\nprintf '%s\\n' \"$@\" >\"" + curlLog + "\"\nprintf '200'\n"
 	if err := os.WriteFile(curlStub, []byte(curlScript), 0o755); err != nil {
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
@@ -288,7 +288,7 @@ Network:
 
 	curlDir := t.TempDir()
 	curlStub := filepath.Join(curlDir, "curl-stub.sh")
-	curlScript := "#!/usr/bin/env sh\nexit 0\n"
+	curlScript := "#!/usr/bin/env sh\nprintf '200'\n"
 	if err := os.WriteFile(curlStub, []byte(curlScript), 0o755); err != nil {
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}

--- a/scripts/https_setup_test.go
+++ b/scripts/https_setup_test.go
@@ -273,6 +273,46 @@ func TestHTTPSSetupAutoModeAPIApplyRequiresRestart(t *testing.T) {
 	}
 }
 
+func TestHTTPSSetupAPIApplyFailureExplainsRetryAndFallback(t *testing.T) {
+	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
+	curlDir := t.TempDir()
+	curlStub := filepath.Join(curlDir, "curl-stub.sh")
+	curlScript := "#!/usr/bin/env sh\nexit 7\n"
+	if err := os.WriteFile(curlStub, []byte(curlScript), 0o755); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := strings.Join([]string{
+		"2",
+		"play.example.com",
+		"",
+		"1",
+		"",
+		"",
+		"password",
+		"",
+	}, "\n")
+
+	output, err := runHTTPSSetupExpectError(t, configPath, input, map[string]string{
+		"CURL_BIN": curlStub,
+	})
+	if err == nil {
+		t.Fatalf("https-setup.sh unexpectedly succeeded for failed API apply")
+	}
+	if !strings.Contains(output, "Failed to apply settings through the admin API.") {
+		t.Fatalf("https-setup output did not report API apply failure:\n%s", output)
+	}
+	if !strings.Contains(output, "GoMud is not reachable at http://127.0.0.1:8080.") {
+		t.Fatalf("https-setup output did not identify unreachable admin URL:\n%s", output)
+	}
+	if !strings.Contains(output, "If the server is already running, enter its current admin URL and try again.") {
+		t.Fatalf("https-setup output did not explain retry guidance:\n%s", output)
+	}
+	if !strings.Contains(output, "Otherwise, save the override snippet below and restart GoMud.") {
+		t.Fatalf("https-setup output did not explain fallback guidance:\n%s", output)
+	}
+}
+
 func TestHTTPSSetupAutoModePrintsLetsEncryptOverrideSnippet(t *testing.T) {
 	configPath := writeHTTPSSetupTempConfig(t, sampleHTTPSConfig)
 


### PR DESCRIPTION
Title: `[HTTPS] [5] Add automatic HTTPS mode to https-setup`

## Summary

Follow-up stack item **HTTPS-5**. Extends `make https-setup` so it can configure the existing automatic Let's Encrypt runtime mode while keeping the non-destructive apply paths from the earlier HTTPS work.

## Changes

- Adds `Automatic Let's Encrypt` as an interactive `https-setup` mode alongside the existing manual-certificate and HTTP-only flows.
- Prompts for a public hostname and optional contact email, then prepares the automatic HTTPS config values.
- Clears `HttpsCertFile` and `HttpsKeyFile` in automatic mode and forces `HttpPort=80`, `HttpsPort=443`, and `HttpsRedirect=true`.
- Rejects `localhost`, private-only names, and raw IP addresses for automatic mode so the helper does not produce a misleading Let's Encrypt config.
- Normalizes pasted hostnames like `https://Play.Example.com/` before writing `WebDomain`.
- Applies settings either by PATCHing a running server through `/admin/api/v1/config` or by printing a `config-overrides.yaml` snippet for manual save.
- Makes the API apply path explicitly require a GoMud restart before new listeners take effect.
- Updates the README and running guide so the automatic helper flow matches the new API and override behavior.

## Scope After Rebase

- Base: `master` now already includes HTTPS-2, HTTPS-3, and HTTPS-4 via `#515`, `#516`, and `#517`.
- This PR now contains only the helper follow-up work in `scripts/https-setup.sh`, `scripts/https_setup_test.go`, `README.md`, and `_datafiles/guides/running/README.md`.

## Validation

- `git diff --check origin/master...HEAD`
- `go test ./internal/web ./scripts`
- `shellcheck scripts/https-setup.sh`
- `shfmt -d scripts/https-setup.sh`
