### PR TITLE
Fix HTTPS public asset URL fallback

### DIFF
--- a/_datafiles/html/public/_footer.html
+++ b/_datafiles/html/public/_footer.html
@@ -3,7 +3,7 @@
 
     <footer>
       <p>Powered by <b>GoMud</b> - Available free at 
-        <a target="_blank" href="http://github.com/GoMudEngine/GoMud">
+        <a target="_blank" href="https://github.com/GoMudEngine/GoMud">
           github.com/GoMudEngine/GoMud
         </a>
       </p>

--- a/_datafiles/html/public/_header.html
+++ b/_datafiles/html/public/_header.html
@@ -9,10 +9,10 @@
   <style>
     :root {
       /* Setting CSS var here so we can prepend WebCDNLocation */
-      --background-image: url('{{ .CONFIG.FilePaths.WebCDNLocation }}/static/images/web_bg.png') center center / cover no-repeat fixed;
+      --background-image: url('{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/images/web_bg.png" }}') center center / cover no-repeat fixed;
     }
   </style>
-  <link rel="stylesheet" href="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/css/gomud.css">
+  <link rel="stylesheet" href="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/css/gomud.css" }}">
   <script type="text/javascript">
     window.addEventListener("load", function(){
       const link = document.getElementById('hide-header-footer');

--- a/_datafiles/html/public/index.html
+++ b/_datafiles/html/public/index.html
@@ -2,7 +2,7 @@
 
   <div class="play-button">
     <a href="/webclient">
-      <img src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/images/btn_play.png" alt="Play" />
+      <img src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/images/btn_play.png" }}" alt="Play" />
     </a>
   </div>
   <p>&nbsp;</p>

--- a/_datafiles/html/public/webclient-pure.html
+++ b/_datafiles/html/public/webclient-pure.html
@@ -1038,30 +1038,30 @@
         .stats-ns-payload.open { display: block; }
     </style>
 
-    <link rel="stylesheet" href="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/css/xterm.css" />
-    <link rel="stylesheet" href="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/css/windows.css" />
+    <link rel="stylesheet" href="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/css/xterm.css" }}" />
+    <link rel="stylesheet" href="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/css/windows.css" }}" />
 
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/xterm.4.19.0.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/xterm-addon-fit.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/mp3.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/fx.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/winbox.bundle.min.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/webclient-core.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/triggers.js"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/xterm.4.19.0.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/xterm-addon-fit.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/mp3.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/fx.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/winbox.bundle.min.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/webclient-core.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/triggers.js" }}"></script>
     <!-- Left dock -->
-     <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-gametime.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-character.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-gear.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-vitals.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-status.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-party.js"></script>
+     <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-gametime.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-character.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-gear.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-vitals.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-status.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-party.js" }}"></script>
     <!-- Right dock -->
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-map.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-room.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-online.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-killstats.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-comm.js"></script>
-    <script src="{{ .CONFIG.FilePaths.WebCDNLocation }}/static/js/windows/window-modal.js"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-map.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-room.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-online.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-killstats.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-comm.js" }}"></script>
+    <script src="{{ staticAssetURL .REQUEST .CONFIG.FilePaths.WebCDNLocation "/static/js/windows/window-modal.js" }}"></script>
     
     
 </head>

--- a/internal/web/template_func.go
+++ b/internal/web/template_func.go
@@ -3,6 +3,8 @@ package web
 import (
 	"fmt"
 	"html"
+	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"text/template"
@@ -123,5 +125,36 @@ var (
 		"httpsUsesExampleHost": func(host string) bool {
 			return httpsUsesExampleHost(host)
 		},
+		"staticAssetURL": func(r *http.Request, cdnBase string, assetPath string) string {
+			return staticAssetURL(r, cdnBase, assetPath)
+		},
 	}
 )
