### PR TITLE
Adding tag registration to modules/plugins

### DIFF
--- a/_datafiles/world/default/rooms/frostfang/642.yaml
+++ b/_datafiles/world/default/rooms/frostfang/642.yaml
@@ -10,4 +10,4 @@ exits:
   east:
     roomid: 166
 tags:
-  - storage
+- storage

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -78,6 +78,8 @@ type Plugin struct {
 	files PluginFiles
 
 	Web WebConfig
+
+	roomTags []string
 }
 
 func New(name string, version string) *Plugin {
@@ -259,6 +261,24 @@ func (p *Plugin) Requires(modname string, modversion string) {
 	reg, _ := regexp.Compile("[^a-zA-Z0-9_]+")
 	modname = reg.ReplaceAllString(modname, "_")
 	p.dependencies = append(p.dependencies, dependency{modname, modversion})
+}
+
+// ReserveTags registers room tags that this plugin recognises, so that
+// "room tags" can list them alongside the owning module name.
+func (p *Plugin) ReserveTags(tags ...string) {
+	p.roomTags = append(p.roomTags, tags...)
+}
+
+// GetRegisteredRoomTags returns a map of plugin name to the room tags it has
+// reserved, containing only plugins that reserved at least one tag.
+func GetRegisteredRoomTags() map[string][]string {
+	result := map[string][]string{}
+	for _, p := range registry {
+		if len(p.roomTags) > 0 {
+			result[p.name] = append([]string(nil), p.roomTags...)
+		}
+	}
+	return result
 }
 
 func (p *Plugin) ExportFunction(stringId string, f any) {

--- a/internal/usercommands/admin.room.go
+++ b/internal/usercommands/admin.room.go
@@ -145,6 +145,24 @@ func Room(rest string, user *users.UserRecord, liveRoom *rooms.Room, flags event
 				user.SendText(fmt.Sprintf(`  <ansi fg="yellow">%s</ansi>`, tag))
 			}
 		}
+
+		registeredTags := roomTagProvider()
+		if len(registeredTags) > 0 {
+			user.SendText(``)
+			user.SendText(`Available Tags:`)
+			moduleNames := make([]string, 0, len(registeredTags))
+			for name := range registeredTags {
+				moduleNames = append(moduleNames, name)
+			}
+			sort.Strings(moduleNames)
+			for _, name := range moduleNames {
+				user.SendText(fmt.Sprintf(`  <ansi fg="cyan">%s</ansi> module:`, name))
+				for _, tag := range registeredTags[name] {
+					user.SendText(fmt.Sprintf(`    <ansi fg="yellow">%s</ansi>`, tag))
+				}
+			}
+		}
+
 		return true, nil
 	}
 

--- a/internal/usercommands/admin.room.go
+++ b/internal/usercommands/admin.room.go
@@ -119,8 +119,28 @@ func Room(rest string, user *users.UserRecord, liveRoom *rooms.Room, flags event
 			return true, nil
 		}
 
