### PR TITLE
[Admin] Add reset-admin-pw helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,10 @@ run-docker: ### Build and run server in docker.
 https-setup: ### Interactive HTTPS certificate setup helper.
 	@sh ./scripts/https-setup.sh
 
+.PHONY: reset-admin-pw
+reset-admin-pw: ### Interactively reset the admin user's password.
+	@go run ./cmd/reset-admin-pw
+
 
 .PHONY: client
 client: ### Build and run client terminal client

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It includes a fully playable default world, and provides built-in tools to customize or create your own.
 
-Playable online demo: **http://www.gomud.net**
+Playable online demo: **<http://www.gomud.net>**
 
 ---
 
@@ -71,31 +71,30 @@ Colorization is handled through extensive use of my [github.com/GoMudEngine/ansi
 
 ### Requirements
 
-- `go` language runtime installed
+- `go` 1.24 or newer
+- Optional: `docker` for container builds/test/runs
 
-- `docker` to build/run as a container (optional)
+### Quick Start
 
-### Usage
-
-In a Terminal, run one of the following commands:
+In a Terminal, run the following commands:
 
 ```shell
-make reset-admin-pw
+git clone https://github.com/GoMudEngine/GoMud.git
+cd GoMud
 
-make run          # runs GoMud using the `go` framework
+make reset-admin-pw   # set a new default admin password
+make run              # runs GoMud server using `go`
 
-make build        # creates a executable binary of GoMud at `./go-mud-server`
-
-make docker-run   # runs GoMud in a container using Docker Compose
-
-make help         # shows all available `make` command options
+make docker-run       # Alternatively, run the GoMud server using `docker`
 ```
+
+Then open your browser to: `http://localhost`
 
 ---
 
 ## Connecting
 
-When the GoMud server is running, you can connect it via the Terminal, or with a web browser:
+When the GoMud server is running, you can connect it via the Terminal, or with a web browser.
 
 - Telnet: `localhost:33333` or `localhost:44444`
 - Local-only telnet port: `127.0.0.1:9999`
@@ -103,14 +102,29 @@ When the GoMud server is running, you can connect it via the Terminal, or with a
 - Web client: [http://localhost/webclient](http://localhost/webclient)
 - Web admin: [http://localhost/admin/](http://localhost/admin/)
 
-Default seeded credentials in the bundled world:
+**Important:** Run `make reset-admin-pw`, otherwise your default world will launch with these credentials:
 
 - Username: `admin`
 - Password: `password`
 
+## Common Server Commands
+
+In a Terminal, run one of the following commands:
+
+```shell
+
+make run          # runs GoMud using the `go` framework
+
+make build        # creates a executable binary of GoMud at `./go-mud-server`
+
+make run-docker   # runs GoMud in a container using Docker Compose
+
+make help         # shows all available `make` command options
+```
+
 ## Configuration
 
-### Configuration Files
+### Config Files
 
 GoMud loads configuration in layers so you can keep your own world-specific changes separate from the bundled defaults:
 
@@ -126,7 +140,8 @@ _datafiles/config.yaml
 - `{DataFiles}/config-overrides.yaml` is the normal place to save local overrides for a world.
 - `CONFIG_PATH=/path/to/config.yaml` can point GoMud at a different override file when you want to keep it outside the repo or maintain separate deploy-specific settings.
 
-For upgrades, treat `_datafiles/config.yaml` as a reference file, not your day-to-day edit target. Keep your custom changes in `config-overrides.yaml` or a separate file selected with `CONFIG_PATH` so pulling new code does not overwrite your local settings.
+- For upgrades, treat `_datafiles/config.yaml` as a reference file, not your day-to-day edit target. 
+= Keep your custom changes in `config-overrides.yaml` or a separate file selected with `CONFIG_PATH` so pulling new code does not overwrite your local settings.
 
 ### Enable Server HTTPS Support
 
@@ -166,7 +181,10 @@ Interested in contributing? Check out our [CONTRIBUTING.md](https://github.com/G
 |--------------------|-----------------------------------------------------------------------------|
 | `make build`       | Validates and builds the server binary.                                     |
 | `make run`         | Generates module imports and starts the server with `go run .`.             |
-| `make run-docker`  | Builds and starts the Docker environment from `compose.yml`.                |
+| `make run-new`     | Deletes generated room instance data, then starts the server fresh.         |
+| `make run-docker`  | Builds and starts the server container from `compose.yml`.                  |
+| `make https-setup` | Runs the interactive HTTPS certificate setup helper.                        |
+| `make reset-admin-pw` | Interactively resets the admin user's password.                          |
 | `make test`        | Runs code generation, JavaScript linting, and `go test -race ./...`.        |
 | `make validate`    | Runs `fmtcheck` and `go vet`.                                               |
 | `make ci-local`    | Builds the local CI container and runs workflow validation.                 |

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Colorization is handled through extensive use of my [github.com/GoMudEngine/ansi
 In a Terminal, run one of the following commands:
 
 ```shell
+make reset-admin-pw
+
 make run          # runs GoMud using the `go` framework
 
 make build        # creates a executable binary of GoMud at `./go-mud-server`

--- a/cmd/reset-admin-pw/main.go
+++ b/cmd/reset-admin-pw/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/GoMud/internal/users"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -15,6 +16,13 @@ import (
 var errPasswordMismatch = errors.New("passwords did not match")
 
 func main() {
+	mudlog.SetupLogger(
+		nil,
+		os.Getenv(`LOG_LEVEL`),
+		os.Getenv(`LOG_PATH`),
+		os.Getenv(`LOG_NOCOLOR`) == ``,
+	)
+
 	if err := configs.ReloadConfig(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
 		os.Exit(1)

--- a/cmd/reset-admin-pw/main.go
+++ b/cmd/reset-admin-pw/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var errPasswordMismatch = errors.New("passwords did not match")
+
+func main() {
+	if err := configs.ReloadConfig(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	adminUser, err := findAdminUser()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to locate admin user: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Resetting password for admin user %q.\n", adminUser.Username)
+
+	newPassword, err := promptForPassword(os.Stdin, os.Stdout, int(os.Stdin.Fd()))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read password: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := adminUser.SetPassword(newPassword); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set password: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := users.SaveUser(*adminUser); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to save admin user: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Admin password updated for %q.\n", adminUser.Username)
+}
+
+func findAdminUser() (*users.UserRecord, error) {
+	var adminUser *users.UserRecord
+
+	users.SearchOfflineUsers(func(u *users.UserRecord) bool {
+		if strings.EqualFold(u.Role, users.RoleAdmin) {
+			copyUser := *u
+			adminUser = &copyUser
+			return false
+		}
+		return true
+	})
+
+	if adminUser == nil {
+		return nil, errors.New("no offline admin user record found")
+	}
+
+	return adminUser, nil
+}
+
+func promptForPassword(stdin *os.File, stdout *os.File, fd int) (string, error) {
+	var reader *bufio.Reader
+	if !terminal.IsTerminal(fd) {
+		reader = bufio.NewReader(stdin)
+	}
+
+	fmt.Fprint(stdout, "New admin password: ")
+	first, err := readPassword(stdin, fd, reader)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Fprintln(stdout)
+	fmt.Fprint(stdout, "Confirm new admin password: ")
+	second, err := readPassword(stdin, fd, reader)
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintln(stdout)
+
+	if first != second {
+		return "", errPasswordMismatch
+	}
+
+	return first, nil
+}
+
+func readPassword(stdin *os.File, fd int, reader *bufio.Reader) (string, error) {
+	if terminal.IsTerminal(fd) {
+		passwordBytes, err := terminal.ReadPassword(fd)
+		if err != nil {
+			return "", err
+		}
+		return string(passwordBytes), nil
+	}
+
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}

--- a/cmd/reset-admin-pw/main_test.go
+++ b/cmd/reset-admin-pw/main_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+func TestFindAdminUser(t *testing.T) {
+	chdirToRepoRoot(t)
+	overridePath := writeTestConfig(t)
+	t.Setenv("CONFIG_PATH", overridePath)
+	mudlog.SetupLogger(nil, "", "", false)
+
+	if err := configs.ReloadConfig(); err != nil {
+		t.Fatalf("ReloadConfig() error = %v", err)
+	}
+	createUserIndex(t)
+
+	adminUser, err := findAdminUser()
+	if err != nil {
+		t.Fatalf("findAdminUser() error = %v", err)
+	}
+
+	if adminUser.Username != "admin" {
+		t.Fatalf("findAdminUser() username = %q, want %q", adminUser.Username, "admin")
+	}
+	if adminUser.Role != users.RoleAdmin {
+		t.Fatalf("findAdminUser() role = %q, want %q", adminUser.Role, users.RoleAdmin)
+	}
+}
+
+func TestPromptForPasswordMismatch(t *testing.T) {
+	chdirToRepoRoot(t)
+	inputFile := writePromptInput(t, "first\nsecond\n")
+	outputFile := tempOutputFile(t)
+
+	_, err := promptForPassword(inputFile, outputFile, -1)
+	if err != errPasswordMismatch {
+		t.Fatalf("promptForPassword() error = %v, want %v", err, errPasswordMismatch)
+	}
+}
+
+func TestResetAdminPasswordPersistsHash(t *testing.T) {
+	chdirToRepoRoot(t)
+	overridePath := writeTestConfig(t)
+	t.Setenv("CONFIG_PATH", overridePath)
+	mudlog.SetupLogger(nil, "", "", false)
+
+	if err := configs.ReloadConfig(); err != nil {
+		t.Fatalf("ReloadConfig() error = %v", err)
+	}
+	createUserIndex(t)
+
+	adminUser, err := findAdminUser()
+	if err != nil {
+		t.Fatalf("findAdminUser() error = %v", err)
+	}
+
+	const newPassword = "new-secret"
+	if err := adminUser.SetPassword(newPassword); err != nil {
+		t.Fatalf("SetPassword() error = %v", err)
+	}
+	if err := users.SaveUser(*adminUser); err != nil {
+		t.Fatalf("SaveUser() error = %v", err)
+	}
+
+	reloadedUser, err := users.LoadUser(adminUser.Username, true)
+	if err != nil {
+		t.Fatalf("LoadUser() error = %v", err)
+	}
+
+	if !reloadedUser.PasswordMatches(newPassword) {
+		t.Fatal("PasswordMatches() returned false for updated password")
+	}
+	if reloadedUser.Password == newPassword {
+		t.Fatal("password was stored in plaintext")
+	}
+}
+
+func writeTestConfig(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	dataFiles := filepath.Join(root, "world")
+	usersDir := filepath.Join(dataFiles, "users")
+	if err := os.MkdirAll(usersDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	adminUser := strings.TrimSpace(`
+userid: 1
+role: admin
+username: admin
+password: password
+character:
+  name: AdminAnt
+`)
+	if err := os.WriteFile(filepath.Join(usersDir, "1.yaml"), []byte(adminUser+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(admin) error = %v", err)
+	}
+
+	overridePath := filepath.Join(root, "config-overrides.yaml")
+	override := "FilePaths.DataFiles: " + dataFiles + "\n"
+	if err := os.WriteFile(overridePath, []byte(override), 0o600); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+
+	return overridePath
+}
+
+func createUserIndex(t *testing.T) {
+	t.Helper()
+
+	index := users.NewUserIndex()
+	if err := index.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := index.AddUser(1, "admin"); err != nil {
+		t.Fatalf("AddUser(admin) error = %v", err)
+	}
+}
+
+func writePromptInput(t *testing.T, contents string) *os.File {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "prompt-input")
+	if err != nil {
+		t.Fatalf("CreateTemp(input) error = %v", err)
+	}
+	if _, err := file.WriteString(contents); err != nil {
+		t.Fatalf("WriteString(input) error = %v", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		t.Fatalf("Seek(input) error = %v", err)
+	}
+	return file
+}
+
+func tempOutputFile(t *testing.T) *os.File {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "prompt-output")
+	if err != nil {
+		t.Fatalf("CreateTemp(output) error = %v", err)
+	}
+	return file
+}
+
+func chdirToRepoRoot(t *testing.T) {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() failed")
+	}
+
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	previousWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("Chdir(%q) error = %v", repoRoot, err)
+	}
+
+	t.Cleanup(func() {
+		_ = os.Chdir(previousWD)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -33,4 +33,6 @@ require (
 require (
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/term v0.37.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,12 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
## Description

Add a dedicated admin password reset helper for operators.

Primary usage: `make reset-admin-pw`

## Changes

- adds `cmd/reset-admin-pw` to reset the offline admin user password
- adds `make reset-admin-pw` as the operator-facing entrypoint
- initializes logging before `configs.ReloadConfig()` so the helper starts cleanly instead of panicking on startup
- refreshes the README command references and Build Commands section to match the current Makefile targets
- adds regression coverage for admin-user lookup, password mismatch handling, and persisted hashing

## Validation

- `go test ./cmd/reset-admin-pw`
- `go test ./internal/configs`
- `make help`
- verified `make reset-admin-pw` end-to-end against a disposable `CONFIG_PATH` world and confirmed the saved password is bcrypt-hashed