+
+func staticAssetURL(r *http.Request, cdnBase string, assetPath string) string {
+	if assetPath == "" {
+		return ""
+	}
+
+	if !strings.HasPrefix(assetPath, "/") {
+		assetPath = "/" + assetPath
+	}
+
+	cdnBase = strings.TrimSpace(strings.TrimRight(cdnBase, "/"))
+	if cdnBase == "" {
+		return assetPath
+	}
+
+	cdnURL, err := url.Parse(cdnBase)
+	if err != nil {
+		return assetPath
+	}
+
+	if r != nil && r.TLS != nil && strings.EqualFold(cdnURL.Scheme, "http") {
+		// Do not emit insecure CDN URLs into HTTPS pages; browsers will block
+		// them as mixed content, so local same-origin assets are the safe fallback.
+		return assetPath
+	}
+
+	return cdnBase + assetPath
+}

--- a/internal/web/template_func_test.go
+++ b/internal/web/template_func_test.go
@@ -1,0 +1,77 @@
+package web
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+func TestStaticAssetURL(t *testing.T) {
+	t.Parallel()
+
+	httpReq, err := http.NewRequest(http.MethodGet, "http://gomud.net/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+
+	httpsReq, err := http.NewRequest(http.MethodGet, "https://gomud.net/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	httpsReq.TLS = &tls.ConnectionState{}
+
+	tests := []struct {
+		name      string
+		req       *http.Request
+		cdnBase   string
+		assetPath string
+		want      string
+	}{
+		{
+			name:      "local asset without cdn",
+			req:       httpReq,
+			cdnBase:   "",
+			assetPath: "/static/css/gomud.css",
+			want:      "/static/css/gomud.css",
+		},
+		{
+			name:      "http request keeps http cdn",
+			req:       httpReq,
+			cdnBase:   "http://files.gomud.net",
+			assetPath: "/static/css/gomud.css",
+			want:      "http://files.gomud.net/static/css/gomud.css",
+		},
+		{
+			name:      "https request drops insecure cdn",
+			req:       httpsReq,
+			cdnBase:   "http://files.gomud.net",
+			assetPath: "/static/css/gomud.css",
+			want:      "/static/css/gomud.css",
+		},
+		{
+			name:      "https request keeps secure cdn",
+			req:       httpsReq,
+			cdnBase:   "https://cdn.example.com/",
+			assetPath: "static/js/webclient-core.js",
+			want:      "https://cdn.example.com/static/js/webclient-core.js",
+		},
+		{
+			name:      "invalid cdn falls back local",
+			req:       httpReq,
+			cdnBase:   "://bad url",
+			assetPath: "/static/images/web_bg.png",
+			want:      "/static/images/web_bg.png",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := staticAssetURL(tt.req, tt.cdnBase, tt.assetPath); got != tt.want {
+				t.Fatalf("staticAssetURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- stop HTTPS public pages from emitting insecure `http://...` CDN asset URLs
- fall back to same-origin `/static/...` assets when `WebCDNLocation` would create mixed content on HTTPS requests
- add focused regression coverage for request-aware static asset URL generation

## Why
A live check of `https://gomud.net` and the HAR at `/home/user/downloads/gomud.net.har` showed the public page HTML rendering asset URLs from `FilePaths.WebCDNLocation` as `http://files.gomud.net/...` on an HTTPS page. That breaks in browsers as mixed content, and one recorded asset fetch also failed with `net::ERR_CERT_COMMON_NAME_INVALID` when the browser attempted to load `https://files.gomud.net/...`.

This change keeps CDN usage intact for non-HTTPS requests and for properly configured HTTPS CDNs, but avoids emitting insecure CDN URLs into HTTPS pages.

## Validation
- `go test ./internal/web`
- verified the HAR shows the broken page HTML emitting `http://files.gomud.net/...` asset URLs

## Follow-up For `gomud.net` Owner
This PR fixes the repo-side HTML generation bug, but the `gomud.net` deployment still needs server/CDN cleanup if it wants to keep using `files.gomud.net`:
- update `FilePaths.WebCDNLocation` on the `gomud.net` server to either be blank or point at a valid HTTPS CDN origin
- if `files.gomud.net` should remain in use, provision a certificate whose SAN covers `files.gomud.net`
- verify the CDN/static host serves the expected CSS/JS/image assets over HTTPS without certificate errors
- redeploy/restart the server so the updated config is active