+		registeredTags := roomTagProvider()
+		moduleNames := make([]string, 0, len(registeredTags))
+		allTags := map[string]struct{}{}
+		if len(registeredTags) > 0 {
+			for name, tags := range registeredTags {
+				moduleNames = append(moduleNames, name)
+				for _, t := range tags {
+					allTags[t] = struct{}{}
+				}
+			}
+		}
+
 		if len(args) == 2 {
+
 			tag := strings.ToLower(args[1])
+
+			if _, ok := allTags[tag]; !ok {
+				user.SendText(``)
+				user.SendText(fmt.Sprintf(`Invalid tag provided: <ansi fg="yellow">%s</ansi>`, tag))
+				user.SendText(``)
+				return true, fmt.Errorf(`Invalid tag provided: %s`, tag)
+			}
 
 			for i, t := range room.Tags {
 				if t == tag {
@@ -137,6 +157,7 @@ func Room(rest string, user *users.UserRecord, liveRoom *rooms.Room, flags event
 			return true, nil
 		}
 
+		user.SendText(``)
 		if len(room.Tags) == 0 {
 			user.SendText(`No tags set on this room.`)
 		} else {
@@ -146,21 +167,16 @@ func Room(rest string, user *users.UserRecord, liveRoom *rooms.Room, flags event
 			}
 		}
 
-		registeredTags := roomTagProvider()
 		if len(registeredTags) > 0 {
 			user.SendText(``)
 			user.SendText(`Available Tags:`)
-			moduleNames := make([]string, 0, len(registeredTags))
-			for name := range registeredTags {
-				moduleNames = append(moduleNames, name)
-			}
-			sort.Strings(moduleNames)
 			for _, name := range moduleNames {
 				user.SendText(fmt.Sprintf(`  <ansi fg="cyan">%s</ansi> module:`, name))
 				for _, tag := range registeredTags[name] {
 					user.SendText(fmt.Sprintf(`    <ansi fg="yellow">%s</ansi>`, tag))
 				}
 			}
+			user.SendText(``)
 		}
 
 		return true, nil

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -39,6 +39,15 @@ func AddFunctionExporter(f FunctionExporter) {
 	functionExporters = append(functionExporters, f)
 }
 
+// roomTagProvider is set by main at startup via SetRoomTagProvider.
+// It returns a map of plugin name to the room tags that plugin has reserved.
+var roomTagProvider func() map[string][]string = func() map[string][]string { return nil }
+
+// SetRoomTagProvider registers the function that returns registered room tags.
+func SetRoomTagProvider(f func() map[string][]string) {
+	roomTagProvider = f
+}
+
 var (
 	functionExporters = []FunctionExporter{}
 

--- a/main.go
+++ b/main.go
@@ -186,6 +186,7 @@ func main() {
 	templates.RegisterFS(plugins.GetPluginRegistry())
 	items.RegisterFS(plugins.GetPluginRegistry())
 	usercommands.AddFunctionExporter(plugins.GetPluginRegistry())
+	usercommands.SetRoomTagProvider(plugins.GetRegisteredRoomTags)
 
 	inputhandlers.AddIACHandler(plugins.GetPluginRegistry())
 	inputhandlers.AddTextPrefixHandler(plugins.GetPluginRegistry())

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -22,6 +22,7 @@ The GoMud modules system provides a powerful plugin architecture that allows for
 - **Lifecycle hooks**: Load and save callbacks for plugin state management via `SetOnLoad`/`SetOnSave`
 - **Script integration**: Expose plugin functions to JavaScript runtime via `AddScriptingFunction`
 - **Function export**: Expose Go functions to other modules via `ExportFunction` / `GetExportedFunction`
+- **Room tag registration**: Declare room tags the plugin recognises via `ReserveTags`; tags are listed by the `room tags` admin command
 
 #### **Configuration System** (`pluginconfig.go`)
 - **Plugin-specific config**: Each plugin gets its own configuration namespace
@@ -81,7 +82,13 @@ type GMCPOut struct {
 
 ## Plugin Capabilities
 
-### **Command System Integration**
+### Room Tag Registration
+```go
+// Declare the room tags this plugin recognises. Listed by "room tags" admin command.
+plugin.ReserveTags("storage")
+```
+
+### Command System Integration
 ```go
 // Add user commands
 plugin.AddUserCommand("auction", auctionCommand, allowWhenDowned, adminOnly)

--- a/modules/gambling/AGENTS.md
+++ b/modules/gambling/AGENTS.md
@@ -18,6 +18,9 @@ tags:
   - slot machine
 ```
 
+The module calls `plug.ReserveTags("slots", "slot machine", "claw machine")` so that
+these tags appear in the output of the `room tags` admin command.
+
 - A single room may carry both tags and have both machines present.
 - Tags are case-insensitive at the module level (`Slot Machine`, `slot machine`, and
   `SLOT MACHINE` are all treated the same).

--- a/modules/gambling/gambling.go
+++ b/modules/gambling/gambling.go
@@ -64,6 +64,8 @@ func init() {
 	// Register the "play" user command (handles both slots and claw machine).
 	g.plug.AddUserCommand(`play`, g.playCommand, false, false)
 
+	g.plug.ReserveTags(`slots`, `slot machine`, `claw machine`)
+
 	// Persist the jackpot across restarts.
 	g.plug.Callbacks.SetOnLoad(g.load)
 	g.plug.Callbacks.SetOnSave(g.save)

--- a/modules/storage/AGENTS.md
+++ b/modules/storage/AGENTS.md
@@ -14,6 +14,9 @@ tags:
   - storage
 ```
 
+The module calls `plug.ReserveTags("storage")` so that this tag appears in the output
+of the `room tags` admin command.
+
 The module registers an `OnRoomLook` hook that injects the storage alert into the room description when the tag is present. The core `roomdetails.go` no longer has a hardcoded `IsStorage` alert.
 
 ## Key Components

--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -39,6 +39,8 @@ func init() {
 
 	m.plug.AddUserCommand(`storage`, m.storageCommand, false, false)
 
+	m.plug.ReserveTags(`storage`)
+
 	m.plug.Callbacks.SetOnSave(m.onSave)
 
 	m.plug.ExportFunction(`GetStorageItems`, m.GetStorageItems)


### PR DESCRIPTION
# Description

This adds tag reservations/declarations for modules. tags will be listed in the `room tag` command along with the module they belong to.

