### PR TITLE
Admin changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vscode
-.claude
 bin/
 private-notes.txt
 _datafiles/**/users/*
@@ -16,3 +15,6 @@ ssh_host_key
 ssh_host_key.pub
 tmp-gomud.exe
 __debug*
+.claude/
+
+

--- a/_datafiles/html/admin/AGENTS.md
+++ b/_datafiles/html/admin/AGENTS.md
@@ -9,75 +9,498 @@ The `_datafiles/html/admin/` directory contains all front-end assets for the GoM
 
 No external CDN dependencies. No Bootstrap, jQuery, or HTMX.
 
-## Files
+---
 
-### `_header.html`
+## Page Skeleton
 
-Defines the Go template named `header`. Included by every admin page via `{{template "header" .}}`.
+Every admin page uses the same three-part structure:
 
-Contents:
-- Minimal HTML5 shell (`<!DOCTYPE html>`, `<head>`, `<body>`)
-- Inline CSS reset and base styles (system font stack, nav bar, `<main>` container)
-- Top navigation bar with links to **Dashboard** (`/admin/`) and **Config** (`/admin/config`)
-- `<script>` tags loading shared JS libraries from `/admin/static/js/` — `api.js`, `ansi-colors.js`, `select-dialog.js`, `script-editor.js`, and `highlight.js`
+```html
+{{template "header" .}}
 
-Template data used: none (the header is layout-only).
+<style>
+    /* Page-specific CSS goes here — never in external files */
+</style>
 
-### `_footer.html`
+<!-- Page HTML content -->
+<h1>Page Title</h1>
+<p class="subtitle">One-line description. <a href="/admin/pagename-api">API Docs &rarr;</a></p>
 
-Defines the Go template named `footer`. Included by every admin page via `{{template "footer" .}}`.
+<!-- ... page body ... -->
 
-Contents:
-- Closing `</main>`, `</body>`, `</html>` tags
+<script>
+    /* Page-specific JavaScript goes here — never in external files */
+</script>
 
-### `index.html`
+{{template "footer" .}}
+```
 
-Admin dashboard page. Rendered by `adminIndex` at `GET /admin/`.
+The `_header.html` template provides: DOCTYPE, `<head>`, CSS reset/base styles, nav bar, all shared JS/CSS imports, and the opening `<main>` tag. The `_footer.html` template closes `</main></body></html>`.
 
-Template data:
-- `.CONFIG` — `configs.Config` struct
-- `.STATS` — `web.Stats` struct
+All page-specific CSS and JS are **inline** within the page file. Shared utilities live in `static/js/`.
 
-Sections:
-- **Header**: MUD name (`CONFIG.Server.MudName`) and version (`CONFIG.Server.CurrentVersion`)
-- **Stats grid** (3 cards): Telnet ports with connection count, WebSocket port with connection count, SSH port with connection count — all sourced from `STATS`
-- **REST API reference**: Expandable `<details>` entries for each API endpoint, showing method badge, path, description, curl examples, and collapsible response examples. The PATCH entry includes a **Test Mode** checkbox that toggles the `X-Test-Mode: true` curl flag via inline JavaScript (`toggleTestMode`)
+## File Naming
 
-Inline JavaScript: `toggleTestMode(blockId, enabled)` — shows or hides `.test-mode-flag` spans within a named curl block.
+| Type | Pattern | Example |
+|---|---|---|
+| Editor/viewer page | `pagename.html` | `races.html` |
+| API documentation | `pagename-api.html` | `races-api.html` |
+| Shared templates | `_name.html` (underscore prefix) | `_header.html` |
+| Shared JavaScript | `static/js/name.js` | `static/js/api.js` |
+| Shared CSS | `static/css/name.css` | `static/css/highlight.css` |
 
-### `config.html`
+Every editor page that calls APIs **must** have a corresponding `pagename-api.html` documenting those endpoints. Link to it from the page subtitle.
 
-Live configuration editor page. Rendered by `adminConfig` at `GET /admin/config`.
+## Template Data
 
-Template data:
-- `.CONFIG` — `configs.Config` struct (used only for the page subtitle; the table is populated via API)
-- `.STATS` — `web.Stats` struct
+Pages receive Go template data from their handler. Common fields:
 
-Behaviour:
-1. On page load, calls `AdminAPI.get('/admin/api/v1/config')` and builds a sortable, section-grouped table from the returned flat key/value map.
-2. **Inline editing**: clicking a non-redacted value hides the display span and shows an `<input>` with Save/Cancel buttons. Pressing Enter stages the edit; Escape cancels.
-3. **Staging**: edits are accumulated in a `pending` map and highlighted in the table row (yellow background). A **Pending Changes** panel appears listing all staged changes with individual remove buttons.
-4. **Apply**: `applyChanges()` calls `AdminAPI.patch('/admin/api/v1/config', pending)`. Applied keys are committed to the local `configData` snapshot; rejected (locked) keys remain staged and are reported in a status banner.
-5. **Discard**: `discardAll()` reverts all staged changes and restores display values from the local snapshot.
-6. **Filtering**: a search input filters rows by key or value substring; a section dropdown filters by config section prefix (e.g. `Server`, `Network`). Section header rows are hidden when all their children are filtered out.
-7. **Locked keys**: displayed with a `locked` badge and are not clickable (no inline edit).
-8. **Redacted secrets**: displayed in italic grey with no click handler.
+- `.CONFIG` — the `configs.Config` struct (server settings, file paths, etc.)
+- `.STATS` — the `web.Stats` struct (connection counts, ports)
+- `.NAV` — navigation entries (consumed by `_header.html`, not your page)
 
-JavaScript functions (all `window`-scoped for template event-handler compatibility):
-- `filterTable()` — applies search and section filters
-- `startEdit(key)` / `cancelEdit(key)` / `editKeydown(event, key)` / `stageEdit(key)` — inline edit lifecycle
-- `removePending(key)` / `discardAll()` — pending change management
-- `applyChanges()` — submits staged changes via `AdminAPI`
+Use `{{.CONFIG.FilePaths.WebDomain}}` in API doc curl examples for the server hostname.
 
-Utility helpers (module-private):
-- `escHtml(s)` / `escAttr(s)` — HTML and attribute escaping
-- `cssId(key)` — converts a dot-path config key to a safe CSS id fragment (e.g. `Server.MudName` → `Server_MudName`)
+---
 
-### `static/js/api.js`
+## Layout Patterns
 
-Served as a static asset at `/admin/static/js/api.js` (loaded by `_header.html`). Provides the `AdminAPI` global object — a thin, promise-based HTTP client for admin pages.
+### Two-Column Layout (Sidebar + Editor)
 
-#### `AdminAPI` API
+This is the standard pattern for CRUD pages (items, buffs, races, quests, colorpatterns). A left sidebar lists records; the right panel shows the editor form.
+
+```html
+<div class="page-layout">
+    <div class="sidebar">
+        <div class="sidebar-header">
+            <input type="search" id="searchInput" placeholder="Search..." oninput="filterList()" />
+        </div>
+        <div id="list" class="thing-list">
+            <div class="no-things">Loading...</div>
+        </div>
+        <button class="btn-new" onclick="newThing()">+ New Thing</button>
+    </div>
+
+    <div class="editor-panel">
+        <div id="editorPlaceholder" class="editor-placeholder">
+            Select an item to edit, or click "New Thing".
+        </div>
+        <div id="editorForm" style="display:none">
+            <div id="statusBar" class="status-bar"></div>
+            <div class="form-grid">
+                <!-- form fields go here -->
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+Required CSS for this layout:
+
+```css
+.page-layout {
+    display: grid;
+    grid-template-columns: 260px 1fr;   /* sidebar width: 260-300px */
+    gap: 1.25rem;
+    align-items: start;
+}
+@media (max-width: 800px) {
+    .page-layout { grid-template-columns: 1fr; }
+}
+```
+
+### Dashboard Layout (Cards Grid)
+
+Used by `index.html` for summary/stats pages:
+
+```html
+<div class="grid">
+    <div class="card">
+        <h2>Card Title</h2>
+        <div class="value">42</div>
+        <div class="detail">Additional info</div>
+    </div>
+    <!-- more cards -->
+</div>
+```
+
+```css
+.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+.card { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 1.25rem; }
+```
+
+### Full-Width Layout
+
+Used by `config.html`, `keywords.html`, and `users.html` for table/search UIs. No sidebar — content fills the `<main>` container directly.
+
+---
+
+## CSS Conventions
+
+### Core Rules
+
+1. **All page styles are inline** in a `<style>` block at the top of the page, after `{{template "header" .}}`.
+2. **No external CSS frameworks.** No Bootstrap, Tailwind, or similar.
+3. **No shared page CSS.** Each page re-declares its own styles. This avoids cross-page coupling.
+4. **Copy proven CSS patterns** from existing pages rather than inventing new ones.
+
+### Color Palette
+
+| Usage | Value |
+|---|---|
+| Primary dark (nav, buttons, focus) | `#1a1a2e` |
+| Primary dark hover | `#2d2d4e` |
+| Success green (background) | `#e6f4ea` |
+| Success green (text) | `#1e6e34` |
+| Error red (background) | `#fde8e8` |
+| Error red (text) | `#8a0000` |
+| Page background | `#f5f5f5` |
+| Card/panel background | `#fff` |
+| Border | `#ddd` |
+| Subtle border | `#eee`, `#f0f0f0` |
+| Label text | `#555` |
+| Muted text | `#888`, `#999` |
+| Button green (new/add) | `#1e6e34` / hover `#145728` |
+
+### Typography
+
+| Element | Size | Weight | Notes |
+|---|---|---|---|
+| `h1` | `1.5rem` | default (700) | Page title |
+| `.subtitle` | `0.9rem` | normal | Below the h1, color `#555` |
+| Labels | `0.78rem` | 600 | Uppercase, letter-spacing `0.03em` |
+| Body/inputs | `0.875rem` | normal | |
+| Small badges | `0.68rem`–`0.75rem` | normal | Monospace for IDs |
+
+### Panels and Cards
+
+```css
+/* Standard white panel (sidebar, editor, cards) */
+background: #fff;
+border: 1px solid #ddd;
+border-radius: 6px;
+```
+
+### Sidebar Rows
+
+Each page names its rows with a page-specific prefix:
+
+```css
+.race-row { /* or .item-row, .buff-row, .quest-row, .pattern-row */
+    padding: 0.5rem 0.9rem;
+    cursor: pointer;
+    border-bottom: 1px solid #f0f0f0;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+}
+.race-row:hover { background: #f5f7ff; }
+.race-row.active { background: #1a1a2e; color: #fff; }
+.race-id { /* ID badge */
+    font-size: 0.75rem;
+    color: #999;
+    font-family: monospace;
+    flex-shrink: 0;
+}
+.race-row.active .race-id { color: #8899cc; }
+```
+
+### Form Grid
+
+Two-column grid inside the editor panel. Fields span one column by default; use `.span2` for full-width.
+
+```css
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.85rem 1.25rem;
+}
+.form-grid .span2 { grid-column: 1 / -1; }
+```
+
+### Form Fields
+
+```html
+<div class="field">
+    <label for="fName">Name</label>
+    <input type="text" id="fName" placeholder="..." />
+</div>
+
+<div class="field span2">
+    <label for="fDesc">Description</label>
+    <textarea id="fDesc" rows="3" placeholder="..."></textarea>
+    <div class="field-hint">Help text shown below the input.</div>
+</div>
+```
+
+```css
+.field label {
+    display: block; font-size: 0.78rem; font-weight: 600;
+    color: #555; margin-bottom: 0.25rem;
+    text-transform: uppercase; letter-spacing: 0.03em;
+}
+.field input, .field select, .field textarea {
+    width: 100%; padding: 0.4rem 0.6rem;
+    border: 1px solid #ccc; border-radius: 4px;
+    font-size: 0.875rem; font-family: inherit; background: #fff;
+}
+.field input:focus, .field select:focus, .field textarea:focus {
+    outline: 2px solid #1a1a2e; outline-offset: 1px; border-color: transparent;
+}
+.field-hint { font-size: 0.75rem; color: #888; margin-top: 0.2rem; }
+```
+
+### Buttons
+
+```css
+/* Primary action (Save) */
+.btn-save {
+    padding: 0.45rem 1.2rem; background: #1a1a2e; color: #fff;
+    border: none; border-radius: 4px; font-size: 0.875rem;
+    font-weight: 600; cursor: pointer;
+}
+.btn-save:hover { background: #2d2d4e; }
+
+/* Destructive action (Delete) */
+.btn-delete {
+    padding: 0.45rem 1rem; background: #fff; color: #8a0000;
+    border: 1px solid #e0a0a0; border-radius: 4px; font-size: 0.875rem;
+    font-weight: 600; cursor: pointer;
+}
+.btn-delete:hover { background: #fde8e8; }
+
+/* New/Create in sidebar */
+.btn-new {
+    margin: 0.6rem 0.9rem; padding: 0.4rem 0.9rem;
+    border: none; border-radius: 4px; background: #1e6e34; color: #fff;
+    font-size: 0.85rem; font-weight: 600; cursor: pointer;
+    display: block; text-align: center;
+}
+.btn-new:hover { background: #145728; }
+
+/* Small add/remove */
+.btn-add-sm {
+    font-size: 0.8rem; padding: 0.3rem 0.7rem;
+    border: 1px dashed #aaa; background: none;
+    border-radius: 4px; cursor: pointer; color: #555;
+}
+.btn-icon {
+    background: none; border: none; cursor: pointer;
+    font-size: 1rem; color: #888; padding: 0 0.2rem;
+}
+.btn-icon:hover { color: #c00; }
+```
+
+### Section Dividers
+
+Use inside `.form-grid` to group related fields:
+
+```html
+<div class="section-title">Base Stats</div>
+```
+
+```css
+.section-title {
+    font-size: 0.78rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.06em; color: #666;
+    padding: 0.75rem 0 0.4rem; border-bottom: 1px solid #eee;
+    margin-bottom: 0.75rem; grid-column: 1 / -1;
+}
+```
+
+### Status Bar
+
+```html
+<div id="statusBar" class="status-bar"></div>
+```
+
+```css
+.status-bar {
+    display: none; padding: 0.55rem 0.9rem; border-radius: 4px;
+    font-size: 0.85rem; margin-bottom: 1rem;
+}
+.status-bar.success { background: #e6f4ea; color: #1e6e34; display: block; }
+.status-bar.error   { background: #fde8e8; color: #8a0000; display: block; }
+```
+
+### Action Row
+
+Buttons at the bottom of the editor form:
+
+```html
+<div class="btn-row">
+    <button class="btn-save" onclick="saveThing()">Save</button>
+    <button class="btn-delete" id="btnDelete" onclick="deleteThing()" style="display:none">Delete</button>
+</div>
+```
+
+```css
+.btn-row {
+    display: flex; gap: 0.6rem; margin-top: 1.25rem; grid-column: 1 / -1;
+}
+```
+
+---
+
+## JavaScript Conventions
+
+### General Rules
+
+1. **All page JS is inline** in a `<script>` block at the bottom of the page, before `{{template "footer" .}}`.
+2. **No external frameworks.** Vanilla JS only.
+3. Functions called from `onclick`/`oninput` HTML attributes must be `window`-scoped (either use `window.fn = function()` or declare them as plain `function` statements at the top level of the `<script>` block).
+4. **No `async`/`await` at the top level.** Wrap initialization in an `async function init()` and call it at the end of the script block.
+
+### Event Handler Conventions
+
+- `oninput="filterList()"` — real-time search filtering
+- `onclick="saveThing()"` — button actions
+- `onchange="handleChange()"` — dropdowns
+- `onkeydown="if(event.key==='Enter') save()"` — enter-to-submit
+- `onclick="event.stopPropagation()"` — prevent event bubbling when needed
+
+### State Management
+
+- Store data in top-level variables (`let allData = {}`, `let activeId = null`, `let isNew = false`).
+- Each page is self-contained. No cross-page state or communication.
+- UI state is tracked via DOM class toggles (`.active`, `.open`) and `style.display`.
+- Never mutate the data store optimistically before the API confirms success.
+
+### Standard Page Lifecycle
+
+```js
+let allData = {};
+let activeId = null;
+let isNew = false;
+
+// 1. Load data on page init
+async function loadData() {
+    const res = await AdminAPI.get('/admin/api/v1/things');
+    if (!res.ok) { console.error('Load failed:', res.error); return; }
+    allData = (res.data && res.data.data) || {};
+    renderList();
+}
+
+// 2. Render sidebar list
+function renderList() {
+    const list = document.getElementById('thingList');
+    const ids = Object.keys(allData).sort((a, b) => parseInt(a) - parseInt(b));
+    if (ids.length === 0) {
+        list.innerHTML = '<div class="no-things">No items found.</div>';
+        return;
+    }
+    list.innerHTML = ids.map(id => {
+        const t = allData[id];
+        return `<div class="thing-row" data-id="${id}" data-name="${escAttr(t.Name || '')}"
+            onclick="selectThing('${id}')">
+            <span class="thing-id">#${id}</span>
+            <span>${escHtml(t.Name || '(unnamed)')}</span>
+        </div>`;
+    }).join('');
+    if (activeId !== null) highlightRow(activeId);
+}
+
+// 3. Filter sidebar
+function filterList() {
+    const q = document.getElementById('searchInput').value.toLowerCase();
+    document.querySelectorAll('.thing-row').forEach(row => {
+        const name = (row.dataset.name || '').toLowerCase();
+        row.style.display = name.includes(q) ? '' : 'none';
+    });
+}
+
+// 4. Select / New
+function selectThing(id) {
+    activeId = id;
+    isNew = false;
+    highlightRow(id);
+    populateForm(allData[id]);
+}
+
+function newThing() {
+    activeId = null;
+    isNew = true;
+    document.querySelectorAll('.thing-row').forEach(r => r.classList.remove('active'));
+    populateForm(null);
+}
+
+// 5. Populate form
+function populateForm(thing) {
+    document.getElementById('editorPlaceholder').style.display = 'none';
+    document.getElementById('editorForm').style.display = '';
+    document.getElementById('statusBar').className = 'status-bar';
+    document.getElementById('btnDelete').style.display = isNew ? 'none' : '';
+    // ... set form field values ...
+}
+
+// 6. Save
+async function saveThing() {
+    const payload = buildPayload();
+    if (!payload.Name) { showStatus('error', 'Name is required.'); return; }
+
+    let res;
+    if (isNew) {
+        res = await AdminAPI.post('/admin/api/v1/things', payload);
+    } else {
+        res = await AdminAPI.patch(`/admin/api/v1/things/${activeId}`, payload);
+    }
+
+    if (!res.ok) { showStatus('error', res.error || 'Save failed.'); return; }
+    // Update local data, re-render list, show success
+    showStatus('success', 'Saved.');
+}
+
+// 7. Delete
+async function deleteThing() {
+    if (!confirm('Delete this? This cannot be undone.')) return;
+    const res = await AdminAPI.delete(`/admin/api/v1/things/${activeId}`);
+    if (!res.ok) { showStatus('error', res.error || 'Delete failed.'); return; }
+    delete allData[activeId];
+    activeId = null;
+    renderList();
+    document.getElementById('editorForm').style.display = 'none';
+    document.getElementById('editorPlaceholder').style.display = '';
+}
+
+// Utilities
+function highlightRow(id) {
+    document.querySelectorAll('.thing-row').forEach(r => r.classList.remove('active'));
+    const row = document.querySelector(`.thing-row[data-id="${id}"]`);
+    if (row) row.classList.add('active');
+}
+
+function showStatus(type, msg) {
+    const bar = document.getElementById('statusBar');
+    bar.className = 'status-bar ' + type;
+    bar.textContent = msg;
+    if (type === 'success') setTimeout(() => { bar.className = 'status-bar'; }, 3000);
+}
+
+function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+function escAttr(s) { return String(s).replace(/"/g,'&quot;'); }
+
+// Kick off
+loadData();
+```
+
+---
+
+## Shared Libraries
+
+These are loaded by `_header.html` and available on every page:
+
+| Global | File | Purpose |
+|---|---|---|
+| `AdminAPI` | `static/js/api.js` | HTTP client with caching |
+| `AnsiColors` | `static/js/ansi-colors.js` | ANSI-256 to hex conversion and swatch rendering |
+| `SelectDialog` | `static/js/select-dialog.js` | Reusable search/select modal |
+| `ScriptEditor` | `static/js/script-editor.js` | Syntax-highlighted textarea for JS scripts |
+| `hljs` | `static/js/highlight.js` | Code syntax highlighting engine |
+
+### AdminAPI (`static/js/api.js`)
+
+Thin, promise-based HTTP client for admin pages.
 
 ```js
 // Single requests — return Promise<APIResult>
@@ -108,18 +531,44 @@ AdminAPI.queue()
 }
 ```
 
-Implementation details:
+**Never use try/catch** — errors are returned as `ok: false`, not thrown.
+
+#### Usage examples
+
+```js
+// GET — cached for 30 seconds
+const res = await AdminAPI.get('/admin/api/v1/things');
+
+// POST/PATCH/PUT/DELETE — invalidates cache for the resource root
+const res = await AdminAPI.post('/admin/api/v1/things', payload);
+const res = await AdminAPI.patch('/admin/api/v1/things/42', payload);
+const res = await AdminAPI.delete('/admin/api/v1/things/42');
+
+// Parallel requests
+const [things, buffs] = await AdminAPI.all([
+    AdminAPI.get('/admin/api/v1/things'),
+    AdminAPI.get('/admin/api/v1/buffs'),
+]);
+
+// Fluent queue
+const results = await AdminAPI.queue()
+    .get('/admin/api/v1/things')
+    .patch('/admin/api/v1/things/42', payload)
+    .run();
+```
+
+#### Implementation details
+
 - Uses `fetch` with `credentials: 'same-origin'` and `Content-Type: application/json`.
 - Never rejects — network errors are caught and returned as `APIResult` with `ok: false`.
 - Response body is parsed as JSON; falls back to raw text on parse failure.
+- GET results are cached for 30 seconds. Mutations (POST/PATCH/PUT/DELETE) invalidate the cache for the resource root path.
 - `AdminAPI.all` delegates to `Promise.all` (already non-rejecting because each request handles its own errors).
 - `AdminAPI.queue().run()` splices the internal pending array so the same queue instance can be reused.
 
-### `static/js/ansi-colors.js`
+### AnsiColors (`static/js/ansi-colors.js`)
 
-Served as a static asset at `/admin/static/js/ansi-colors.js` (loaded by `_header.html` after `api.js`). Provides the `AnsiColors` global object for converting ANSI 256-color codes to CSS hex values and rendering color previews.
-
-#### `AnsiColors` API
+Converts ANSI 256-color codes to CSS hex values and renders color previews.
 
 ```js
 AnsiColors.toHex(n)                    // ANSI code (0–255) → CSS hex string e.g. '#ff0000'
@@ -131,11 +580,9 @@ AnsiColors.previewTextHtml(text, colors)  // colorize a text string using bounce
 - `swatchHtml(colors, max?)` returns `<span style="background:#hex"></span>` for each code, optionally limited to `max` entries.
 - `previewTextHtml(text, colors)` applies the default bounce pattern (per-character, reversing at ends) and returns HTML with inline `color:` styles.
 
-### `static/js/select-dialog.js`
+### SelectDialog (`static/js/select-dialog.js`)
 
-Served as a static asset at `/admin/static/js/select-dialog.js` (loaded by `_header.html`). Provides the `SelectDialog` global object — a reusable search-and-select modal dialog for admin pages.
-
-#### `SelectDialog` API
+Reusable search-and-select modal dialog.
 
 ```js
 SelectDialog.open({
@@ -152,11 +599,9 @@ SelectDialog.close();             // close programmatically
 
 `transform(data)` receives the parsed `APIResult.data` field and must return an array of `{label: string, value: string}` objects.
 
-In **single-select** mode (default), clicking an item calls `onSelect(value)` and closes the dialog immediately.
+In **single-select** mode (default), clicking an item calls `onSelect(value)` and closes the dialog immediately. In **multi-select** mode, items show checkboxes and a "Select" button appears in the footer.
 
-In **multi-select** mode, items show checkboxes and a "Select" button appears in the footer. Clicking "Select" calls `onSelect([...values])`.
-
-A search/filter input is always shown. The dialog closes on Cancel, the × button, or clicking the overlay backdrop.
+A search/filter input is always shown. The dialog closes on Cancel, the x button, or clicking the overlay backdrop.
 
 #### Common usage: inject a color pattern name into a text input
 
@@ -166,38 +611,26 @@ SelectDialog.open({
   apiPath: '/admin/api/v1/colorpatterns',
   transform: data => Object.keys(data).sort().map(k => ({ label: k, value: k })),
   onSelect: value => {
-    myInput.value += ':' + value;  // inject as :patternname
+    myInput.value += ':' + value;
   },
 });
 ```
 
-## Template Rendering Flow
+### ScriptEditor (`static/js/script-editor.js`)
 
-Both admin pages follow the same pattern:
+Overlays syntax highlighting on a `<textarea>` for editing JavaScript. Supports tab indentation (4 spaces) and synchronized scroll.
 
-```
-handler parses:
-  _header.html  (defines "header")
-  <page>.html   (defines page body, calls {{template "header" .}} and {{template "footer" .}})
-  _footer.html  (defines "footer")
-
-template.New("<page>.html").Funcs(funcMap).ParseFiles(...).Execute(w, templateData)
+```js
+const syncHighlight = ScriptEditor.init('scriptTextarea');
+// After programmatically changing textarea value:
+syncHighlight();
 ```
 
-`Cache-Control: no-store` is set on every response to prevent stale admin pages.
+---
 
-## Relationship to Go Source
+## API Documentation Pages
 
-| HTML file | Go handler | Route |
-|---|---|---|
-| `index.html` | `internal/web/admin.go` `adminIndex` | `GET /admin/` |
-| `config.html` | `internal/web/admin_config.go` `adminConfig` | `GET /admin/config` |
-| `static/js/*.js` | `internal/web/web.go` `serveAdminStaticFile` | `GET /admin/static/{path...}` |
-| `_header.html`, `_footer.html` | included by both page handlers | — |
-
-## API Documentation Page Specification
-
-Every `-api.html` page documents the REST endpoints for its resource. New API doc pages must follow this structure so the admin interface stays consistent.
+Every page that uses API endpoints must have a matching `-api.html` file (e.g. `items.html` -> `items-api.html`).
 
 ### Page structure
 
@@ -220,6 +653,51 @@ Each `<details class="api-entry">` contains:
    - **Response examples** (required): a `<div class="response-examples">` containing one or more `<details class="resp-entry">` blocks:
      - Each has a **summary** with a status badge (`status-ok` or `status-err`) and a label (e.g. "Success", "Not Found").
      - Each has a **body** with a `<div class="curl-block">` showing an example JSON response.
+
+### Template
+
+```html
+{{template "header" .}}
+
+<style>
+    /* Copy the standard API page styles from any existing -api.html */
+</style>
+
+<h1>Things API Reference</h1>
+<p class="subtitle">REST endpoints for managing things.</p>
+
+<div class="api-list">
+    <details class="api-entry">
+        <summary>
+            <span class="method method-get">GET</span>
+            <span class="api-path">/admin/api/v1/things</span>
+            <span class="api-desc">Return all things</span>
+        </summary>
+        <div class="api-body">
+            <p>Description of the endpoint.</p>
+            <div class="curl-block">
+                <span class="kw">curl</span> <span class="flag">-s</span>
+                <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/things</span>
+            </div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary>
+                        <span class="method resp-label status-ok">200</span>
+                        <span class="resp-label">Success</span>
+                    </summary>
+                    <div class="resp-body">
+                        <div class="curl-block">{"success":true,"data":{...}}</div>
+                    </div>
+                </details>
+            </div>
+        </div>
+    </details>
+    <!-- more endpoints -->
+</div>
+
+{{template "footer" .}}
+```
 
 ### Required response examples
 
@@ -245,7 +723,11 @@ All `-api.html` pages share the same `<style>` block. The required classes are:
 | `.api-list` | Flex column container for all entries |
 | `.api-entry` | Collapsible `<details>` wrapper |
 | `.method` | Base style for HTTP method badges |
-| `.method-get`, `.method-post`, `.method-patch`, `.method-put`, `.method-delete` | Color variants |
+| `.method-get` | Green badge |
+| `.method-post` | Blue badge |
+| `.method-patch` | Orange badge |
+| `.method-put` | Orange badge (same as patch) |
+| `.method-delete` | Red badge |
 | `.api-path` | Monospace route path |
 | `.api-desc` | Right-aligned description text |
 | `.api-body` | Expanded content area |
@@ -253,3 +735,187 @@ All `-api.html` pages share the same `<style>` block. The required classes are:
 | `.response-examples` | Container for response entries |
 | `.resp-entry` | Collapsible response example |
 | `.status-ok`, `.status-err` | Green/red status badges |
+
+### Curl block syntax highlighting
+
+| Class | Usage | Color |
+|---|---|---|
+| `.kw` | `curl`, HTTP methods | Blue `#79c0ff` |
+| `.flag` | `-s`, `-X`, `-H`, `-d` | Purple `#d2a8ff` |
+| `.str` | URLs, JSON payloads, strings | Light blue `#a5d6ff` |
+
+---
+
+## Reusable UI Components
+
+### Tabs
+
+```html
+<div class="tab-bar">
+    <button class="tab-btn active" onclick="switchTab('general')">General</button>
+    <button class="tab-btn" onclick="switchTab('advanced')">Advanced</button>
+</div>
+<div id="tab-general" class="tab-panel active">...</div>
+<div id="tab-advanced" class="tab-panel">...</div>
+```
+
+```css
+.tab-bar { display: flex; gap: 0; border-bottom: 2px solid #ddd; margin-bottom: 1rem; }
+.tab-btn {
+    padding: 0.5rem 1rem; border: none; background: none;
+    cursor: pointer; font-size: 0.85rem; color: #666;
+    border-bottom: 2px solid transparent; margin-bottom: -2px;
+}
+.tab-btn.active { color: #1a1a2e; border-bottom-color: #1a1a2e; font-weight: 600; }
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+```
+
+### Collapsible Sections
+
+```html
+<div class="help-group">
+    <div class="help-group-header" onclick="this.parentElement.classList.toggle('open')">
+        Section Title
+    </div>
+    <div class="help-group-body">
+        <!-- content -->
+    </div>
+</div>
+```
+
+### Chips (Tags with Remove)
+
+```html
+<div class="buff-ids-wrap">
+    <span class="chip">
+        Buff #5
+        <span class="x" onclick="removeBuff(5)">&times;</span>
+    </span>
+</div>
+```
+
+### Stat Modifier Grid
+
+Used by items and buffs for editing stat modifications. Groups stats by category with labeled inputs.
+
+### Flags Grid
+
+Grid of labeled checkboxes for boolean flags:
+
+```html
+<div class="flags-grid">
+    <label class="flag-item">
+        <input type="checkbox" value="hidden" />
+        <span class="flag-name">hidden</span>
+        <span class="flag-desc">Not visible in buff list</span>
+    </label>
+</div>
+```
+
+---
+
+## Checklist for New Pages
+
+1. Start with `{{template "header" .}}` and end with `{{template "footer" .}}`.
+2. Add a `<style>` block with page-specific CSS. Copy the standard patterns from an existing page like `races.html` (simplest CRUD example) or `items.html` (full-featured example).
+3. Add `<h1>` title and `<p class="subtitle">` with a link to the API docs page.
+4. Use the two-column layout for CRUD pages, or full-width for specialized UIs.
+5. Add a `<script>` block with the standard lifecycle: load, render, filter, select, populate, save, delete, showStatus, escHtml, escAttr.
+6. Use `AdminAPI` for all HTTP requests. Never use raw `fetch`.
+7. Create the matching `pagename-api.html` documenting all endpoints.
+8. Register the Go handler and route in `internal/web/`. Add the page to the navigation entries so it appears in the nav bar.
+
+---
+
+## Reference: Existing Pages by Complexity
+
+| Page | Layout | Complexity | Good template for... |
+|---|---|---|---|
+| `index.html` | Cards grid | Simple | Dashboard/summary pages |
+| `users.html` | Full-width table | Simple | Search/list-only pages |
+| `https.html` | Full-width | Simple | Info/status pages |
+| `races.html` | Sidebar + editor | Medium | Basic CRUD with form fields |
+| `colorpatterns.html` | Sidebar + editor | Medium | CRUD with preview/visualization |
+| `quests.html` | Sidebar + editor | Complex | Nested/dynamic sub-editors (steps) |
+| `buffs.html` | Sidebar + editor | Complex | Stat mods, flags, script editor |
+| `items.html` | Sidebar + editor | Complex | All features (stat mods, scripts, SelectDialog, chips) |
+| `keywords.html` | Full-width + tabs | Complex | Tabbed UIs with multiple data types |
+| `config.html` | Full-width table | Complex | Inline editing, staged changes |
+
+---
+
+## Detailed File Reference
+
+### `_header.html`
+
+Defines the Go template named `header`. Included by every admin page via `{{template "header" .}}`.
+
+Contents:
+- Minimal HTML5 shell (`<!DOCTYPE html>`, `<head>`, `<body>`)
+- Inline CSS reset and base styles (system font stack, nav bar, `<main>` container)
+- Top navigation bar built from `.NAV` template data, with support for nested dropdowns via `.SubItems`
+- `<script>` tags loading shared JS libraries from `/admin/static/js/` — `api.js`, `ansi-colors.js`, `select-dialog.js`, `script-editor.js`, and `highlight.js`
+- `<link>` to `/admin/static/css/highlight.css`
+
+### `_footer.html`
+
+Defines the Go template named `footer`. Included by every admin page via `{{template "footer" .}}`.
+
+Contents: closing `</main>`, `</body>`, `</html>` tags.
+
+### `index.html`
+
+Admin dashboard page. Rendered by `adminIndex` at `GET /admin/`.
+
+Template data: `.CONFIG` (configs.Config), `.STATS` (web.Stats).
+
+Sections:
+- **Header**: MUD name and version from `.CONFIG`
+- **Stats grid** (3 cards): Telnet ports, WebSocket port, SSH port — each with connection count from `.STATS`
+- **API reference card**: link to Config API docs
+
+### `config.html`
+
+Live configuration editor page. Rendered by `adminConfig` at `GET /admin/config`.
+
+Template data: `.CONFIG` (used only for the subtitle), `.STATS`.
+
+Behaviour:
+1. On page load, calls `AdminAPI.get('/admin/api/v1/config')` and builds a sortable, section-grouped table.
+2. **Inline editing**: clicking a non-redacted value shows an `<input>` with Save/Cancel. Enter stages the edit; Escape cancels.
+3. **Staging**: edits accumulate in a `pending` map with yellow-highlighted rows. A **Pending Changes** panel lists staged changes.
+4. **Apply**: `applyChanges()` calls `AdminAPI.patch('/admin/api/v1/config', pending)`. Rejected (locked) keys remain staged.
+5. **Discard**: `discardAll()` reverts all staged changes.
+6. **Filtering**: search input filters by key/value; section dropdown filters by prefix.
+7. **Locked keys**: displayed with a `locked` badge, not clickable.
+8. **Redacted secrets**: displayed in italic grey, no click handler.
+
+JavaScript functions (all `window`-scoped):
+- `filterTable()`, `startEdit(key)`, `cancelEdit(key)`, `editKeydown(event, key)`, `stageEdit(key)`, `removePending(key)`, `discardAll()`, `applyChanges()`
+
+Utility helpers: `escHtml(s)`, `escAttr(s)`, `cssId(key)`.
+
+## Template Rendering Flow
+
+All admin pages follow the same pattern:
+
+```
+handler parses:
+  _header.html  (defines "header")
+  <page>.html   (defines page body, calls {{template "header" .}} and {{template "footer" .}})
+  _footer.html  (defines "footer")
+
+template.New("<page>.html").Funcs(funcMap).ParseFiles(...).Execute(w, templateData)
+```
+
+`Cache-Control: no-store` is set on every response to prevent stale admin pages.
+
+## Relationship to Go Source
+
+| HTML file | Go handler | Route |
+|---|---|---|
+| `index.html` | `internal/web/admin.go` `adminIndex` | `GET /admin/` |
+| `config.html` | `internal/web/admin_config.go` `adminConfig` | `GET /admin/config` |
+| `static/js/*.js` | `internal/web/web.go` `serveAdminStaticFile` | `GET /admin/static/{path...}` |
+| `_header.html`, `_footer.html` | included by both page handlers | — |

--- a/_datafiles/html/admin/AGENTS.md
+++ b/_datafiles/html/admin/AGENTS.md
@@ -497,6 +497,7 @@ These are loaded by `_header.html` and available on every page:
 | `SelectDialog` | `static/js/select-dialog.js` | Reusable search/select modal |
 | `ScriptEditor` | `static/js/script-editor.js` | Syntax-highlighted textarea for JS scripts |
 | `hljs` | `static/js/highlight.js` | Code syntax highlighting engine |
+| `AnsiTags` | `static/js/ansitags.js` | ANSI tag parsing and rendering |
 
 ### AdminAPI (`static/js/api.js`)
 
@@ -855,7 +856,7 @@ Contents:
 - Minimal HTML5 shell (`<!DOCTYPE html>`, `<head>`, `<body>`)
 - Inline CSS reset and base styles (system font stack, nav bar, `<main>` container)
 - Top navigation bar built from `.NAV` template data, with support for nested dropdowns via `.SubItems`
-- `<script>` tags loading shared JS libraries from `/admin/static/js/` — `api.js`, `ansi-colors.js`, `select-dialog.js`, `script-editor.js`, and `highlight.js`
+- `<script>` tags loading shared JS libraries from `/admin/static/js/` — `api.js`, `ansi-colors.js`, `select-dialog.js`, `script-editor.js`, `highlight.js`, and `ansitags.js`
 - `<link>` to `/admin/static/css/highlight.css`
 
 ### `_footer.html`

--- a/_datafiles/html/admin/_header.html
+++ b/_datafiles/html/admin/_header.html
@@ -37,6 +37,7 @@
     <script src="/admin/static/js/ansi-colors.js"></script>
     <script src="/admin/static/js/select-dialog.js"></script>
     <script src="/admin/static/js/script-editor.js"></script>
+    <script src="/admin/static/js/ansitags.js"></script>
 </head>
 <body>
     <nav>

--- a/_datafiles/html/admin/color-aliases-api.html
+++ b/_datafiles/html/admin/color-aliases-api.html
@@ -1,0 +1,129 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .api-list { display: flex; flex-direction: column; gap: 0.75rem; }
+    .api-entry { border: 1px solid #ddd; border-radius: 6px; overflow: hidden; }
+    .api-entry summary {
+        display: flex; align-items: center; gap: 0.75rem; padding: 0.7rem 1rem;
+        cursor: pointer; background: #fafafa; list-style: none; font-size: 0.875rem;
+        user-select: none;
+    }
+    .api-entry summary::-webkit-details-marker { display: none; }
+    .api-entry[open] summary { background: #f0f0f8; border-bottom: 1px solid #ddd; }
+    .method {
+        font-size: 0.72rem; font-weight: 700; padding: 0.2rem 0.5rem;
+        border-radius: 3px; text-transform: uppercase; white-space: nowrap; color: #fff;
+    }
+    .method-get    { background: #1e6e34; }
+    .method-patch  { background: #8a5a00; }
+    .method-delete { background: #8a0000; }
+    .api-path { font-family: monospace; font-size: 0.82rem; color: #1a1a2e; }
+    .api-desc { margin-left: auto; font-size: 0.8rem; color: #666; }
+    .api-body { padding: 1rem 1.25rem; font-size: 0.875rem; line-height: 1.6; }
+    .api-body p { margin-bottom: 0.75rem; color: #333; }
+    .curl-block {
+        background: #1a1a2e; color: #ccc; font-family: monospace; font-size: 0.8rem;
+        padding: 0.75rem 1rem; border-radius: 4px; white-space: pre-wrap; word-break: break-all;
+        margin: 0.5rem 0 1rem;
+    }
+    .kw   { color: #79c0ff; }
+    .flag { color: #d2a8ff; }
+    .str  { color: #a5d6ff; }
+    .response-examples { margin-top: 0.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
+    .resp-entry { border: 1px solid #eee; border-radius: 4px; overflow: hidden; }
+    .resp-entry summary { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.75rem; cursor: pointer; background: #fafafa; list-style: none; font-size: 0.8rem; }
+    .resp-entry summary::-webkit-details-marker { display: none; }
+    .resp-entry[open] summary { background: #f5f5f5; border-bottom: 1px solid #eee; }
+    .resp-body { padding: 0.5rem 0.75rem; }
+    .resp-label { font-size: 0.75rem; font-weight: 600; }
+    .status-ok  { background: #e6f4ea; color: #1e6e34; padding: 0.15rem 0.45rem; border-radius: 3px; }
+    .status-err { background: #fde8e8; color: #8a0000; padding: 0.15rem 0.45rem; border-radius: 3px; }
+</style>
+
+<h1>Color Aliases API Reference</h1>
+<p class="subtitle">REST endpoints for managing named ANSI color aliases.</p>
+
+<div class="api-list">
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-get">GET</span>
+            <span class="api-path">/admin/api/v1/color-aliases</span>
+            <span class="api-desc">Return all color aliases</span>
+        </summary>
+        <div class="api-body">
+            <p>Returns all currently loaded ANSI color aliases as a flat object mapping alias name to numeric color code (0–255).</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/color-aliases</span></div>
+            <div class="response-examples">
+                <details class="resp-entry" open>
+                    <summary><span class="method resp-label status-ok">200</span><span class="resp-label">Success</span></summary>
+                    <div class="resp-body">
+                        <div class="curl-block">{"success":true,"data":{"username":11,"mobname":51,"gold":220}}</div>
+                    </div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-patch">PATCH</span>
+            <span class="api-path">/admin/api/v1/color-aliases</span>
+            <span class="api-desc">Set or update an alias</span>
+        </summary>
+        <div class="api-body">
+            <p>Sets a single alias to the given ANSI 256-color code. If the alias already exists it is overwritten. The change is persisted to <code>ansi-aliases.yaml</code> and aliases are reloaded immediately.</p>
+            <p><strong>Body fields:</strong></p>
+            <ul style="margin:0 0 0.75rem 1.25rem; font-size:0.85rem; color:#333;">
+                <li><code>alias</code> (string, required) — alias name</li>
+                <li><code>value</code> (integer 0–255, required) — ANSI color code</li>
+            </ul>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> <span class="str">PATCH</span> \
+     <span class="flag">-H</span> <span class="str">'Content-Type: application/json'</span> \
+     <span class="flag">-d</span> <span class="str">'{"alias":"username","value":195}'</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/color-aliases</span></div>
+            <div class="response-examples">
+                <details class="resp-entry" open>
+                    <summary><span class="method resp-label status-ok">200</span><span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span><span class="resp-label">Bad Request</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"value must be between 0 and 255"}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-delete">DELETE</span>
+            <span class="api-path">/admin/api/v1/color-aliases/{alias}</span>
+            <span class="api-desc">Delete an alias</span>
+        </summary>
+        <div class="api-body">
+            <p>Removes the named alias from <code>ansi-aliases.yaml</code> and reloads aliases. The alias name is URL-encoded in the path.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> <span class="str">DELETE</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/color-aliases/username</span></div>
+            <div class="response-examples">
+                <details class="resp-entry" open>
+                    <summary><span class="method resp-label status-ok">200</span><span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">404</span><span class="resp-label">Not Found</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"alias not found: username"}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+</div>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/color-aliases.html
+++ b/_datafiles/html/admin/color-aliases.html
@@ -1,0 +1,280 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .page-layout { display: grid; grid-template-columns: 280px 1fr; gap: 1.25rem; align-items: start; }
+    @media (max-width: 800px) { .page-layout { grid-template-columns: 1fr; } }
+
+    .sidebar { background: #fff; border: 1px solid #ddd; border-radius: 6px; overflow: hidden; display: flex; flex-direction: column; }
+    .sidebar-header { padding: 0.75rem 0.9rem; border-bottom: 1px solid #eee; display: flex; gap: 0.5rem; }
+    .sidebar-header input[type="search"] { flex: 1; padding: 0.35rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; font-size: 0.85rem; }
+    .alias-list { overflow-y: auto; max-height: 72vh; }
+    .alias-row {
+        padding: 0.45rem 0.9rem; cursor: pointer; border-bottom: 1px solid #f0f0f0;
+        display: flex; align-items: center; gap: 0.6rem; font-size: 0.875rem;
+    }
+    .alias-row:last-child { border-bottom: none; }
+    .alias-row:hover { background: #f5f7ff; }
+    .alias-row.active { background: #1a1a2e; color: #fff; }
+    .alias-swatch {
+        width: 18px; height: 18px; border-radius: 3px; flex-shrink: 0;
+        border: 1px solid rgba(0,0,0,0.15);
+    }
+    .alias-name { flex: 1; font-family: monospace; font-size: 0.82rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .alias-value { font-size: 0.75rem; color: #999; font-family: monospace; flex-shrink: 0; }
+    .alias-row.active .alias-value { color: #8899cc; }
+    .no-aliases { padding: 1.5rem; text-align: center; color: #888; font-size: 0.85rem; }
+    .btn-new { margin: 0.6rem 0.9rem; padding: 0.4rem 0.9rem; border: none; border-radius: 4px; background: #1e6e34; color: #fff; font-size: 0.85rem; font-weight: 600; cursor: pointer; display: block; text-align: center; }
+    .btn-new:hover { background: #145728; }
+
+    .editor-panel { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 1.25rem; }
+    .editor-placeholder { color: #aaa; text-align: center; padding: 4rem 1rem; font-size: 0.9rem; }
+
+    .status-bar { display: none; padding: 0.55rem 0.9rem; border-radius: 4px; font-size: 0.85rem; margin-bottom: 1rem; }
+    .status-bar.success { background: #e6f4ea; color: #1e6e34; display: block; }
+    .status-bar.error   { background: #fde8e8; color: #8a0000; display: block; }
+
+    .section-title { font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: #666; padding: 0.5rem 0 0.4rem; border-bottom: 1px solid #eee; margin-bottom: 0.9rem; }
+
+    .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.85rem 1.25rem; }
+    .field label { display: block; font-size: 0.78rem; font-weight: 600; color: #555; margin-bottom: 0.25rem; text-transform: uppercase; letter-spacing: 0.03em; }
+    .field input[type="text"], .field input[type="number"] {
+        width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #ccc;
+        border-radius: 4px; font-size: 0.875rem; font-family: inherit; background: #fff;
+    }
+    .field input:focus { outline: 2px solid #1a1a2e; outline-offset: 1px; border-color: transparent; }
+    .field-hint { font-size: 0.75rem; color: #888; margin-top: 0.2rem; }
+
+    .value-row { display: flex; gap: 0.5rem; align-items: center; }
+    .value-row input { flex: 1; }
+    .color-swatch-lg {
+        width: 36px; height: 36px; border-radius: 4px; flex-shrink: 0;
+        border: 1px solid #ccc; background: #000;
+    }
+
+    .preview-section { margin-top: 1.25rem; padding-top: 1rem; border-top: 1px solid #eee; }
+    .preview-section h3 { font-size: 0.82rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: #555; margin-bottom: 0.5rem; }
+    .preview-output {
+        font-family: monospace; font-size: 1rem; padding: 0.6rem 0.8rem;
+        background: #000; border-radius: 4px; color: #ccc; min-height: 2.4rem;
+        display: flex; align-items: center; gap: 0.5rem;
+    }
+    .preview-swatch { width: 22px; height: 22px; border-radius: 3px; border: 1px solid rgba(255,255,255,0.2); flex-shrink: 0; }
+    .preview-sample { font-size: 0.95rem; }
+
+    .btn-row { display: flex; gap: 0.6rem; margin-top: 1.25rem; }
+    .btn-save { padding: 0.45rem 1.2rem; background: #1a1a2e; color: #fff; border: none; border-radius: 4px; font-size: 0.875rem; font-weight: 600; cursor: pointer; }
+    .btn-save:hover { background: #2d2d4e; }
+    .btn-delete { padding: 0.45rem 1rem; background: #fff; color: #8a0000; border: 1px solid #e0a0a0; border-radius: 4px; font-size: 0.875rem; font-weight: 600; cursor: pointer; }
+    .btn-delete:hover { background: #fde8e8; }
+</style>
+
+<h1>Color Aliases</h1>
+<p class="subtitle">Manage named ANSI color aliases used in game templates and markup. <a href="/admin/color-aliases-api">API Docs &rarr;</a></p>
+
+<div class="page-layout">
+    <div class="sidebar">
+        <div class="sidebar-header">
+            <input type="search" id="aliasSearch" placeholder="Search aliases…" oninput="filterAliases()" />
+        </div>
+        <div id="aliasList" class="alias-list">
+            <div class="no-aliases">Loading…</div>
+        </div>
+        <button class="btn-new" onclick="newAlias()">+ New Alias</button>
+    </div>
+
+    <div class="editor-panel">
+        <div id="editorPlaceholder" class="editor-placeholder">Select an alias to edit, or click "New Alias".</div>
+        <div id="editorForm" style="display:none">
+            <div id="statusBar" class="status-bar"></div>
+            <p class="section-title" id="editorTitle">Edit Alias</p>
+
+            <div class="form-grid">
+                <div class="field">
+                    <label for="fieldName">Alias Name</label>
+                    <input type="text" id="fieldName" placeholder="e.g. username" />
+                    <div class="field-hint" id="nameHint"></div>
+                </div>
+
+                <div class="field">
+                    <label for="fieldValue">ANSI Color Code (0–255)</label>
+                    <div class="value-row">
+                        <input type="number" id="fieldValue" min="0" max="255" placeholder="0–255" oninput="updatePreview()" />
+                        <div class="color-swatch-lg" id="valueSwatch"></div>
+                    </div>
+                    <div class="field-hint">Enter a numeric ANSI 256-color code.</div>
+                </div>
+            </div>
+
+            <div class="preview-section">
+                <h3>Preview</h3>
+                <div class="preview-output" id="previewOutput">
+                    <div class="preview-swatch" id="previewSwatch"></div>
+                    <span class="preview-sample" id="previewSample"></span>
+                </div>
+            </div>
+
+            <div class="btn-row">
+                <button class="btn-save" onclick="saveAlias()">Save</button>
+                <button class="btn-delete" id="btnDelete" onclick="deleteAlias()" style="display:none">Delete</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+let aliasData = {};   // name -> numeric code
+let activeName = null;
+let isNew = false;
+
+// ---- Load ----
+async function loadAliases() {
+    const res = await AdminAPI.get('/admin/api/v1/color-aliases');
+    if (!res.ok) { console.error('Load failed:', res.error); return; }
+    const raw = (res.data && res.data.data) || {};
+    // Normalise: values may arrive as int or string (named alias references).
+    // Only keep numeric entries for display; string refs are internal.
+    aliasData = {};
+    for (const [k, v] of Object.entries(raw)) {
+        const n = parseInt(v, 10);
+        if (!isNaN(n)) aliasData[k] = n;
+    }
+    renderList();
+}
+
+function filterAliases() {
+    const q = document.getElementById('aliasSearch').value.toLowerCase();
+    document.querySelectorAll('.alias-row').forEach(row => {
+        row.style.display = row.dataset.name.includes(q) ? '' : 'none';
+    });
+}
+
+function renderList() {
+    const list = document.getElementById('aliasList');
+    const names = Object.keys(aliasData).sort();
+    if (names.length === 0) {
+        list.innerHTML = '<div class="no-aliases">No aliases found.</div>';
+        return;
+    }
+    list.innerHTML = names.map(name => {
+        const code = aliasData[name];
+        const hex = AnsiColors.toHex(code);
+        const isActive = name === activeName;
+        return `<div class="alias-row${isActive ? ' active' : ''}" data-name="${escAttr(name)}" onclick="selectAlias(${JSON.stringify(name)})">
+            <div class="alias-swatch" style="background:${hex}"></div>
+            <span class="alias-name">${escHtml(name)}</span>
+            <span class="alias-value">${code}</span>
+        </div>`;
+    }).join('');
+}
+
+function highlightRow(name) {
+    document.querySelectorAll('.alias-row').forEach(r => r.classList.remove('active'));
+    const row = document.querySelector(`.alias-row[data-name="${escAttr(name)}"]`);
+    if (row) {
+        row.classList.add('active');
+        row.scrollIntoView({ block: 'nearest' });
+    }
+}
+
+// ---- Select / New ----
+function selectAlias(name) {
+    activeName = name;
+    isNew = false;
+    highlightRow(name);
+    showEditor(name, aliasData[name]);
+}
+
+function newAlias() {
+    activeName = null;
+    isNew = true;
+    document.querySelectorAll('.alias-row').forEach(r => r.classList.remove('active'));
+    showEditor('', null);
+}
+
+function showEditor(name, code) {
+    document.getElementById('editorPlaceholder').style.display = 'none';
+    document.getElementById('editorForm').style.display = '';
+    document.getElementById('statusBar').className = 'status-bar';
+    document.getElementById('fieldName').value = name;
+    document.getElementById('fieldName').readOnly = !isNew;
+    document.getElementById('nameHint').textContent = isNew ? '' : 'Name cannot be changed. Delete and recreate to rename.';
+    document.getElementById('editorTitle').textContent = isNew ? 'New Alias' : 'Edit: ' + name;
+    document.getElementById('fieldValue').value = code !== null && code !== undefined ? code : '';
+    document.getElementById('btnDelete').style.display = isNew ? 'none' : '';
+    updatePreview();
+}
+
+// ---- Preview ----
+function updatePreview() {
+    const code = parseInt(document.getElementById('fieldValue').value, 10);
+    if (isNaN(code) || code < 0 || code > 255) {
+        document.getElementById('valueSwatch').style.background = '#000';
+        document.getElementById('previewSwatch').style.background = '#333';
+        document.getElementById('previewSample').innerHTML = '<span style="color:#666">Enter a valid code (0–255)</span>';
+        return;
+    }
+    const hex = AnsiColors.toHex(code);
+    document.getElementById('valueSwatch').style.background = hex;
+    document.getElementById('previewSwatch').style.background = hex;
+
+    const name = document.getElementById('fieldName').value || 'alias-name';
+    document.getElementById('previewSample').innerHTML =
+        ansitags.parse('<ansi fg="' + code + '">The quick brown fox — code ' + escHtml(String(code)) + '</ansi>');
+}
+
+// ---- Save / Delete ----
+async function saveAlias() {
+    const name = document.getElementById('fieldName').value.trim();
+    const code = parseInt(document.getElementById('fieldValue').value, 10);
+
+    if (!name) { showStatus('error', 'Alias name is required.'); return; }
+    if (isNaN(code) || code < 0 || code > 255) { showStatus('error', 'Color code must be 0–255.'); return; }
+
+    const res = await AdminAPI.patch('/admin/api/v1/color-aliases', { alias: name, value: code });
+    if (!res.ok) { showStatus('error', res.error || 'Save failed.'); return; }
+
+    aliasData[name] = code;
+    if (isNew) {
+        activeName = name;
+        isNew = false;
+        document.getElementById('fieldName').readOnly = true;
+        document.getElementById('nameHint').textContent = 'Name cannot be changed. Delete and recreate to rename.';
+        document.getElementById('editorTitle').textContent = 'Edit: ' + name;
+        document.getElementById('btnDelete').style.display = '';
+    }
+    renderList();
+    highlightRow(name);
+    showStatus('success', 'Alias "' + name + '" saved.');
+}
+
+async function deleteAlias() {
+    if (!activeName) return;
+    if (!confirm('Delete alias "' + activeName + '"? This cannot be undone.')) return;
+
+    const res = await AdminAPI.delete('/admin/api/v1/color-aliases/' + encodeURIComponent(activeName));
+    if (!res.ok) { showStatus('error', res.error || 'Delete failed.'); return; }
+
+    delete aliasData[activeName];
+    activeName = null;
+    renderList();
+    document.getElementById('editorForm').style.display = 'none';
+    document.getElementById('editorPlaceholder').style.display = '';
+}
+
+function showStatus(type, msg) {
+    const bar = document.getElementById('statusBar');
+    bar.className = 'status-bar ' + type;
+    bar.textContent = msg;
+    if (type === 'success') setTimeout(() => { bar.className = 'status-bar'; }, 3000);
+}
+
+function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+function escAttr(s) { return String(s).replace(/"/g,'&quot;'); }
+
+loadAliases();
+</script>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/color-tester.html
+++ b/_datafiles/html/admin/color-tester.html
@@ -1,0 +1,598 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    /* ── Main layout ── */
+    .tester-layout { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start; }
+    @media (max-width: 900px) { .tester-layout { grid-template-columns: 1fr; } }
+
+    .panel { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 1.25rem; }
+    .panel-title {
+        font-size: 0.78rem; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 0.06em; color: #666; padding-bottom: 0.5rem;
+        border-bottom: 1px solid #eee; margin-bottom: 0.9rem;
+    }
+
+    /* ── Editor ── */
+    .editor-toolbar { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.6rem; align-items: center; }
+    .btn-colorize {
+        padding: 0.38rem 0.9rem; background: #1a1a2e; color: #fff; border: none;
+        border-radius: 4px; font-size: 0.82rem; font-weight: 600; cursor: pointer;
+        display: flex; align-items: center; gap: 0.4rem;
+    }
+    .btn-colorize:hover { background: #2d2d4e; }
+    .btn-colorize .icon { font-size: 0.95rem; }
+    .btn-strip {
+        padding: 0.38rem 0.9rem; background: #fff; color: #555; border: 1px solid #ccc;
+        border-radius: 4px; font-size: 0.82rem; font-weight: 600; cursor: pointer;
+    }
+    .btn-strip:hover { background: #f0f0f0; }
+    .toolbar-hint { font-size: 0.75rem; color: #999; margin-left: auto; }
+
+    #sourceInput {
+        width: 100%; min-height: 120px; padding: 0.55rem 0.7rem;
+        border: 1px solid #ccc; border-radius: 4px; font-family: monospace;
+        font-size: 0.85rem; line-height: 1.55; resize: vertical; background: #fafafa;
+    }
+    #sourceInput:focus { outline: 2px solid #1a1a2e; outline-offset: 1px; border-color: transparent; background: #fff; }
+
+    /* ── Preview ── */
+    #previewOutput {
+        min-height: 120px; padding: 0.65rem 0.8rem;
+        background: #000; border-radius: 4px; color: #ccc;
+        font-family: monospace; font-size: 0.95rem; line-height: 1.6;
+        white-space: pre-wrap; word-break: break-word;
+    }
+    .preview-empty { color: #444; font-style: italic; }
+
+    /* ── Colorize modal ── */
+    .ct-overlay {
+        display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.5);
+        align-items: center; justify-content: center; z-index: 9999;
+    }
+    .ct-overlay.open { display: flex; }
+    .ct-modal {
+        background: #fff; border-radius: 8px; box-shadow: 0 8px 40px rgba(0,0,0,0.3);
+        width: 560px; max-width: 96vw; max-height: 90vh;
+        display: flex; flex-direction: column; overflow: hidden;
+    }
+    .ct-modal-header {
+        padding: 0.85rem 1.1rem 0.7rem; border-bottom: 1px solid #e5e5e5;
+        display: flex; align-items: center; justify-content: space-between; flex-shrink: 0;
+    }
+    .ct-modal-title { font-size: 1rem; font-weight: 700; color: #1a1a2e; }
+    .ct-modal-close { background: none; border: none; font-size: 1.3rem; cursor: pointer; color: #888; line-height: 1; }
+    .ct-modal-close:hover { color: #333; }
+
+    .ct-modal-body { overflow-y: auto; padding: 1rem 1.1rem; flex: 1; }
+
+    /* Selection preview strip */
+    .ct-selection-strip {
+        background: #000; border-radius: 4px; padding: 0.45rem 0.7rem;
+        font-family: monospace; font-size: 0.9rem; color: #ccc;
+        margin-bottom: 1rem; min-height: 2rem; word-break: break-all;
+    }
+    .ct-selection-label { font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #888; margin-bottom: 0.3rem; }
+
+    /* FG / BG pickers */
+    .ct-pickers { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+    .ct-picker-section {
+        border: 2px solid transparent; border-radius: 6px;
+        padding: 0.6rem 0.7rem; cursor: pointer; transition: border-color 0.12s, background 0.12s;
+    }
+    .ct-picker-section:hover { background: #f9f9ff; }
+    .ct-picker-section.active-fg { border-color: #1a1a2e; background: #f0f2ff; cursor: default; }
+    .ct-picker-section.active-bg { border-color: #666; background: #f5f5f5; cursor: default; }
+    .ct-picker-label {
+        font-size: 0.78rem; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 0.05em; color: #555; margin-bottom: 0.5rem;
+        display: flex; align-items: center; gap: 0.5rem; pointer-events: none;
+    }
+    .ct-picker-badge {
+        font-size: 0.65rem; padding: 0.1rem 0.4rem; border-radius: 3px;
+        font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .ct-badge-fg { background: #1a1a2e; color: #fff; }
+    .ct-badge-bg { background: #555; color: #fff; }
+
+    .ct-color-input-row { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 0.5rem; }
+    .ct-color-input-row input[type="number"] {
+        width: 70px; padding: 0.35rem 0.5rem; border: 1px solid #ccc;
+        border-radius: 4px; font-size: 0.85rem; font-family: monospace;
+    }
+    .ct-color-input-row input:focus { outline: 2px solid #1a1a2e; outline-offset: 1px; border-color: transparent; }
+    .ct-swatch-lg { width: 30px; height: 30px; border-radius: 4px; border: 1px solid #ccc; background: #000; flex-shrink: 0; }
+    .ct-clear-btn {
+        font-size: 0.75rem; padding: 0.25rem 0.5rem; border: 1px solid #ccc;
+        background: #fff; border-radius: 3px; cursor: pointer; color: #555;
+    }
+    .ct-clear-btn:hover { background: #f0f0f0; }
+
+    /* Alias list */
+    .ct-alias-section { margin-bottom: 0.75rem; }
+    .ct-alias-title {
+        font-size: 0.75rem; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 0.04em; color: #888; margin-bottom: 0.4rem;
+    }
+    .ct-alias-search-wrap { margin-bottom: 0.4rem; }
+    .ct-alias-search {
+        width: 100%; padding: 0.32rem 0.55rem; border: 1px solid #ccc;
+        border-radius: 4px; font-size: 0.82rem;
+    }
+    .ct-alias-search:focus { outline: 2px solid #1a1a2e; outline-offset: 1px; border-color: transparent; }
+    .ct-alias-list {
+        max-height: 180px; overflow-y: auto;
+        border: 1px solid #e8e8e8; border-radius: 4px;
+    }
+    .ct-alias-row {
+        display: flex; align-items: center; gap: 0.6rem;
+        padding: 0.3rem 0.6rem; cursor: pointer;
+        border-bottom: 1px solid #f2f2f2; user-select: none;
+    }
+    .ct-alias-row:last-child { border-bottom: none; }
+    .ct-alias-row:hover { background: #f5f7ff; }
+    .ct-alias-row.sel-fg { background: #1a1a2e; color: #fff; }
+    .ct-alias-row.sel-bg { background: #555; color: #fff; }
+    .ct-alias-row.sel-both { background: linear-gradient(90deg, #1a1a2e 50%, #555 50%); color: #fff; }
+    .ct-alias-swatch {
+        width: 28px; height: 20px; border-radius: 3px; flex-shrink: 0;
+        border: 1px solid rgba(0,0,0,0.12);
+    }
+    .ct-alias-name { flex: 1; font-size: 0.82rem; font-family: monospace; }
+    .ct-alias-code {
+        font-size: 0.72rem; font-family: monospace; color: #aaa;
+        flex-shrink: 0;
+    }
+    .ct-alias-row.sel-fg .ct-alias-code,
+    .ct-alias-row.sel-bg .ct-alias-code,
+    .ct-alias-row.sel-both .ct-alias-code { color: rgba(255,255,255,0.6); }
+    .ct-alias-sel-badges { display: flex; gap: 0.25rem; flex-shrink: 0; }
+    .ct-sel-badge {
+        font-size: 0.6rem; font-weight: 700; padding: 0.1rem 0.3rem;
+        border-radius: 2px; text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .ct-sel-badge-fg { background: rgba(255,255,255,0.25); color: #fff; }
+    .ct-sel-badge-bg { background: rgba(255,255,255,0.25); color: #fff; }
+    .ct-alias-empty { padding: 0.8rem; text-align: center; color: #aaa; font-size: 0.82rem; font-style: italic; }
+
+    /* 256-color palette grid */
+    .ct-palette-section { margin-bottom: 0.75rem; }
+    .ct-palette-title {
+        font-size: 0.75rem; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 0.04em; color: #888; margin-bottom: 0.5rem;
+    }
+    .ct-palette {
+        display: flex; flex-wrap: wrap; gap: 2px;
+    }
+    .ct-palette-cell {
+        width: 18px; height: 18px; border-radius: 2px; cursor: pointer;
+        border: 2px solid transparent; flex-shrink: 0;
+        transition: transform 0.08s;
+    }
+    .ct-palette-cell:hover { transform: scale(1.35); border-color: rgba(255,255,255,0.6); z-index: 1; position: relative; }
+    .ct-palette-cell.ring-fg { border-color: #fff; box-shadow: 0 0 0 2px #1a1a2e; }
+    .ct-palette-cell.ring-bg { border-color: #fff; box-shadow: 0 0 0 2px #888; }
+
+    /* Live result preview inside modal */
+    .ct-result-preview {
+        background: #000; border-radius: 4px; padding: 0.45rem 0.7rem;
+        font-family: monospace; font-size: 0.9rem; color: #ccc;
+        margin-top: 0.75rem; min-height: 2rem; word-break: break-all;
+    }
+    .ct-result-label { font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #888; margin-bottom: 0.3rem; margin-top: 0.75rem; }
+
+    .ct-modal-footer {
+        padding: 0.7rem 1.1rem; border-top: 1px solid #eee;
+        display: flex; justify-content: flex-end; gap: 0.5rem; flex-shrink: 0;
+    }
+    .ct-btn {
+        padding: 0.42rem 1.1rem; border-radius: 4px; font-size: 0.85rem;
+        font-weight: 600; cursor: pointer; border: 1px solid transparent;
+    }
+    .ct-btn-cancel { background: #f0f0f0; color: #444; border-color: #ccc; }
+    .ct-btn-cancel:hover { background: #e5e5e5; }
+    .ct-btn-apply { background: #1a1a2e; color: #fff; }
+    .ct-btn-apply:hover { background: #2d2d4e; }
+    .ct-btn-apply:disabled { background: #999; cursor: not-allowed; }
+</style>
+
+<h1>Color Tester</h1>
+<p class="subtitle">Compose and preview ANSI-tagged text with the live renderer.</p>
+
+<div class="tester-layout">
+    <!-- Left: editor -->
+    <div class="panel">
+        <div class="panel-title">Source</div>
+        <div class="editor-toolbar">
+            <button class="btn-colorize" onclick="openColorizeModal()">
+                <span class="icon">&#9998;</span> Colorize Selection
+            </button>
+            <button class="btn-strip" onclick="stripTags()">&#10006; Strip Tags</button>
+            <span class="toolbar-hint">Select text, then click Colorize</span>
+        </div>
+        <textarea id="sourceInput" spellcheck="false" placeholder="Type your text here, e.g.&#10;<ansi fg=&quot;username&quot;>Hello</ansi>, <ansi fg=&quot;gold&quot;>world</ansi>!" oninput="renderPreview()"></textarea>
+    </div>
+
+    <!-- Right: preview -->
+    <div class="panel">
+        <div class="panel-title">Preview</div>
+        <div id="previewOutput"><span class="preview-empty">Preview will appear here…</span></div>
+    </div>
+</div>
+
+<!-- Colorize modal -->
+<div class="ct-overlay" id="ctOverlay" onclick="if(event.target===this)closeModal()">
+    <div class="ct-modal">
+        <div class="ct-modal-header">
+            <span class="ct-modal-title">Colorize Selection</span>
+            <button class="ct-modal-close" onclick="closeModal()">&#215;</button>
+        </div>
+        <div class="ct-modal-body">
+            <div class="ct-selection-label">Selected text</div>
+            <div class="ct-selection-strip" id="ctSelectionPreview"></div>
+
+            <div class="ct-pickers">
+                <div class="ct-picker-section" id="fgSection" onclick="setActiveTarget('fg')">
+                    <div class="ct-picker-label">
+                        <span class="ct-picker-badge ct-badge-fg">FG</span> Foreground
+                    </div>
+                    <div class="ct-color-input-row">
+                        <input type="number" id="fgInput" min="0" max="255" placeholder="0&#8211;255" oninput="onFgInput()" onclick="event.stopPropagation()" />
+                        <div class="ct-swatch-lg" id="fgSwatch"></div>
+                        <button class="ct-clear-btn" onclick="event.stopPropagation();clearFg()">None</button>
+                    </div>
+                </div>
+                <div class="ct-picker-section" id="bgSection" onclick="setActiveTarget('bg')">
+                    <div class="ct-picker-label">
+                        <span class="ct-picker-badge ct-badge-bg">BG</span> Background
+                    </div>
+                    <div class="ct-color-input-row">
+                        <input type="number" id="bgInput" min="0" max="255" placeholder="0&#8211;255" oninput="onBgInput()" onclick="event.stopPropagation()" />
+                        <div class="ct-swatch-lg" id="bgSwatch"></div>
+                        <button class="ct-clear-btn" onclick="event.stopPropagation();clearBg()">None</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Alias list -->
+            <div class="ct-alias-section">
+                <div class="ct-alias-title">Color Aliases</div>
+                <div class="ct-alias-search-wrap">
+                    <input type="search" class="ct-alias-search" id="ctAliasSearch" placeholder="Search aliases…" oninput="filterAliasRows()" />
+                </div>
+                <div class="ct-alias-list" id="ctAliasGrid"></div>
+            </div>
+
+            <!-- 256-color palette -->
+            <div class="ct-palette-section">
+                <div class="ct-palette-title">256-Color Palette &mdash; click to apply to active channel</div>
+                <div class="ct-palette" id="ctPalette"></div>
+            </div>
+
+            <div class="ct-result-label">Result preview</div>
+            <div class="ct-result-preview" id="ctResultPreview"></div>
+        </div>
+        <div class="ct-modal-footer">
+            <button class="ct-btn ct-btn-cancel" onclick="closeModal()">Cancel</button>
+            <button class="ct-btn ct-btn-apply" id="ctApplyBtn" onclick="applyColorize()">Apply</button>
+        </div>
+    </div>
+</div>
+
+<script>
+// ── State ──────────────────────────────────────────────────────────────────
+var aliasData = {};       // name -> numeric code
+var selStart = 0;
+var selEnd = 0;
+var selText = '';
+var pendingFg = null;     // null | integer 0-255 (palette/numeric) | string (alias name)
+var pendingBg = null;
+var activeTarget = 'fg';  // 'fg' or 'bg'
+
+// ── Boot ──────────────────────────────────────────────────────────────────
+async function init() {
+    const res = await AdminAPI.get('/admin/api/v1/color-aliases');
+    if (res.ok) {
+        const raw = (res.data && res.data.data) || {};
+        for (const [k, v] of Object.entries(raw)) {
+            const n = parseInt(v, 10);
+            if (!isNaN(n)) aliasData[k] = n;
+        }
+        ansitags.loadAliases(aliasData);
+    }
+    buildPalette();
+    renderPreview();
+}
+
+// ── Live preview ───────────────────────────────────────────────────────────
+function renderPreview() {
+    const src = document.getElementById('sourceInput').value;
+    const out = document.getElementById('previewOutput');
+    if (!src.trim()) {
+        out.innerHTML = '<span class="preview-empty">Preview will appear here\u2026</span>';
+        return;
+    }
+    out.innerHTML = ansitags.parse(src);
+}
+
+// ── Strip tags ─────────────────────────────────────────────────────────────
+function stripTags() {
+    const ta = document.getElementById('sourceInput');
+    ta.value = ansitags.parse(ta.value, { stripTags: true });
+    renderPreview();
+}
+
+// ── Colorize modal ─────────────────────────────────────────────────────────
+function openColorizeModal() {
+    const ta = document.getElementById('sourceInput');
+    selStart = ta.selectionStart;
+    selEnd   = ta.selectionEnd;
+    selText  = ta.value.slice(selStart, selEnd);
+
+    pendingFg = null;
+    pendingBg = null;
+    activeTarget = 'fg';
+
+    // Selection preview
+    document.getElementById('ctSelectionPreview').innerHTML =
+        selText ? ansitags.parse(selText) : '<span style="color:#555;font-style:italic">No text selected — tag will wrap the entire input</span>';
+
+    // Reset inputs
+    document.getElementById('fgInput').value = '';
+    document.getElementById('bgInput').value = '';
+    updateFgSwatch();
+    updateBgSwatch();
+    updateSectionBorders();
+
+    buildAliasGrid();
+    updateResultPreview();
+
+    document.getElementById('ctOverlay').classList.add('open');
+    document.getElementById('fgInput').focus();
+}
+
+function closeModal() {
+    document.getElementById('ctOverlay').classList.remove('open');
+}
+
+// ── Active target toggle ──────────────────────────────────────────────────
+function setActiveTarget(target) {
+    activeTarget = target;
+    updateSectionBorders();
+}
+
+function updateSectionBorders() {
+    document.getElementById('fgSection').classList.toggle('active-fg', activeTarget === 'fg');
+    document.getElementById('fgSection').classList.remove('active-bg');
+    document.getElementById('bgSection').classList.toggle('active-bg', activeTarget === 'bg');
+    document.getElementById('bgSection').classList.remove('active-fg');
+}
+
+// ── FG / BG input handlers ─────────────────────────────────────────────────
+function onFgInput() {
+    const v = parseInt(document.getElementById('fgInput').value, 10);
+    pendingFg = (!isNaN(v) && v >= 0 && v <= 255) ? v : null;
+    updateFgSwatch();
+    syncPaletteRings();
+    syncAliasChips();
+    updateResultPreview();
+}
+
+function onBgInput() {
+    const v = parseInt(document.getElementById('bgInput').value, 10);
+    pendingBg = (!isNaN(v) && v >= 0 && v <= 255) ? v : null;
+    updateBgSwatch();
+    syncPaletteRings();
+    syncAliasChips();
+    updateResultPreview();
+}
+
+function clearFg() {
+    pendingFg = null;
+    document.getElementById('fgInput').value = '';
+    updateFgSwatch();
+    syncPaletteRings();
+    syncAliasChips();
+    updateResultPreview();
+}
+
+function clearBg() {
+    pendingBg = null;
+    document.getElementById('bgInput').value = '';
+    updateBgSwatch();
+    syncPaletteRings();
+    syncAliasChips();
+    updateResultPreview();
+}
+
+// Returns the CSS hex for a pending value (int or alias string).
+function pendingToHex(val) {
+    if (val === null) return null;
+    if (typeof val === 'string') {
+        const n = aliasData[val];
+        return n !== undefined ? AnsiColors.toHex(n) : '#888';
+    }
+    return AnsiColors.toHex(val);
+}
+
+function updateFgSwatch() {
+    const sw = document.getElementById('fgSwatch');
+    const hex = pendingToHex(pendingFg);
+    sw.style.background = hex || '#1a1a1a';
+    sw.style.borderColor = pendingFg !== null ? '#aaa' : '#ccc';
+}
+
+function updateBgSwatch() {
+    const sw = document.getElementById('bgSwatch');
+    const hex = pendingToHex(pendingBg);
+    sw.style.background = hex || '#1a1a1a';
+    sw.style.borderColor = pendingBg !== null ? '#aaa' : '#ccc';
+}
+
+// ── Alias chips ────────────────────────────────────────────────────────────
+function buildAliasGrid() {
+    const grid = document.getElementById('ctAliasGrid');
+    const search = document.getElementById('ctAliasSearch');
+    if (search) search.value = '';
+    renderAliasRows('');
+}
+
+function renderAliasRows(filter) {
+    const grid = document.getElementById('ctAliasGrid');
+    const q = filter.toLowerCase();
+    const names = Object.keys(aliasData).sort().filter(n => !q || n.includes(q));
+    if (names.length === 0) {
+        grid.innerHTML = '<div class="ct-alias-empty">No aliases match.</div>';
+        return;
+    }
+    grid.innerHTML = names.map(name => {
+        const code = aliasData[name];
+        const hex  = AnsiColors.toHex(code);
+        const isFg = pendingFg === name;
+        const isBg = pendingBg === name;
+        var rowCls = 'ct-alias-row';
+        if (isFg && isBg) rowCls += ' sel-both';
+        else if (isFg)   rowCls += ' sel-fg';
+        else if (isBg)   rowCls += ' sel-bg';
+        var badges = '';
+        if (isFg) badges += '<span class="ct-sel-badge ct-sel-badge-fg">FG</span>';
+        if (isBg) badges += '<span class="ct-sel-badge ct-sel-badge-bg">BG</span>';
+        return '<div class="' + rowCls + '" data-code="' + code + '" data-name="' + escAttr(name) + '" onclick="aliasClick(event,this)">' +
+            '<div class="ct-alias-swatch" style="background:' + hex + '"></div>' +
+            '<span class="ct-alias-name">' + escHtml(name) + '</span>' +
+            (badges ? '<span class="ct-alias-sel-badges">' + badges + '</span>' : '') +
+            '<span class="ct-alias-code">' + code + '</span>' +
+        '</div>';
+    }).join('');
+}
+
+function filterAliasRows() {
+    const q = document.getElementById('ctAliasSearch').value;
+    renderAliasRows(q);
+}
+
+function aliasClick(event, row) {
+    const name = row.dataset.name;
+    if (activeTarget === 'bg') {
+        pendingBg = (pendingBg === name) ? null : name;
+        // Clear the numeric input — alias takes precedence
+        document.getElementById('bgInput').value = '';
+        updateBgSwatch();
+    } else {
+        pendingFg = (pendingFg === name) ? null : name;
+        document.getElementById('fgInput').value = '';
+        updateFgSwatch();
+    }
+    syncPaletteRings();
+    syncAliasChips();
+    updateResultPreview();
+}
+
+function syncAliasChips() {
+    renderAliasRows(document.getElementById('ctAliasSearch') ? document.getElementById('ctAliasSearch').value : '');
+}
+
+// ── 256-color palette ──────────────────────────────────────────────────────
+function buildPalette() {
+    const palette = document.getElementById('ctPalette');
+    if (!palette) return;
+    var html = '';
+    for (var i = 0; i < 256; i++) {
+        const hex = AnsiColors.toHex(i);
+        html += '<div class="ct-palette-cell" data-code="' + i + '" style="background:' + hex + '" onclick="paletteClick(event,this)" title="' + i + '"></div>';
+    }
+    palette.innerHTML = html;
+}
+
+function paletteClick(event, cell) {
+    const code = parseInt(cell.dataset.code, 10);
+    if (activeTarget === 'bg') {
+        pendingBg = (pendingBg === code) ? null : code;
+        document.getElementById('bgInput').value = pendingBg !== null ? pendingBg : '';
+        updateBgSwatch();
+    } else {
+        pendingFg = (pendingFg === code) ? null : code;
+        document.getElementById('fgInput').value = pendingFg !== null ? pendingFg : '';
+        updateFgSwatch();
+    }
+    syncPaletteRings();
+    syncAliasChips();
+    updateResultPreview();
+}
+
+// Returns the numeric code for palette ring comparison (aliases resolve via aliasData).
+function pendingToCode(val) {
+    if (val === null) return null;
+    if (typeof val === 'string') return aliasData[val] !== undefined ? aliasData[val] : null;
+    return val;
+}
+
+function syncPaletteRings() {
+    const fgCode = pendingToCode(pendingFg);
+    const bgCode = pendingToCode(pendingBg);
+    document.querySelectorAll('.ct-palette-cell').forEach(function(cell) {
+        const code = parseInt(cell.dataset.code, 10);
+        cell.classList.toggle('ring-fg', fgCode === code && typeof pendingFg === 'number');
+        cell.classList.toggle('ring-bg', bgCode === code && typeof pendingBg === 'number');
+    });
+}
+
+// ── Result preview inside modal ────────────────────────────────────────────
+function updateResultPreview() {
+    const preview = document.getElementById('ctResultPreview');
+    const target  = selText || '(entire input)';
+    const tag     = buildTag(target);
+    preview.innerHTML = ansitags.parse(tag);
+
+    const canApply = pendingFg !== null || pendingBg !== null;
+    document.getElementById('ctApplyBtn').disabled = !canApply;
+}
+
+function buildTag(inner) {
+    if (pendingFg === null && pendingBg === null) return escHtml(inner);
+    var attrs = '';
+    if (pendingFg !== null) attrs += ' fg="' + pendingFg + '"';
+    if (pendingBg !== null) attrs += ' bg="' + pendingBg + '"';
+    return '<ansi' + attrs + '>' + inner + '</ansi>';
+}
+
+// ── Apply ──────────────────────────────────────────────────────────────────
+function applyColorize() {
+    if (pendingFg === null && pendingBg === null) return;
+
+    const ta   = document.getElementById('sourceInput');
+    const text = ta.value;
+    const target = selText || text;
+    const start  = selText ? selStart : 0;
+    const end    = selText ? selEnd   : text.length;
+
+    var attrs = '';
+    if (pendingFg !== null) attrs += ' fg="' + pendingFg + '"';
+    if (pendingBg !== null) attrs += ' bg="' + pendingBg + '"';
+    const wrapped = '<ansi' + attrs + '>' + target + '</ansi>';
+
+    ta.value = text.slice(0, start) + wrapped + text.slice(end);
+
+    // Restore cursor after the inserted tag
+    const newPos = start + wrapped.length;
+    ta.setSelectionRange(newPos, newPos);
+    ta.focus();
+
+    renderPreview();
+    closeModal();
+}
+
+// ── Keyboard shortcut: Escape closes modal ─────────────────────────────────
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') closeModal();
+});
+
+function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+function escAttr(s) { return String(s).replace(/"/g,'&quot;'); }
+
+init();
+</script>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/items-api.html
+++ b/_datafiles/html/admin/items-api.html
@@ -40,7 +40,7 @@
 </style>
 
 <h1>Items API Reference</h1>
-<p class="subtitle">REST endpoints for browsing, creating, editing, and deleting item definitions.</p>
+<p class="subtitle">REST endpoints for browsing, creating, editing, and deleting item definitions. For attack message endpoints see <a href="/admin/items-attack-messages-api">Attack Messages API Docs</a>.</p>
 
 <div class="api-list">
 
@@ -58,25 +58,6 @@
                 <details class="resp-entry">
                     <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
                     <div class="resp-body"><div class="curl-block">{"success":true,"data":{"subtypes":[...],"types":[{"Type":"weapon","Description":"...","Count":0,"MinItemId":10000,"MaxItemId":19999},...]}}</div></div>
-                </details>
-            </div>
-        </div>
-    </details>
-
-    <details class="api-entry">
-        <summary>
-            <span class="method method-get">GET</span>
-            <span class="api-path">/admin/api/v1/items/attack-messages</span>
-            <span class="api-desc">Return all weapon attack message groups</span>
-        </summary>
-        <div class="api-body">
-            <p>Returns all loaded weapon attack message groups keyed by subtype (generic, slashing, stabbing, etc.).</p>
-            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
-     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/items/attack-messages</span></div>
-            <div class="response-examples">
-                <details class="resp-entry">
-                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
-                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"generic":{"Intensity":{...}},"slashing":{...},...}}</div></div>
                 </details>
             </div>
         </div>

--- a/_datafiles/html/admin/items-attack-messages-api.html
+++ b/_datafiles/html/admin/items-attack-messages-api.html
@@ -1,0 +1,124 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 2rem; font-size: 0.9rem; }
+    .api-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .api-entry { background: #fff; border: 1px solid #ddd; border-radius: 6px; overflow: hidden; }
+    .api-entry summary { display: flex; align-items: baseline; gap: 0.75rem; padding: 0.65rem 1rem; cursor: pointer; user-select: none; list-style: none; }
+    .api-entry summary::-webkit-details-marker { display: none; }
+    .api-entry summary::before { content: "\25B6"; font-size: 0.65rem; color: #888; transition: transform 0.15s; flex-shrink: 0; }
+    .api-entry[open] summary::before { transform: rotate(90deg); }
+    .api-entry summary:hover { background: #fafafa; }
+    .method { font-family: monospace; font-size: 0.8rem; font-weight: 700; padding: 0.15rem 0.45rem; border-radius: 3px; flex-shrink: 0; }
+    .method-get    { background: #e6f4ea; color: #1e6e34; }
+    .method-put    { background: #f3e5f5; color: #6a1b9a; }
+    .method-delete { background: #fde8e8; color: #8a0000; }
+    .api-path { font-family: monospace; font-size: 0.9rem; color: #1a1a2e; }
+    .api-desc { font-size: 0.85rem; color: #555; margin-left: auto; text-align: right; }
+    .api-body { padding: 0.75rem 1rem 1rem; border-top: 1px solid #eee; background: #fafafa; }
+    .api-body p { font-size: 0.85rem; color: #444; margin-bottom: 0.5rem; }
+    .curl-block { background: #1a1a2e; color: #c9d1d9; font-family: monospace; font-size: 0.82rem; padding: 0.85rem 1rem; border-radius: 5px; white-space: pre; overflow-x: auto; line-height: 1.6; margin-bottom: 0.5rem; }
+    .curl-block .kw   { color: #79c0ff; }
+    .curl-block .str  { color: #a5d6ff; }
+    .curl-block .flag { color: #d2a8ff; }
+    .response-examples { margin-top: 1rem; display: flex; flex-direction: column; gap: 0.4rem; }
+    .resp-entry { border: 1px solid #ddd; border-radius: 4px; overflow: hidden; }
+    .resp-entry summary { display: flex; align-items: baseline; gap: 0.6rem; padding: 0.45rem 0.75rem; cursor: pointer; user-select: none; list-style: none; background: #f5f5f5; font-size: 0.82rem; }
+    .resp-entry summary::-webkit-details-marker { display: none; }
+    .resp-entry summary::before { content: "\25B6"; font-size: 0.6rem; color: #888; transition: transform 0.15s; flex-shrink: 0; }
+    .resp-entry[open] summary::before { transform: rotate(90deg); }
+    .resp-entry summary:hover { background: #efefef; }
+    .resp-body { padding: 0.6rem 0.75rem 0.75rem; border-top: 1px solid #eee; background: #fafafa; }
+    .status-ok  { background: #e6f4ea; color: #1e6e34; }
+    .status-err { background: #fde8e8; color: #8a0000; }
+    .resp-label { font-size: 0.8rem; color: #444; }
+</style>
+
+<h1>Attack Messages API Reference</h1>
+<p class="subtitle">REST endpoints for viewing and editing weapon combat messages.</p>
+
+<div class="api-list">
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-get">GET</span>
+            <span class="api-path">/admin/api/v1/items/attack-messages</span>
+            <span class="api-desc">Return all weapon attack message groups</span>
+        </summary>
+        <div class="api-body">
+            <p>Returns every weapon subtype's attack messages, keyed by subtype. Each subtype contains intensities (prepare, wait, miss, weak, normal, heavy, critical), each with Together and Separate proximity groups containing messages by target audience.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/items/attack-messages</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"claws":{"OptionId":"claws","Options":{"prepare":{"Together":{"ToAttacker":["..."],"ToDefender":["..."],"ToRoom":["..."]},"Separate":{...}},...}},...}}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-put">PUT</span>
+            <span class="api-path">/admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}</span>
+            <span class="api-desc">Add a new attack message</span>
+        </summary>
+        <div class="api-body">
+            <p>Appends a new message to the specified subtype, intensity, proximity, and target. The message is saved to the YAML file immediately.</p>
+            <p><strong>Path parameters:</strong></p>
+            <p><code>subtype</code> — weapon subtype (e.g. claws, slashing, generic).<br>
+               <code>intensity</code> — one of: prepare, wait, miss, weak, normal, heavy, critical.<br>
+               <code>proximity</code> — <code>together</code> (same room) or <code>separate</code> (different rooms).<br>
+               <code>target</code> — message audience. Together: toattacker, todefender, toroom. Separate: toattacker, todefender, toattackerroom, todefenderroom.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> <span class="kw">PUT</span> \
+     <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
+     <span class="flag">-d</span> <span class="str">'{"message":"You lunge at &lt;ansi fg=\"{targettype}\"&gt;{target}&lt;/ansi&gt; with your &lt;ansi fg=\"item\"&gt;{itemname}&lt;/ansi&gt;!"}'</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/items/attack-messages/claws/normal/together/toattacker</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">Bad Request</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"unknown subtype: invalid"}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-delete">DELETE</span>
+            <span class="api-path">/admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}/{index}</span>
+            <span class="api-desc">Delete an attack message by index</span>
+        </summary>
+        <div class="api-body">
+            <p>Removes the message at the given zero-based index from the specified location. The change is saved to the YAML file immediately.</p>
+            <p><strong>Path parameters:</strong> Same as PUT, plus <code>index</code> — zero-based position of the message to delete.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> <span class="kw">DELETE</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/items/attack-messages/claws/normal/together/toattacker/2</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">Bad Request — invalid index</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"index 99 out of range (length 3)"}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">Bad Request — unknown subtype</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"unknown subtype: invalid"}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+</div>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/items-attack-messages.html
+++ b/_datafiles/html/admin/items-attack-messages.html
@@ -1,0 +1,535 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .page-layout { display: grid; grid-template-columns: 220px 1fr; gap: 1.25rem; align-items: start; }
+    @media (max-width: 800px) { .page-layout { grid-template-columns: 1fr; } }
+
+    .sidebar { background: #fff; border: 1px solid #ddd; border-radius: 6px; overflow: hidden; }
+    .subtype-list { overflow-y: auto; max-height: 72vh; }
+    .subtype-row {
+        padding: 0.6rem 0.9rem; cursor: pointer; border-bottom: 1px solid #f0f0f0;
+        font-size: 0.875rem; text-transform: capitalize;
+    }
+    .subtype-row:hover { background: #f5f7ff; }
+    .subtype-row.active { background: #1a1a2e; color: #fff; }
+
+    .editor-panel { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 1.25rem; }
+    .editor-placeholder { color: #888; font-size: 0.9rem; padding: 2rem 1rem; text-align: center; }
+
+    .status-bar { display: none; padding: 0.55rem 0.9rem; border-radius: 4px; font-size: 0.85rem; margin-bottom: 1rem; }
+    .status-bar.success { background: #e6f4ea; color: #1e6e34; display: block; }
+    .status-bar.error   { background: #fde8e8; color: #8a0000; display: block; }
+
+    .tab-bar { display: flex; gap: 0; border-bottom: 2px solid #1a1a2e; margin-bottom: 1.25rem; flex-wrap: wrap; }
+    .tab-btn {
+        padding: 0.5rem 0.85rem; border: none; background: #eee; color: #555;
+        font-size: 0.82rem; font-weight: 600; cursor: pointer; border-radius: 4px 4px 0 0;
+        margin-bottom: -2px; border: 2px solid transparent; border-bottom: none;
+    }
+    .tab-btn:hover { background: #e0e0e0; }
+    .tab-btn.active { background: #fff; color: #1a1a2e; border-color: #1a1a2e; }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+
+    .proximity-section { margin-bottom: 1.25rem; }
+    .proximity-header {
+        font-size: 0.82rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+        color: #1a1a2e; padding: 0.5rem 0; border-bottom: 1px solid #ddd; margin-bottom: 0.75rem;
+        cursor: pointer; user-select: none; display: flex; align-items: center; gap: 0.5rem;
+    }
+    .proximity-header .arrow { font-size: 0.6rem; color: #888; transition: transform 0.15s; }
+    .proximity-section.open .arrow { transform: rotate(90deg); }
+    .proximity-body { display: none; }
+    .proximity-section.open .proximity-body { display: block; }
+    .proximity-hint { font-size: 0.75rem; color: #888; font-weight: normal; text-transform: none; letter-spacing: normal; }
+
+    .target-group { margin-bottom: 1rem; padding-left: 0.5rem; }
+    .target-label {
+        font-size: 0.78rem; font-weight: 600; color: #555; margin-bottom: 0.4rem;
+        text-transform: uppercase; letter-spacing: 0.03em;
+    }
+    .msg-list { list-style: none; padding: 0; margin: 0 0 0.4rem 0; }
+    .msg-item {
+        display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.35rem 0;
+        border-bottom: 1px solid #f5f5f5; font-size: 0.84rem;
+    }
+    .msg-index {
+        font-size: 0.72rem; color: #999; font-family: monospace; min-width: 1.5rem;
+        text-align: right; padding-top: 0.15rem; flex-shrink: 0;
+    }
+    .msg-text { flex: 1; word-break: break-word; line-height: 1.4; font-family: monospace; font-size: 0.8rem; }
+    .msg-delete {
+        background: none; border: none; cursor: pointer; color: #bbb; font-size: 1rem; padding: 0 0.2rem;
+        flex-shrink: 0;
+    }
+    .msg-delete:hover { color: #c00; }
+
+    .msg-add-row { display: flex; gap: 0.4rem; margin-top: 0.4rem; }
+    .msg-add-row textarea {
+        flex: 1; padding: 0.35rem 0.5rem; border: 1px solid #ccc; border-radius: 4px;
+        font-size: 0.82rem; font-family: monospace; resize: vertical; min-height: 2.2rem;
+    }
+    .msg-add-row textarea:focus { outline: 2px solid #1a1a2e; outline-offset: 1px; border-color: transparent; }
+    .btn-add {
+        padding: 0.35rem 0.7rem; background: #1e6e34; color: #fff; border: none;
+        border-radius: 4px; font-size: 0.8rem; font-weight: 600; cursor: pointer; align-self: flex-end;
+    }
+    .btn-add:hover { background: #145728; }
+
+    .token-ref { margin-bottom: 1.25rem; }
+    .token-ref summary {
+        font-size: 0.82rem; font-weight: 600; color: #555; cursor: pointer; user-select: none;
+        text-transform: uppercase; letter-spacing: 0.03em;
+    }
+    .token-table { width: 100%; border-collapse: collapse; margin-top: 0.6rem; font-size: 0.8rem; }
+    .token-table th {
+        text-align: left; font-size: 0.72rem; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 0.04em; color: #666; padding: 0.3rem 0.6rem;
+        border-bottom: 2px solid #e0e0e0; white-space: nowrap;
+    }
+    .token-table td { padding: 0.35rem 0.6rem; border-bottom: 1px solid #f0f0f0; vertical-align: top; }
+    .token-table tr:last-child td { border-bottom: none; }
+    .token-table tr:hover td { background: #f9f9ff; }
+    .tok-name { font-family: monospace; color: #1a1a2e; white-space: nowrap; }
+    .tok-resolves { color: #444; }
+    .tok-context { color: #666; line-height: 1.45; }
+    .tok-badge {
+        display: inline-block; font-size: 0.68rem; padding: 0.1rem 0.4rem; border-radius: 3px;
+        white-space: nowrap; margin-top: 0.15rem;
+    }
+    .badge-always  { background: #e6f4ea; color: #1e6e34; }
+    .badge-separate { background: #e3f2fd; color: #0d47a1; }
+    .badge-limited { background: #fff3e0; color: #8a4a00; }
+
+    .empty-msg { font-size: 0.82rem; color: #aaa; font-style: italic; padding: 0.3rem 0; }
+
+    .msg-add-warning {
+        display: none; font-size: 0.78rem; color: #8a0000; background: #fde8e8;
+        border: 1px solid #f5c6c6; border-radius: 4px; padding: 0.3rem 0.55rem;
+        margin-top: 0.3rem; line-height: 1.4;
+    }
+    .msg-add-warning.visible { display: block; }
+
+    .msg-add-preview {
+        display: none;
+        font-family: monospace;
+        font-size: 0.8rem;
+        background: #000;
+        color: #ccc;
+        border-radius: 4px;
+        padding: 0.3rem 0.55rem;
+        margin-top: 0.3rem;
+        min-height: 1.4em;
+        word-break: break-word;
+    }
+    .msg-add-preview.visible { display: block; }
+
+    .ansi-tooltip {
+        display: none;
+        position: fixed;
+        background: #000;
+        color: #ccc;
+        border: 1px solid #444;
+        border-radius: 4px;
+        padding: 0.35rem 0.6rem;
+        font-size: 0.82rem;
+        font-family: monospace;
+        white-space: pre;
+        pointer-events: none;
+        z-index: 9999;
+        max-width: 600px;
+    }
+</style>
+
+<h1>Attack Messages</h1>
+<p class="subtitle">Edit combat messages by weapon subtype and intensity. <a href="/admin/items-attack-messages-api">API Docs &rarr;</a></p>
+
+<div id="ansiTooltip" class="ansi-tooltip"></div>
+
+<div class="page-layout">
+    <div class="sidebar">
+        <div id="subtypeList" class="subtype-list">
+            <div class="editor-placeholder">Loading...</div>
+        </div>
+    </div>
+
+    <div class="editor-panel">
+        <div id="editorPlaceholder" class="editor-placeholder">
+            Select a weapon subtype to view and edit its attack messages.
+        </div>
+        <div id="editorContent" style="display:none">
+            <div id="statusBar" class="status-bar"></div>
+
+            <details class="token-ref">
+                <summary>Available Tokens</summary>
+                <table class="token-table">
+                    <thead>
+                        <tr>
+                            <th>Token</th>
+                            <th>Resolves To</th>
+                            <th>Context</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="tok-name">{source}</td>
+                            <td class="tok-resolves">Attacker's display name</td>
+                            <td class="tok-context">
+                                Always available. Use in messages shown to the defender or the room so they know who is attacking.
+                                <br><span class="tok-badge badge-always">always set</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="tok-name">{sourcetype}</td>
+                            <td class="tok-resolves"><code>username</code> or <code>mobname</code></td>
+                            <td class="tok-context">
+                                Always available. Used as an ANSI color tag foreground value to color the attacker's name correctly, e.g. <code>&lt;ansi fg="{sourcetype}"&gt;{source}&lt;/ansi&gt;</code>.
+                                <br><span class="tok-badge badge-always">always set</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="tok-name">{target}</td>
+                            <td class="tok-resolves">Defender's display name</td>
+                            <td class="tok-context">
+                                Always available. Use in messages shown to the attacker or the room so they know who is being hit.
+                                <br><span class="tok-badge badge-always">always set</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="tok-name">{targettype}</td>
+                            <td class="tok-resolves"><code>username</code> or <code>mobname</code></td>
+                            <td class="tok-context">
+                                Always available. Used as an ANSI color tag foreground value to color the defender's name correctly, e.g. <code>&lt;ansi fg="{targettype}"&gt;{target}&lt;/ansi&gt;</code>.
+                                <br><span class="tok-badge badge-always">always set</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="tok-name">{itemname}</td>
+                            <td class="tok-resolves">Weapon display name, or unarmed attack name</td>
+                            <td class="tok-context">
+                                Always available. Falls back to the race's unarmed attack name when no weapon is equipped. Useful in all message targets to describe what was used.
+                                <br><span class="tok-badge badge-always">always set</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="tok-name">{damage}</td>
+                            <td class="tok-resolves">Numeric damage dealt (e.g. <code>14</code>)</td>
+                            <td class="tok-context">
+                                Available for all non-prepare, non-wait, non-miss intensities. Not meaningful in <em>prepare</em> or <em>wait</em> messages since no damage has been dealt yet. Best used in <em>To Attacker</em> messages for feedback.
+                                <br><span class="tok-badge badge-always">always set</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="tok-name">{exitname}</td>
+                            <td class="tok-resolves">Exit direction from attacker's room toward defender (e.g. <code>north</code>)</td>
+                            <td class="tok-context">
+                                Only meaningful in <strong>Separate Rooms</strong> messages. Resolves to <code>unknown</code> in same-room combat. Use in <em>To Attacker</em> or <em>To Attacker Room</em> to indicate which direction the attack was fired.
+                                <br><span class="tok-badge badge-separate">separate rooms only</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="tok-name">{entrancename}</td>
+                            <td class="tok-resolves">Exit direction from defender's room back toward attacker (e.g. <code>south</code>)</td>
+                            <td class="tok-context">
+                                Only meaningful in <strong>Separate Rooms</strong> messages. Resolves to <code>unknown</code> in same-room combat. Use in <em>To Defender</em> or <em>To Defender Room</em> to show where the attack came from.
+                                <br><span class="tok-badge badge-separate">separate rooms only</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </details>
+
+            <div class="tab-bar" id="intensityTabs"></div>
+            <div id="intensityPanels"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+    const INTENSITIES = ['prepare','wait','miss','weak','normal','heavy','critical'];
+    const TOGETHER_TARGETS = ['toattacker','todefender','toroom'];
+    const SEPARATE_TARGETS = ['toattacker','todefender','toattackerroom','todefenderroom'];
+    const TARGET_LABELS = {
+        toattacker: 'To Attacker',
+        todefender: 'To Defender',
+        toroom: 'To Room',
+        toattackerroom: 'To Attacker Room',
+        todefenderroom: 'To Defender Room'
+    };
+
+    let allData = {};
+    let activeSubtype = null;
+    let activeIntensity = null;
+
+    async function loadData() {
+        const [aliasRes, dataRes] = await AdminAPI.all([
+            AdminAPI.get('/admin/api/v1/color-aliases'),
+            AdminAPI.get('/admin/api/v1/items/attack-messages'),
+        ]);
+        if (aliasRes.ok) {
+            ansitags.loadAliases((aliasRes.data && aliasRes.data.data) || {});
+        }
+        if (!dataRes.ok) { console.error('Load failed:', dataRes.error); return; }
+        allData = (dataRes.data && dataRes.data.data) || {};
+        renderSubtypeList();
+    }
+
+    function renderSubtypeList() {
+        const list = document.getElementById('subtypeList');
+        const subtypes = Object.keys(allData).sort();
+        if (subtypes.length === 0) {
+            list.innerHTML = '<div class="editor-placeholder">No attack messages found.</div>';
+            return;
+        }
+        list.innerHTML = subtypes.map(st =>
+            '<div class="subtype-row' + (st === activeSubtype ? ' active' : '') + '" data-st="' + escAttr(st) + '" onclick="selectSubtype(\'' + escAttr(st) + '\')">' +
+                escHtml(st) +
+            '</div>'
+        ).join('');
+    }
+
+    function selectSubtype(st) {
+        activeSubtype = st;
+        activeIntensity = activeIntensity || INTENSITIES[0];
+        renderSubtypeList();
+        renderEditor();
+    }
+
+    function renderEditor() {
+        document.getElementById('editorPlaceholder').style.display = 'none';
+        document.getElementById('editorContent').style.display = '';
+        document.getElementById('statusBar').className = 'status-bar';
+
+        const group = allData[activeSubtype];
+        if (!group) return;
+        const options = group.Options || {};
+
+        const tabBar = document.getElementById('intensityTabs');
+        tabBar.innerHTML = INTENSITIES.map(int =>
+            '<button class="tab-btn' + (int === activeIntensity ? ' active' : '') + '" onclick="switchIntensity(\'' + int + '\')">' +
+                escHtml(int.charAt(0).toUpperCase() + int.slice(1)) +
+            '</button>'
+        ).join('');
+
+        const panels = document.getElementById('intensityPanels');
+        panels.innerHTML = INTENSITIES.map(int => {
+            const opts = options[int] || {};
+            const tog = opts.Together || {};
+            const sep = opts.Separate || {};
+            const isActive = int === activeIntensity;
+
+            return '<div class="tab-panel' + (isActive ? ' active' : '') + '" id="panel-' + int + '">' +
+                renderProximitySection('together', 'Same Room', 'Both combatants are in the same room', TOGETHER_TARGETS, tog, int) +
+                renderProximitySection('separate', 'Separate Rooms', 'Combatants are in different rooms (ranged only)', SEPARATE_TARGETS, sep, int) +
+            '</div>';
+        }).join('');
+
+        document.querySelectorAll('.proximity-section').forEach(function(s) {
+            s.classList.add('open');
+        });
+    }
+
+    function renderProximitySection(proximity, title, hint, targets, data, intensity) {
+        var html = '<div class="proximity-section open">' +
+            '<div class="proximity-header" onclick="this.parentElement.classList.toggle(\'open\')">' +
+                '<span class="arrow">&#9654;</span> ' + escHtml(title) +
+                ' <span class="proximity-hint">(' + escHtml(hint) + ')</span>' +
+            '</div>' +
+            '<div class="proximity-body">';
+
+        for (var i = 0; i < targets.length; i++) {
+            var t = targets[i];
+            var key = t.charAt(0).toUpperCase() === t.charAt(0) ? t : capitalizeTarget(t);
+            var msgs = data[key] || [];
+            html += renderTargetGroup(intensity, proximity, t, msgs);
+        }
+
+        html += '</div></div>';
+        return html;
+    }
+
+    function capitalizeTarget(t) {
+        var map = {
+            toattacker: 'ToAttacker',
+            todefender: 'ToDefender',
+            toroom: 'ToRoom',
+            toattackerroom: 'ToAttackerRoom',
+            todefenderroom: 'ToDefenderRoom'
+        };
+        return map[t] || t;
+    }
+
+    function renderTargetGroup(intensity, proximity, target, msgs) {
+        var id = intensity + '-' + proximity + '-' + target;
+        var html = '<div class="target-group">' +
+            '<div class="target-label">' + escHtml(TARGET_LABELS[target] || target) + '</div>' +
+            '<ul class="msg-list" id="msgs-' + id + '">';
+
+        if (msgs.length === 0) {
+            html += '<li class="empty-msg">No messages defined.</li>';
+        } else {
+            for (var i = 0; i < msgs.length; i++) {
+                html += '<li class="msg-item">' +
+                    '<span class="msg-index">' + i + '</span>' +
+                    '<span class="msg-text" onmouseenter="showAnsiTooltip(event,this)" onmouseleave="hideAnsiTooltip()">' + escHtml(msgs[i]) + '</span>' +
+                    '<button class="msg-delete" title="Delete" onclick="deleteMsg(\'' + escAttr(intensity) + '\',\'' + escAttr(proximity) + '\',\'' + escAttr(target) + '\',' + i + ')">&times;</button>' +
+                '</li>';
+            }
+        }
+
+        var isTogether = (proximity === 'together');
+        html += '</ul>' +
+            '<div class="msg-add-row">' +
+                '<textarea id="add-' + id + '" placeholder="New message..." rows="1"' +
+                    ' oninput="updateAddPreview(this,\'' + escAttr(id) + '\')' + (isTogether ? ';checkTogetherTokens(this,\'' + escAttr(id) + '\')' : '') + '"' +
+                    ' onkeydown="if(event.ctrlKey&&event.key===\'Enter\')addMsg(\'' + escAttr(intensity) + '\',\'' + escAttr(proximity) + '\',\'' + escAttr(target) + '\')"></textarea>' +
+                '<button class="btn-add" onclick="addMsg(\'' + escAttr(intensity) + '\',\'' + escAttr(proximity) + '\',\'' + escAttr(target) + '\')">Add</button>' +
+            '</div>' +
+            '<div class="msg-add-preview" id="preview-' + id + '"></div>' +
+            '<div class="msg-add-warning" id="warn-' + id + '"></div>' +
+        '</div>';
+        return html;
+    }
+
+    function switchIntensity(int) {
+        activeIntensity = int;
+        document.querySelectorAll('.tab-btn').forEach(function(b) {
+            b.classList.toggle('active', b.textContent.toLowerCase() === int);
+        });
+        document.querySelectorAll('.tab-panel').forEach(function(p) {
+            p.classList.toggle('active', p.id === 'panel-' + int);
+        });
+    }
+
+    // Returns an array of same-room-invalid token names found in the message string.
+    function separateOnlyTokensIn(message) {
+        var bad = [];
+        if (message.indexOf('{exitname}') !== -1)     bad.push('{exitname}');
+        if (message.indexOf('{entrancename}') !== -1) bad.push('{entrancename}');
+        return bad;
+    }
+
+    function checkTogetherTokens(textarea, id) {
+        var warn = document.getElementById('warn-' + id);
+        if (!warn) return;
+        var bad = separateOnlyTokensIn(textarea.value);
+        if (bad.length > 0) {
+            warn.textContent = bad.join(' and ') + (bad.length === 1 ? ' is' : ' are') +
+                ' only valid in Separate Rooms messages and will always resolve to "unknown" here.';
+            warn.classList.add('visible');
+        } else {
+            warn.classList.remove('visible');
+        }
+    }
+
+    async function addMsg(intensity, proximity, target) {
+        var id = intensity + '-' + proximity + '-' + target;
+        var textarea = document.getElementById('add-' + id);
+        var message = textarea.value.trim();
+        if (!message) { showStatus('error', 'Message cannot be empty.'); return; }
+
+        if (proximity === 'together') {
+            var bad = separateOnlyTokensIn(message);
+            if (bad.length > 0) {
+                showStatus('error',
+                    bad.join(' and ') + (bad.length === 1 ? ' is' : ' are') +
+                    ' only valid in Separate Rooms messages and will always resolve to "unknown" in Same Room messages.');
+                return;
+            }
+        }
+
+        var url = '/admin/api/v1/items/attack-messages/' +
+            encodeURIComponent(activeSubtype) + '/' +
+            encodeURIComponent(intensity) + '/' +
+            encodeURIComponent(proximity) + '/' +
+            encodeURIComponent(target);
+
+        var res = await AdminAPI.put(url, { message: message });
+        if (!res.ok) { showStatus('error', res.error || 'Add failed.'); return; }
+
+        textarea.value = '';
+        showStatus('success', 'Message added.');
+        await reloadAndRender();
+    }
+
+    async function deleteMsg(intensity, proximity, target, index) {
+        if (!confirm('Delete message #' + index + '?')) return;
+
+        var url = '/admin/api/v1/items/attack-messages/' +
+            encodeURIComponent(activeSubtype) + '/' +
+            encodeURIComponent(intensity) + '/' +
+            encodeURIComponent(proximity) + '/' +
+            encodeURIComponent(target) + '/' + index;
+
+        var res = await AdminAPI.delete(url);
+        if (!res.ok) { showStatus('error', res.error || 'Delete failed.'); return; }
+
+        showStatus('success', 'Message deleted.');
+        await reloadAndRender();
+    }
+
+    async function reloadAndRender() {
+        var res = await AdminAPI.get('/admin/api/v1/items/attack-messages');
+        if (!res.ok) { return; }
+        allData = (res.data && res.data.data) || {};
+        renderSubtypeList();
+        renderEditor();
+    }
+
+    function showStatus(type, msg) {
+        var bar = document.getElementById('statusBar');
+        bar.className = 'status-bar ' + type;
+        bar.textContent = msg;
+        if (type === 'success') setTimeout(function() { bar.className = 'status-bar'; }, 3000);
+    }
+
+    function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+    function escAttr(s) { return String(s).replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
+
+    function updateAddPreview(textarea, id) {
+        var el = document.getElementById('preview-' + id);
+        if (!el) return;
+        var raw = textarea.value
+            .replace(/\{sourcetype\}/g, 'username')
+            .replace(/\{targettype\}/g, 'mobname');
+        if (!raw.trim()) {
+            el.classList.remove('visible');
+            el.innerHTML = '';
+        } else {
+            el.innerHTML = ansitags.parse(raw);
+            el.classList.add('visible');
+        }
+    }
+
+    var _ansiTooltip = null;
+    function showAnsiTooltip(event, el) {
+        if (!_ansiTooltip) _ansiTooltip = document.getElementById('ansiTooltip');
+        var raw = el.textContent
+            .replace(/\{sourcetype\}/g, 'username')
+            .replace(/\{targettype\}/g, 'mobname');
+        _ansiTooltip.innerHTML = ansitags.parse(raw);
+        _ansiTooltip.style.display = 'block';
+        positionTooltip(event);
+    }
+    function hideAnsiTooltip() {
+        if (!_ansiTooltip) _ansiTooltip = document.getElementById('ansiTooltip');
+        _ansiTooltip.style.display = 'none';
+    }
+    function positionTooltip(event) {
+        var tip = _ansiTooltip;
+        var x = event.clientX + 14;
+        var y = event.clientY + 14;
+        tip.style.left = x + 'px';
+        tip.style.top  = y + 'px';
+    }
+    document.addEventListener('mousemove', function(event) {
+        if (_ansiTooltip && _ansiTooltip.style.display === 'block') positionTooltip(event);
+    });
+
+    loadData();
+</script>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/keywords-api.html
+++ b/_datafiles/html/admin/keywords-api.html
@@ -1,0 +1,92 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 2rem; font-size: 0.9rem; }
+    .api-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .api-entry { background: #fff; border: 1px solid #ddd; border-radius: 6px; overflow: hidden; }
+    .api-entry summary { display: flex; align-items: baseline; gap: 0.75rem; padding: 0.65rem 1rem; cursor: pointer; user-select: none; list-style: none; }
+    .api-entry summary::-webkit-details-marker { display: none; }
+    .api-entry summary::before { content: "\25B6"; font-size: 0.65rem; color: #888; transition: transform 0.15s; flex-shrink: 0; }
+    .api-entry[open] summary::before { transform: rotate(90deg); }
+    .api-entry summary:hover { background: #fafafa; }
+    .method { font-family: monospace; font-size: 0.8rem; font-weight: 700; padding: 0.15rem 0.45rem; border-radius: 3px; flex-shrink: 0; }
+    .method-get    { background: #e6f4ea; color: #1e6e34; }
+    .method-patch  { background: #fff3e0; color: #8a4a00; }
+    .api-path { font-family: monospace; font-size: 0.9rem; color: #1a1a2e; }
+    .api-desc { font-size: 0.85rem; color: #555; margin-left: auto; text-align: right; }
+    .api-body { padding: 0.75rem 1rem 1rem; border-top: 1px solid #eee; background: #fafafa; }
+    .api-body p { font-size: 0.85rem; color: #444; margin-bottom: 0.5rem; }
+    .curl-block { background: #1a1a2e; color: #c9d1d9; font-family: monospace; font-size: 0.82rem; padding: 0.85rem 1rem; border-radius: 5px; white-space: pre; overflow-x: auto; line-height: 1.6; margin-bottom: 0.5rem; }
+    .curl-block .kw   { color: #79c0ff; }
+    .curl-block .str  { color: #a5d6ff; }
+    .curl-block .flag { color: #d2a8ff; }
+    .response-examples { margin-top: 1rem; display: flex; flex-direction: column; gap: 0.4rem; }
+    .resp-entry { border: 1px solid #ddd; border-radius: 4px; overflow: hidden; }
+    .resp-entry summary { display: flex; align-items: baseline; gap: 0.6rem; padding: 0.45rem 0.75rem; cursor: pointer; user-select: none; list-style: none; background: #f5f5f5; font-size: 0.82rem; }
+    .resp-entry summary::-webkit-details-marker { display: none; }
+    .resp-entry summary::before { content: "\25B6"; font-size: 0.6rem; color: #888; transition: transform 0.15s; flex-shrink: 0; }
+    .resp-entry[open] summary::before { transform: rotate(90deg); }
+    .resp-entry summary:hover { background: #efefef; }
+    .resp-body { padding: 0.6rem 0.75rem 0.75rem; border-top: 1px solid #eee; background: #fafafa; }
+    .status-ok  { background: #e6f4ea; color: #1e6e34; }
+    .status-err { background: #fde8e8; color: #8a0000; }
+    .resp-label { font-size: 0.8rem; color: #444; }
+</style>
+
+<h1>Keywords API Reference</h1>
+<p class="subtitle">REST endpoints for viewing and updating keywords: help topics, aliases, direction shortcuts, and map legend overrides.</p>
+
+<div class="api-list">
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-get">GET</span>
+            <span class="api-path">/admin/api/v1/keywords</span>
+            <span class="api-desc">Return all keywords data</span>
+        </summary>
+        <div class="api-body">
+            <p>Returns the full keywords configuration containing help topics, help aliases, command aliases, direction aliases, and map legend overrides.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/keywords</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"Help":{"command":{"configuration":["alias","macros","set"],...},"skill":{"all":["aid","backstab",...]},"admin":{"all":["buff","build",...]}},"HelpAliases":{"brawling":["tackle","brawl"],...},"CommandAliases":{"say":["."],"status":["sta","stat"],...},"DirectionAliases":{"n":"north","s":"south",...},"MapLegendOverrides":{"*":{"$":"Shop","★":"Bank"},"Frostfang":{"!":"Throne Room"}}}}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-patch">PATCH</span>
+            <span class="api-path">/admin/api/v1/keywords</span>
+            <span class="api-desc">Update all keywords data</span>
+        </summary>
+        <div class="api-body">
+            <p>Replaces the entire keywords configuration. The request body must contain the full keywords structure with all five sections: <code>Help</code>, <code>HelpAliases</code>, <code>CommandAliases</code>, <code>DirectionAliases</code>, and <code>MapLegendOverrides</code>. The file is saved to disk and reloaded in memory.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> <span class="flag">-X</span> PATCH \
+     <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
+     <span class="flag">-d</span> <span class="str">'{"Help":{"command":{"general":["quit","online"]}},"HelpAliases":{"brawling":["tackle"]},"CommandAliases":{"say":["."]},"DirectionAliases":{"n":"north"},"MapLegendOverrides":{"*":{"$":"Shop"}}}'</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/keywords</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"Help":{...},"HelpAliases":{...},"CommandAliases":{...},"DirectionAliases":{...},"MapLegendOverrides":{...}}}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">Bad Request</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"malformed request body: unexpected EOF"}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">500</span> <span class="resp-label">Internal Server Error</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"writing keywords file: permission denied"}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+</div>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/keywords.html
+++ b/_datafiles/html/admin/keywords.html
@@ -1,0 +1,577 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .status-bar { display: none; padding: 0.55rem 0.9rem; border-radius: 4px; font-size: 0.85rem; margin-bottom: 1rem; }
+    .status-bar.success { background: #e6f4ea; color: #1e6e34; display: block; }
+    .status-bar.error   { background: #fde8e8; color: #8a0000; display: block; }
+
+    .tab-bar { display: flex; gap: 0; border-bottom: 2px solid #1a1a2e; margin-bottom: 1.25rem; flex-wrap: wrap; }
+    .tab-btn {
+        padding: 0.55rem 1.1rem; border: none; background: #eee; color: #555;
+        font-size: 0.85rem; font-weight: 600; cursor: pointer; border-radius: 4px 4px 0 0;
+        margin-bottom: -2px; border: 2px solid transparent; border-bottom: none;
+    }
+    .tab-btn:hover { background: #e0e0e0; }
+    .tab-btn.active { background: #fff; color: #1a1a2e; border-color: #1a1a2e; }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+
+    .section-panel { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 1.25rem; margin-bottom: 1rem; }
+    .section-desc { font-size: 0.82rem; color: #666; margin-bottom: 1rem; }
+
+    .btn-save-all { padding: 0.5rem 1.5rem; background: #1a1a2e; color: #fff; border: none; border-radius: 4px; font-size: 0.9rem; font-weight: 600; cursor: pointer; margin-bottom: 1.25rem; }
+    .btn-save-all:hover { background: #2d2d4e; }
+    .btn-add { padding: 0.3rem 0.8rem; background: #1e6e34; color: #fff; border: none; border-radius: 4px; font-size: 0.8rem; font-weight: 600; cursor: pointer; }
+    .btn-add:hover { background: #145728; }
+    .btn-remove { padding: 0.2rem 0.5rem; background: #fff; color: #8a0000; border: 1px solid #e0a0a0; border-radius: 3px; font-size: 0.75rem; cursor: pointer; }
+    .btn-remove:hover { background: #fde8e8; }
+
+    /* Help Topics */
+    .help-group { margin-bottom: 1rem; border: 1px solid #e0e0e0; border-radius: 5px; overflow: hidden; }
+    .help-group-header {
+        display: flex; align-items: center; gap: 0.75rem; padding: 0.55rem 0.85rem;
+        background: #f5f5f5; font-weight: 600; font-size: 0.85rem; cursor: pointer; user-select: none;
+    }
+    .help-group-header:hover { background: #eee; }
+    .help-group-header .arrow { font-size: 0.65rem; color: #888; transition: transform 0.15s; }
+    .help-group.open .arrow { transform: rotate(90deg); }
+    .help-group-body { display: none; padding: 0.5rem 0.85rem 0.75rem; }
+    .help-group.open .help-group-body { display: block; }
+    .help-category { margin-bottom: 0.75rem; }
+    .help-category-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.35rem; }
+    .help-category-name { font-size: 0.82rem; font-weight: 600; color: #444; text-transform: capitalize; }
+    .chip-list { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+    .chip {
+        display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.2rem 0.55rem;
+        background: #e8eaf6; border-radius: 12px; font-size: 0.78rem; color: #333;
+    }
+    .chip .x { cursor: pointer; color: #888; font-weight: 700; font-size: 0.7rem; }
+    .chip .x:hover { color: #c00; }
+    .add-inline { display: inline-flex; align-items: center; gap: 0.3rem; }
+    .add-inline input { padding: 0.2rem 0.4rem; border: 1px solid #ccc; border-radius: 3px; font-size: 0.8rem; width: 120px; }
+    .add-inline button { padding: 0.2rem 0.5rem; background: #1e6e34; color: #fff; border: none; border-radius: 3px; font-size: 0.75rem; cursor: pointer; }
+
+    /* Alias Tables */
+    .alias-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+    .alias-table th { text-align: left; font-size: 0.75rem; font-weight: 700; text-transform: uppercase; color: #666; padding: 0.4rem 0.6rem; border-bottom: 2px solid #ddd; letter-spacing: 0.03em; }
+    .alias-table td { padding: 0.4rem 0.6rem; border-bottom: 1px solid #eee; vertical-align: middle; }
+    .alias-table tr:hover { background: #fafafa; }
+    .alias-table input[type="text"] {
+        width: 100%; padding: 0.3rem 0.5rem; border: 1px solid #ccc; border-radius: 3px;
+        font-size: 0.84rem; font-family: inherit;
+    }
+    .alias-table input:focus { outline: 2px solid #1a1a2e; outline-offset: 1px; border-color: transparent; }
+    .col-action { width: 40px; text-align: center; }
+    .add-row { display: flex; gap: 0.5rem; margin-top: 0.6rem; align-items: center; flex-wrap: wrap; }
+    .add-row input { padding: 0.35rem 0.5rem; border: 1px solid #ccc; border-radius: 3px; font-size: 0.84rem; }
+    .add-row .inp-key { width: 140px; }
+    .add-row .inp-val { width: 260px; }
+    .add-row .inp-short { width: 60px; }
+
+    /* Legend Overrides */
+    .legend-zone { margin-bottom: 1rem; border: 1px solid #e0e0e0; border-radius: 5px; overflow: hidden; }
+    .legend-zone-header {
+        display: flex; align-items: center; gap: 0.75rem; padding: 0.55rem 0.85rem;
+        background: #f5f5f5; font-weight: 600; font-size: 0.85rem;
+    }
+    .legend-zone-body { padding: 0.5rem 0.85rem 0.75rem; }
+</style>
+
+<h1>Keywords</h1>
+<p class="subtitle">Help topics, aliases, direction shortcuts, and map legend overrides. <a href="/admin/keywords-api">API Docs →</a></p>
+
+<div id="statusBar" class="status-bar"></div>
+<button class="btn-save-all" onclick="saveAll()">Save All Changes</button>
+
+<div class="tab-bar">
+    <button class="tab-btn active" onclick="switchTab('help')">Help Topics</button>
+    <button class="tab-btn" onclick="switchTab('helpAliases')">Help Aliases</button>
+    <button class="tab-btn" onclick="switchTab('cmdAliases')">Command Aliases</button>
+    <button class="tab-btn" onclick="switchTab('dirAliases')">Direction Aliases</button>
+    <button class="tab-btn" onclick="switchTab('legend')">Legend Overrides</button>
+</div>
+
+<!-- Help Topics -->
+<div id="tab-help" class="tab-panel active">
+    <div class="section-panel">
+        <p class="section-desc">
+            Organized help topics displayed via <code>help &lt;topic&gt;</code>. Grouped by type (command, skill, admin) and category.
+        </p>
+        <div id="helpTopicsContainer"></div>
+        <div class="add-row" style="margin-top:1rem;">
+            <input type="text" id="newHelpType" class="inp-key" placeholder="Type (e.g. command)" />
+            <input type="text" id="newHelpCat" class="inp-key" placeholder="Category" />
+            <button class="btn-add" onclick="addHelpCategory()">+ Add Category</button>
+        </div>
+    </div>
+</div>
+
+<!-- Help Aliases -->
+<div id="tab-helpAliases" class="tab-panel">
+    <div class="section-panel">
+        <p class="section-desc">
+            When a user types <code>help &lt;alias&gt;</code>, it redirects to the target help topic.
+        </p>
+        <table class="alias-table">
+            <thead><tr><th>Target Topic</th><th>Aliases (comma-separated)</th><th class="col-action"></th></tr></thead>
+            <tbody id="helpAliasesBody"></tbody>
+        </table>
+        <div class="add-row">
+            <input type="text" id="newHelpAliasKey" class="inp-key" placeholder="Target topic" />
+            <input type="text" id="newHelpAliasVal" class="inp-val" placeholder="alias1, alias2, ..." />
+            <button class="btn-add" onclick="addHelpAlias()">+ Add</button>
+        </div>
+    </div>
+</div>
+
+<!-- Command Aliases -->
+<div id="tab-cmdAliases" class="tab-panel">
+    <div class="section-panel">
+        <p class="section-desc">
+            Shorthand aliases for in-game commands. For example, <code>i</code> → <code>inventory</code>.
+            Multi-word targets like <code>party chat</code> are supported.
+        </p>
+        <table class="alias-table">
+            <thead><tr><th>Command</th><th>Aliases (comma-separated)</th><th class="col-action"></th></tr></thead>
+            <tbody id="cmdAliasesBody"></tbody>
+        </table>
+        <div class="add-row">
+            <input type="text" id="newCmdAliasKey" class="inp-key" placeholder="Command" />
+            <input type="text" id="newCmdAliasVal" class="inp-val" placeholder="alias1, alias2, ..." />
+            <button class="btn-add" onclick="addCmdAlias()">+ Add</button>
+        </div>
+    </div>
+</div>
+
+<!-- Direction Aliases -->
+<div id="tab-dirAliases" class="tab-panel">
+    <div class="section-panel">
+        <p class="section-desc">
+            Single-character shortcuts for movement directions.
+        </p>
+        <table class="alias-table">
+            <thead><tr><th>Shortcut</th><th>Direction</th><th class="col-action"></th></tr></thead>
+            <tbody id="dirAliasesBody"></tbody>
+        </table>
+        <div class="add-row">
+            <input type="text" id="newDirAliasKey" class="inp-short" placeholder="Key" />
+            <input type="text" id="newDirAliasVal" class="inp-key" placeholder="Direction" />
+            <button class="btn-add" onclick="addDirAlias()">+ Add</button>
+        </div>
+    </div>
+</div>
+
+<!-- Legend Overrides -->
+<div id="tab-legend" class="tab-panel">
+    <div class="section-panel">
+        <p class="section-desc">
+            Custom map symbols shown in the map legend. The <code>*</code> zone applies globally unless overridden by a specific zone entry.
+        </p>
+        <div id="legendContainer"></div>
+        <div class="add-row" style="margin-top:1rem;">
+            <input type="text" id="newLegendZone" class="inp-key" placeholder="Zone name (or *)" />
+            <button class="btn-add" onclick="addLegendZone()">+ Add Zone</button>
+        </div>
+    </div>
+</div>
+
+<button class="btn-save-all" onclick="saveAll()">Save All Changes</button>
+
+<script>
+let data = null;
+
+async function init() {
+    const res = await AdminAPI.get('/admin/api/v1/keywords');
+    if (!res.ok) { showStatus('error', 'Failed to load keywords: ' + res.error); return; }
+    data = (res.data && res.data.data) || {};
+    if (!data.Help) data.Help = {};
+    if (!data.HelpAliases) data.HelpAliases = {};
+    if (!data.CommandAliases) data.CommandAliases = {};
+    if (!data.DirectionAliases) data.DirectionAliases = {};
+    if (!data.MapLegendOverrides) data.MapLegendOverrides = {};
+    renderAll();
+}
+
+function renderAll() {
+    renderHelpTopics();
+    renderHelpAliases();
+    renderCmdAliases();
+    renderDirAliases();
+    renderLegend();
+}
+
+// ---- Tabs ----
+function switchTab(id) {
+    document.querySelectorAll('.tab-btn').forEach((b, i) => b.classList.remove('active'));
+    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+    document.getElementById('tab-' + id).classList.add('active');
+    const tabs = ['help','helpAliases','cmdAliases','dirAliases','legend'];
+    document.querySelectorAll('.tab-btn')[tabs.indexOf(id)].classList.add('active');
+}
+
+// ---- Help Topics ----
+function renderHelpTopics() {
+    const c = document.getElementById('helpTopicsContainer');
+    const types = Object.keys(data.Help).sort();
+    if (types.length === 0) { c.innerHTML = '<div style="color:#888;font-size:0.85rem;">No help topics defined.</div>'; return; }
+    c.innerHTML = types.map(type => {
+        const cats = data.Help[type];
+        const catKeys = Object.keys(cats).sort();
+        return `<div class="help-group open" data-type="${esc(type)}">
+            <div class="help-group-header" onclick="this.parentElement.classList.toggle('open')">
+                <span class="arrow">&#9654;</span>
+                <span>${esc(type)}</span>
+                <span style="font-size:0.75rem;color:#888;font-weight:400;">(${catKeys.length} categories)</span>
+                <button class="btn-remove" style="margin-left:auto;" onclick="event.stopPropagation();removeHelpType('${esc(type)}')">Remove Type</button>
+            </div>
+            <div class="help-group-body">
+                ${catKeys.map(cat => renderHelpCategory(type, cat, cats[cat])).join('')}
+                <div class="add-inline" style="margin-top:0.5rem;">
+                    <input type="text" placeholder="New category" id="newCat-${esc(type)}" />
+                    <button onclick="addHelpCategoryInline('${esc(type)}')">+ Category</button>
+                </div>
+            </div>
+        </div>`;
+    }).join('');
+}
+
+function renderHelpCategory(type, cat, commands) {
+    const cmds = commands || [];
+    return `<div class="help-category">
+        <div class="help-category-header">
+            <span class="help-category-name">${esc(cat)}</span>
+            <button class="btn-remove" onclick="removeHelpCategory('${esc(type)}','${esc(cat)}')">Remove</button>
+        </div>
+        <div class="chip-list">
+            ${cmds.map(cmd => `<span class="chip">${esc(cmd)}<span class="x" onclick="removeHelpCommand('${esc(type)}','${esc(cat)}','${esc(cmd)}')">&times;</span></span>`).join('')}
+            <span class="add-inline">
+                <input type="text" placeholder="command" id="addCmd-${esc(type)}-${esc(cat)}" onkeydown="if(event.key==='Enter')addHelpCommand('${esc(type)}','${esc(cat)}')" />
+                <button onclick="addHelpCommand('${esc(type)}','${esc(cat)}')">+</button>
+            </span>
+        </div>
+    </div>`;
+}
+
+function addHelpCategory() {
+    const type = document.getElementById('newHelpType').value.trim().toLowerCase();
+    const cat = document.getElementById('newHelpCat').value.trim().toLowerCase();
+    if (!type || !cat) return;
+    if (!data.Help[type]) data.Help[type] = {};
+    if (!data.Help[type][cat]) data.Help[type][cat] = [];
+    document.getElementById('newHelpType').value = '';
+    document.getElementById('newHelpCat').value = '';
+    renderHelpTopics();
+}
+
+function addHelpCategoryInline(type) {
+    const input = document.getElementById('newCat-' + type);
+    const cat = input.value.trim().toLowerCase();
+    if (!cat) return;
+    if (!data.Help[type][cat]) data.Help[type][cat] = [];
+    input.value = '';
+    renderHelpTopics();
+}
+
+function addHelpCommand(type, cat) {
+    const input = document.getElementById('addCmd-' + type + '-' + cat);
+    const cmd = input.value.trim().toLowerCase();
+    if (!cmd) return;
+    if (!data.Help[type][cat].includes(cmd)) data.Help[type][cat].push(cmd);
+    input.value = '';
+    renderHelpTopics();
+}
+
+function removeHelpCommand(type, cat, cmd) {
+    data.Help[type][cat] = data.Help[type][cat].filter(c => c !== cmd);
+    renderHelpTopics();
+}
+
+function removeHelpCategory(type, cat) {
+    if (!confirm('Remove category "' + cat + '" and all its commands?')) return;
+    delete data.Help[type][cat];
+    renderHelpTopics();
+}
+
+function removeHelpType(type) {
+    if (!confirm('Remove help type "' + type + '" and all its categories?')) return;
+    delete data.Help[type];
+    renderHelpTopics();
+}
+
+// ---- Help Aliases ----
+function renderHelpAliases() {
+    const body = document.getElementById('helpAliasesBody');
+    const keys = Object.keys(data.HelpAliases).sort();
+    body.innerHTML = keys.map(k => {
+        const vals = (data.HelpAliases[k] || []).join(', ');
+        return `<tr>
+            <td><input type="text" value="${escAttr(k)}" onchange="renameHelpAlias('${escAttr(k)}',this.value)" /></td>
+            <td><input type="text" value="${escAttr(vals)}" onchange="updateHelpAliasValues('${escAttr(k)}',this.value,this.parentElement.parentElement)" /></td>
+            <td class="col-action"><button class="btn-remove" onclick="removeHelpAlias('${escAttr(k)}')">&times;</button></td>
+        </tr>`;
+    }).join('');
+}
+
+function renameHelpAlias(oldKey, newKey) {
+    newKey = newKey.trim();
+    if (!newKey || newKey === oldKey) return;
+    data.HelpAliases[newKey] = data.HelpAliases[oldKey];
+    delete data.HelpAliases[oldKey];
+    renderHelpAliases();
+}
+
+function updateHelpAliasValues(key, valStr, row) {
+    const currentKeyInput = row.querySelector('td:first-child input');
+    const currentKey = currentKeyInput ? currentKeyInput.value.trim() : key;
+    const actualKey = data.HelpAliases[currentKey] !== undefined ? currentKey : key;
+    data.HelpAliases[actualKey] = valStr.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function removeHelpAlias(key) { delete data.HelpAliases[key]; renderHelpAliases(); }
+
+function addHelpAlias() {
+    const k = document.getElementById('newHelpAliasKey').value.trim();
+    const v = document.getElementById('newHelpAliasVal').value.trim();
+    if (!k) return;
+    data.HelpAliases[k] = v ? v.split(',').map(s => s.trim()).filter(Boolean) : [];
+    document.getElementById('newHelpAliasKey').value = '';
+    document.getElementById('newHelpAliasVal').value = '';
+    renderHelpAliases();
+}
+
+// ---- Command Aliases ----
+function renderCmdAliases() {
+    const body = document.getElementById('cmdAliasesBody');
+    const keys = Object.keys(data.CommandAliases).sort();
+    body.innerHTML = keys.map(k => {
+        const vals = (data.CommandAliases[k] || []).join(', ');
+        return `<tr>
+            <td><input type="text" value="${escAttr(k)}" onchange="renameCmdAlias('${escAttr(k)}',this.value)" /></td>
+            <td><input type="text" value="${escAttr(vals)}" onchange="updateCmdAliasValues('${escAttr(k)}',this.value,this.parentElement.parentElement)" /></td>
+            <td class="col-action"><button class="btn-remove" onclick="removeCmdAlias('${escAttr(k)}')">&times;</button></td>
+        </tr>`;
+    }).join('');
+}
+
+function renameCmdAlias(oldKey, newKey) {
+    newKey = newKey.trim();
+    if (!newKey || newKey === oldKey) return;
+    data.CommandAliases[newKey] = data.CommandAliases[oldKey];
+    delete data.CommandAliases[oldKey];
+    renderCmdAliases();
+}
+
+function updateCmdAliasValues(key, valStr, row) {
+    const currentKeyInput = row.querySelector('td:first-child input');
+    const currentKey = currentKeyInput ? currentKeyInput.value.trim() : key;
+    const actualKey = data.CommandAliases[currentKey] !== undefined ? currentKey : key;
+    data.CommandAliases[actualKey] = valStr.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function removeCmdAlias(key) { delete data.CommandAliases[key]; renderCmdAliases(); }
+
+function addCmdAlias() {
+    const k = document.getElementById('newCmdAliasKey').value.trim();
+    const v = document.getElementById('newCmdAliasVal').value.trim();
+    if (!k) return;
+    data.CommandAliases[k] = v ? v.split(',').map(s => s.trim()).filter(Boolean) : [];
+    document.getElementById('newCmdAliasKey').value = '';
+    document.getElementById('newCmdAliasVal').value = '';
+    renderCmdAliases();
+}
+
+// ---- Direction Aliases ----
+function renderDirAliases() {
+    const body = document.getElementById('dirAliasesBody');
+    const keys = Object.keys(data.DirectionAliases).sort();
+    body.innerHTML = keys.map(k => {
+        return `<tr>
+            <td><input type="text" value="${escAttr(k)}" onchange="renameDirAlias('${escAttr(k)}',this.value)" /></td>
+            <td><input type="text" value="${escAttr(data.DirectionAliases[k])}" onchange="updateDirAlias('${escAttr(k)}',this.value,this.parentElement.parentElement)" /></td>
+            <td class="col-action"><button class="btn-remove" onclick="removeDirAlias('${escAttr(k)}')">&times;</button></td>
+        </tr>`;
+    }).join('');
+}
+
+function renameDirAlias(oldKey, newKey) {
+    newKey = newKey.trim();
+    if (!newKey || newKey === oldKey) return;
+    data.DirectionAliases[newKey] = data.DirectionAliases[oldKey];
+    delete data.DirectionAliases[oldKey];
+    renderDirAliases();
+}
+
+function updateDirAlias(key, val, row) {
+    const currentKeyInput = row.querySelector('td:first-child input');
+    const currentKey = currentKeyInput ? currentKeyInput.value.trim() : key;
+    const actualKey = data.DirectionAliases[currentKey] !== undefined ? currentKey : key;
+    data.DirectionAliases[actualKey] = val.trim();
+}
+
+function removeDirAlias(key) { delete data.DirectionAliases[key]; renderDirAliases(); }
+
+function addDirAlias() {
+    const k = document.getElementById('newDirAliasKey').value.trim();
+    const v = document.getElementById('newDirAliasVal').value.trim();
+    if (!k || !v) return;
+    data.DirectionAliases[k] = v;
+    document.getElementById('newDirAliasKey').value = '';
+    document.getElementById('newDirAliasVal').value = '';
+    renderDirAliases();
+}
+
+// ---- Legend Overrides ----
+function renderLegend() {
+    const c = document.getElementById('legendContainer');
+    const zones = Object.keys(data.MapLegendOverrides).sort((a, b) => {
+        if (a === '*') return -1;
+        if (b === '*') return 1;
+        return a.localeCompare(b);
+    });
+    if (zones.length === 0) { c.innerHTML = '<div style="color:#888;font-size:0.85rem;">No legend overrides defined.</div>'; return; }
+    c.innerHTML = zones.map(zone => {
+        const entries = data.MapLegendOverrides[zone] || {};
+        const symbols = Object.keys(entries).sort();
+        return `<div class="legend-zone">
+            <div class="legend-zone-header">
+                <span>${zone === '*' ? '* (Global)' : esc(zone)}</span>
+                <button class="btn-remove" style="margin-left:auto;" onclick="removeLegendZone('${escAttr(zone)}')">Remove Zone</button>
+            </div>
+            <div class="legend-zone-body">
+                <table class="alias-table">
+                    <thead><tr><th>Symbol</th><th>Label</th><th class="col-action"></th></tr></thead>
+                    <tbody>
+                        ${symbols.map(sym => `<tr>
+                            <td><input type="text" value="${escAttr(sym)}" style="width:60px;text-align:center;" onchange="renameLegendSymbol('${escAttr(zone)}','${escAttr(sym)}',this.value)" /></td>
+                            <td><input type="text" value="${escAttr(entries[sym])}" onchange="updateLegendEntry('${escAttr(zone)}','${escAttr(sym)}',this.value,this.parentElement.parentElement)" /></td>
+                            <td class="col-action"><button class="btn-remove" onclick="removeLegendEntry('${escAttr(zone)}','${escAttr(sym)}')">&times;</button></td>
+                        </tr>`).join('')}
+                    </tbody>
+                </table>
+                <div class="add-row">
+                    <input type="text" class="inp-short" placeholder="Sym" id="newLegSym-${escAttr(zone)}" />
+                    <input type="text" class="inp-key" placeholder="Label" id="newLegLbl-${escAttr(zone)}" />
+                    <button class="btn-add" onclick="addLegendEntry('${escAttr(zone)}')">+ Add</button>
+                </div>
+            </div>
+        </div>`;
+    }).join('');
+}
+
+function addLegendZone() {
+    const zone = document.getElementById('newLegendZone').value.trim();
+    if (!zone) return;
+    if (!data.MapLegendOverrides[zone]) data.MapLegendOverrides[zone] = {};
+    document.getElementById('newLegendZone').value = '';
+    renderLegend();
+}
+
+function removeLegendZone(zone) {
+    if (!confirm('Remove zone "' + zone + '" and all its entries?')) return;
+    delete data.MapLegendOverrides[zone];
+    renderLegend();
+}
+
+function addLegendEntry(zone) {
+    const sym = document.getElementById('newLegSym-' + zone).value.trim();
+    const lbl = document.getElementById('newLegLbl-' + zone).value.trim();
+    if (!sym || !lbl) return;
+    data.MapLegendOverrides[zone][sym] = lbl;
+    document.getElementById('newLegSym-' + zone).value = '';
+    document.getElementById('newLegLbl-' + zone).value = '';
+    renderLegend();
+}
+
+function removeLegendEntry(zone, sym) {
+    delete data.MapLegendOverrides[zone][sym];
+    renderLegend();
+}
+
+function renameLegendSymbol(zone, oldSym, newSym) {
+    newSym = newSym.trim();
+    if (!newSym || newSym === oldSym) return;
+    data.MapLegendOverrides[zone][newSym] = data.MapLegendOverrides[zone][oldSym];
+    delete data.MapLegendOverrides[zone][oldSym];
+    renderLegend();
+}
+
+function updateLegendEntry(zone, sym, val, row) {
+    const currentSymInput = row.querySelector('td:first-child input');
+    const currentSym = currentSymInput ? currentSymInput.value.trim() : sym;
+    const actualSym = data.MapLegendOverrides[zone][currentSym] !== undefined ? currentSym : sym;
+    data.MapLegendOverrides[zone][actualSym] = val.trim();
+}
+
+// ---- Save ----
+async function saveAll() {
+    collectTableEdits();
+    const res = await AdminAPI.patch('/admin/api/v1/keywords', data);
+    if (res.ok) {
+        data = (res.data && res.data.data) || data;
+        if (!data.Help) data.Help = {};
+        if (!data.HelpAliases) data.HelpAliases = {};
+        if (!data.CommandAliases) data.CommandAliases = {};
+        if (!data.DirectionAliases) data.DirectionAliases = {};
+        if (!data.MapLegendOverrides) data.MapLegendOverrides = {};
+        renderAll();
+        showStatus('success', 'Keywords saved successfully.');
+    } else {
+        showStatus('error', 'Save failed: ' + (res.error || 'unknown error'));
+    }
+}
+
+function collectTableEdits() {
+    // Re-read all table inputs to capture any uncommitted edits
+    const collectMap = (bodyId) => {
+        const result = {};
+        document.querySelectorAll('#' + bodyId + ' tr').forEach(row => {
+            const inputs = row.querySelectorAll('input[type="text"]');
+            if (inputs.length >= 2) {
+                const key = inputs[0].value.trim();
+                const val = inputs[1].value.trim();
+                if (key) result[key] = val;
+            }
+        });
+        return result;
+    };
+
+    // Help aliases
+    const ha = collectMap('helpAliasesBody');
+    data.HelpAliases = {};
+    for (const [k, v] of Object.entries(ha)) {
+        data.HelpAliases[k] = v.split(',').map(s => s.trim()).filter(Boolean);
+    }
+
+    // Command aliases
+    const ca = collectMap('cmdAliasesBody');
+    data.CommandAliases = {};
+    for (const [k, v] of Object.entries(ca)) {
+        data.CommandAliases[k] = v.split(',').map(s => s.trim()).filter(Boolean);
+    }
+
+    // Direction aliases
+    const da = collectMap('dirAliasesBody');
+    data.DirectionAliases = {};
+    for (const [k, v] of Object.entries(da)) {
+        if (k && v) data.DirectionAliases[k] = v;
+    }
+}
+
+// ---- Helpers ----
+function showStatus(type, msg) {
+    const bar = document.getElementById('statusBar');
+    bar.className = 'status-bar ' + type;
+    bar.textContent = msg;
+    if (type === 'success') setTimeout(() => { bar.className = 'status-bar'; }, 4000);
+}
+
+function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+function escAttr(s) { return String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+init();
+</script>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/keywords.html
+++ b/_datafiles/html/admin/keywords.html
@@ -81,7 +81,7 @@
 </style>
 
 <h1>Keywords</h1>
-<p class="subtitle">Help topics, aliases, direction shortcuts, and map legend overrides. <a href="/admin/keywords-api">API Docs →</a></p>
+<p class="subtitle">Help topics, aliases, direction shortcuts, and map legend overrides.</p>
 
 <div id="statusBar" class="status-bar"></div>
 <button class="btn-save-all" onclick="saveAll()">Save All Changes</button>

--- a/_datafiles/html/admin/races.html
+++ b/_datafiles/html/admin/races.html
@@ -62,7 +62,7 @@
 </style>
 
 <h1>Races</h1>
-<p class="subtitle">View, create, edit and delete race definitions. <a href="/admin/races-api">API Docs →</a></p>
+<p class="subtitle">View, create, edit and delete race definitions.</p>
 
 <div class="page-layout">
     <div class="sidebar">

--- a/_datafiles/html/admin/static/js/ansitags.js
+++ b/_datafiles/html/admin/static/js/ansitags.js
@@ -1,0 +1,531 @@
+/**
+ * ansitags.js
+ *
+ * Parses strings containing <ansi> tags and converts them to HTML <span> tags
+ * with inline color styles. This is a JavaScript port of the ansitags Go library,
+ * supporting the same tag format and producing identical HTML output.
+ *
+ * Tag format:
+ *   <ansi fg="{color}" bg="{color}">text</ansi>
+ *
+ *   Colors may be specified as a 256-color ANSI code (0-255) or a named alias.
+ *   Built-in named colors: black, red, green, yellow, blue, magenta, cyan, white,
+ *   and their -bold variants (e.g. red-bold, blue-bold).
+ *
+ * Browser usage (include the script directly in a web page):
+ *
+ *   <script src="ansitags.js"></script>
+ *   <script>
+ *     document.getElementById('output').innerHTML =
+ *       ansitags.parse('<ansi fg="red">hello</ansi> world');
+ *   </script>
+ *
+ * Node.js usage:
+ *
+ *   const { parse, loadAliases, setAlias, setAliases, rgb } = require('./ansitags');
+ *
+ *   // Basic parsing - outputs HTML spans
+ *   parse('<ansi fg="red">hello</ansi>');
+ *   // => '<span style="color:#800000;">hello</span>'
+ *
+ *   // Foreground and background
+ *   parse('<ansi fg="blue" bg="yellow">hello</ansi>');
+ *   // => '<span style="color:#000080;background-color:#808000;">hello</span>'
+ *
+ *   // Numeric 256-color codes
+ *   parse('<ansi fg="196">hello</ansi>');
+ *   // => '<span style="color:#ff0000;">hello</span>'
+ *
+ *   // Nested tags - inner tag inherits unspecified properties from parent
+ *   parse('<ansi fg="green">outer <ansi fg="red">inner</ansi> outer</ansi>');
+ *
+ *   // Strip all tags, leaving only the text content
+ *   parse('<ansi fg="red">hello</ansi>', { stripTags: true });
+ *   // => 'hello'
+ *
+ *   // Monochrome - strip color, keep tag structure
+ *   parse('<ansi fg="red">hello</ansi>', { monochrome: true });
+ *   // => '<span>hello</span>'
+ *
+ *   // Load custom color aliases (flat key:value object)
+ *   loadAliases({ date: 207, username: 195, highlight: 'yellow' });
+ *   parse('<ansi fg="date">2026-04-22</ansi>');
+ *
+ *   // Look up RGB values for any ANSI 256 color code
+ *   rgb(196); // => { r: 255, g: 0, b: 0, hex: 'ff0000' }
+ */
+
+'use strict';
+
+// ANSI 256-color palette: RGB values for codes 0-255
+const ansi256 = (() => {
+  const palette = new Array(256);
+
+  const base16 = [
+    [0, 0, 0], [128, 0, 0], [0, 128, 0], [128, 128, 0],
+    [0, 0, 128], [128, 0, 128], [0, 128, 128], [192, 192, 192],
+    [128, 128, 128], [255, 0, 0], [0, 255, 0], [255, 255, 0],
+    [0, 0, 255], [255, 0, 255], [0, 255, 255], [255, 255, 255],
+  ];
+  for (let i = 0; i < 16; i++) {
+    palette[i] = base16[i];
+  }
+
+  const cube = [0, 95, 135, 175, 215, 255];
+  let idx = 16;
+  for (let r = 0; r < 6; r++) {
+    for (let g = 0; g < 6; g++) {
+      for (let b = 0; b < 6; b++) {
+        palette[idx++] = [cube[r], cube[g], cube[b]];
+      }
+    }
+  }
+
+  for (let i = 232; i < 256; i++) {
+    const gray = 8 + (i - 232) * 10;
+    palette[i] = [gray, gray, gray];
+  }
+
+  return palette;
+})();
+
+function toHex(n) {
+  return n.toString(16).padStart(2, '0');
+}
+
+function colorHex(colorCode) {
+  const [r, g, b] = ansi256[colorCode];
+  return toHex(r) + toHex(g) + toHex(b);
+}
+
+// Pre-computed HTML style fragments for all 256 colors
+const htmlFgStyle = new Array(256);
+const htmlBgStyle = new Array(256);
+for (let i = 0; i < 256; i++) {
+  const hex = colorHex(i);
+  htmlFgStyle[i] = 'color:#' + hex + ';';
+  htmlBgStyle[i] = 'background-color:#' + hex + ';';
+}
+
+const DEFAULT_COLOR = -2;
+const HTML_RESET_ALL = '</span>';
+
+const defaultColorAliases = {
+  'black': 0, 'red': 1, 'green': 2, 'yellow': 3,
+  'blue': 4, 'magenta': 5, 'cyan': 6, 'white': 7,
+  'black-bold': 8, 'red-bold': 9, 'green-bold': 10, 'yellow-bold': 11,
+  'blue-bold': 12, 'magenta-bold': 13, 'cyan-bold': 14, 'white-bold': 15,
+};
+
+const defaultPositionMap = {
+  'topleft': ['1', '1'],
+};
+
+const clearMap = {
+  'aftercursor': 0,
+  'beforecursor': 1,
+  'all': 2,
+  'scrollback': 3,
+};
+
+// Mutable state — aliases and position map
+let colorAliases = Object.assign({}, defaultColorAliases);
+let positionMap = Object.assign({}, defaultPositionMap);
+
+// --- Tag matcher ---
+
+class TagMatcher {
+  constructor(startByte, midBytes, endByte, unknownLength) {
+    this.startByte = startByte;
+    this.midBytes = midBytes;
+    this.endByte = endByte;
+    this.exactMatch = !unknownLength;
+    this.totalSize = midBytes.length + 1;
+    this.position = 0;
+  }
+
+  reset() {
+    this.position = 0;
+  }
+
+  // Returns { matched: bool, complete: bool }
+  matchNext(char) {
+    if (this.position === 0) {
+      if (char === this.startByte) {
+        this.position++;
+        return { matched: true, complete: false };
+      }
+      return { matched: false, complete: true };
+    }
+
+    if (this.position >= this.totalSize) {
+      if (char === this.endByte) {
+        this.position++;
+        return { matched: true, complete: true };
+      }
+      if (this.exactMatch) {
+        this.position = 0;
+        return { matched: false, complete: true };
+      }
+      return { matched: true, complete: false };
+    }
+
+    if (char === this.midBytes[this.position - 1]) {
+      this.position++;
+      return { matched: true, complete: false };
+    }
+
+    this.position = 0;
+    return { matched: false, complete: true };
+  }
+}
+
+// --- Property extraction ---
+
+function extractProperties(tagStr) {
+  const props = { fg: DEFAULT_COLOR, bg: DEFAULT_COLOR, clear: -1, position: null };
+
+  let i = 0;
+  const n = tagStr.length;
+
+  while (i < n) {
+    if (tagStr[i] !== ' ') {
+      i++;
+      continue;
+    }
+    i++; // consume space
+
+    const keyStart = i;
+    while (i < n && tagStr[i] !== '=') i++;
+    if (i >= n) break;
+    const key = tagStr.slice(keyStart, i);
+    i++; // consume '='
+
+    if (i >= n) break;
+
+    let quote = 0;
+    if (tagStr[i] === "'" || tagStr[i] === '"') {
+      quote = tagStr[i];
+      i++;
+    }
+    const valStart = i;
+    if (quote) {
+      while (i < n && tagStr[i] !== quote) i++;
+    } else {
+      while (i < n && tagStr[i] !== ' ' && tagStr[i] !== '>') i++;
+    }
+    const val = tagStr.slice(valStart, i);
+    if (quote && i < n) i++; // consume closing quote
+
+    if (val.length === 0) continue;
+
+    switch (key) {
+      case 'fg': {
+        const num = parseInt(val, 10);
+        if (!isNaN(num) && String(num) === val) {
+          props.fg = num;
+        } else if (colorAliases[val] !== undefined) {
+          props.fg = colorAliases[val];
+        } else {
+          props.fg = DEFAULT_COLOR;
+        }
+        break;
+      }
+      case 'bg': {
+        const num = parseInt(val, 10);
+        if (!isNaN(num) && String(num) === val) {
+          props.bg = num;
+        } else if (colorAliases[val] !== undefined) {
+          props.bg = colorAliases[val];
+        } else {
+          props.bg = DEFAULT_COLOR;
+        }
+        break;
+      }
+      case 'position': {
+        let posArr = null;
+        if (positionMap[val]) {
+          posArr = positionMap[val];
+        } else {
+          const comma = val.indexOf(',');
+          if (comma > 0) {
+            posArr = [val.slice(0, comma), val.slice(comma + 1)];
+          }
+        }
+        if (posArr && posArr.length === 2) {
+          const x = parseInt(posArr[0], 10);
+          const y = parseInt(posArr[1], 10);
+          if (!isNaN(x) && !isNaN(y) && x >= 0 && y >= 0 && x <= 16000 && y <= 16000) {
+            props.position = [x, y];
+          }
+        }
+        break;
+      }
+      case 'clear': {
+        if (clearMap[val] !== undefined) {
+          props.clear = clearMap[val];
+        }
+        break;
+      }
+    }
+  }
+
+  return props;
+}
+
+// --- HTML span generation ---
+
+function propagateHTML(props, previous) {
+  let fg = props.fg;
+  let bg = props.bg;
+
+  if (previous !== null) {
+    if (fg === DEFAULT_COLOR) fg = previous.fg;
+    if (bg === DEFAULT_COLOR) bg = previous.bg;
+  }
+
+  if (previous !== null && fg === previous.fg && bg === previous.bg) {
+    return '<span>';
+  }
+
+  if (fg === DEFAULT_COLOR && bg === DEFAULT_COLOR) {
+    return '<span>';
+  }
+
+  if (fg > -1 && bg > -1) {
+    return '<span style="' + htmlFgStyle[fg] + htmlBgStyle[bg] + '">';
+  }
+  if (fg > -1) {
+    return '<span style="' + htmlFgStyle[fg] + '">';
+  }
+  if (bg > -1) {
+    return '<span style="' + htmlBgStyle[bg] + '">';
+  }
+  return '<span>';
+}
+
+// --- Core parser ---
+
+const TAG_START = '<';
+const TAG_END = '>';
+const TAG_OPEN_MID = 'ansi';
+const TAG_CLOSE_MID = '/ansi';
+const MAX_TAG_SIZE = 256;
+
+const PARSE_MODE_NONE = 0;
+const PARSE_MODE_MATCHING = 1;
+
+/**
+ * Parse a string containing <ansi> tags and return HTML with <span> tags.
+ *
+ * @param {string} str - Input string with ansi tags.
+ * @param {object} [options]
+ * @param {boolean} [options.stripTags=false] - Remove all valid ansi tags from output.
+ * @param {boolean} [options.monochrome=false] - Ignore color properties.
+ * @returns {string} Parsed output string.
+ */
+function parse(str, options) {
+  const stripAllTags = !!(options && options.stripTags);
+  const stripAllColor = !!(options && options.monochrome);
+
+  const tagStack = [];
+  const tagBuf = new Array(MAX_TAG_SIZE);
+  let tagLen = 0;
+
+  const openMatcher = new TagMatcher(TAG_START, TAG_OPEN_MID, TAG_END, true);
+  const closeMatcher = new TagMatcher(TAG_START, TAG_CLOSE_MID, TAG_END, false);
+
+  let mode = PARSE_MODE_NONE;
+  let out = '';
+
+  for (let i = 0; i < str.length; i++) {
+    const input = str[i];
+
+    if (mode === PARSE_MODE_NONE) {
+      if (input !== TAG_START) {
+        out += input;
+        continue;
+      }
+      mode = PARSE_MODE_MATCHING;
+    }
+
+    if (mode === PARSE_MODE_MATCHING) {
+      const openResult = openMatcher.matchNext(input);
+      const closeResult = closeMatcher.matchNext(input);
+
+      if (openResult.matched) {
+        if (tagLen < MAX_TAG_SIZE) {
+          tagBuf[tagLen++] = input;
+        }
+
+        if (!openResult.complete) continue;
+
+        let newTag = extractProperties(tagBuf.slice(0, tagLen).join(''));
+
+        if (stripAllColor) {
+          newTag.fg = DEFAULT_COLOR;
+          newTag.bg = DEFAULT_COLOR;
+        }
+
+        tagLen = 0;
+
+        if (!stripAllTags) {
+          const stackLen = tagStack.length;
+          const previous = stackLen > 0 ? tagStack[stackLen - 1] : null;
+          out += propagateHTML(newTag, previous);
+          tagStack.push(newTag);
+        }
+
+        mode = PARSE_MODE_NONE;
+        openMatcher.reset();
+        closeMatcher.reset();
+        continue;
+      }
+      openMatcher.reset();
+
+      if (closeResult.matched) {
+        if (tagLen < MAX_TAG_SIZE) {
+          tagBuf[tagLen++] = input;
+        }
+
+        if (!closeResult.complete) continue;
+
+        tagLen = 0;
+        if (!stripAllTags) {
+          const stackLen = tagStack.length;
+
+          if (stackLen > 2) {
+            out += propagateHTML(tagStack[stackLen - 2], tagStack[stackLen - 3]);
+          } else if (stackLen > 1) {
+            out += propagateHTML(tagStack[stackLen - 2], null);
+          } else {
+            out += HTML_RESET_ALL;
+          }
+
+          if (stackLen > 0) {
+            tagStack.pop();
+          }
+        }
+
+        mode = PARSE_MODE_NONE;
+        openMatcher.reset();
+        closeMatcher.reset();
+        continue;
+      }
+      closeMatcher.reset();
+
+      if (openResult.complete && closeResult.complete) {
+        if (tagLen < MAX_TAG_SIZE) {
+          tagBuf[tagLen++] = input;
+        }
+      }
+
+      mode = PARSE_MODE_NONE;
+
+      if (!stripAllTags) {
+        out += tagBuf.slice(0, tagLen).join('');
+      }
+      tagLen = 0;
+      continue;
+    }
+  }
+
+  if (!stripAllTags) {
+    if (tagLen > 0) {
+      out += tagBuf.slice(0, tagLen).join('');
+      tagLen = 0;
+    }
+
+    if (tagStack.length > 0) {
+      out += HTML_RESET_ALL;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Set a single color alias.
+ *
+ * @param {string} alias
+ * @param {number} value - 0-255
+ */
+function setAlias(alias, value) {
+  if (value < 0 || value > 255) {
+    throw new RangeError(`value "${value}" out of allowable range for alias "${alias}"`);
+  }
+  colorAliases = Object.assign({}, colorAliases, { [alias]: value });
+}
+
+/**
+ * Set multiple color aliases at once.
+ *
+ * @param {Object.<string, number>} aliases
+ */
+function setAliases(aliases) {
+  for (const [alias, value] of Object.entries(aliases)) {
+    if (value < 0 || value > 255) {
+      throw new RangeError(`value "${value}" out of allowable range for alias "${alias}"`);
+    }
+  }
+  colorAliases = Object.assign({}, colorAliases, aliases);
+}
+
+/**
+ * Load color aliases from a flat object.
+ *
+ * Values may be numeric color codes (0-255) or strings referencing another
+ * alias name. Alias-to-alias references are resolved after all numeric values
+ * are registered. Unresolvable references are silently ignored.
+ *
+ * Example:
+ *   loadAliases({ date: 207, username: 195, highlight: 'yellow' });
+ *
+ * @param {Object.<string, number|string>} aliases
+ */
+function loadAliases(aliases) {
+  const newColors = Object.assign({}, colorAliases);
+  const deferred = {};
+
+  for (const [alias, raw] of Object.entries(aliases)) {
+    const num = typeof raw === 'number' ? raw : parseInt(raw, 10);
+    if (!isNaN(num) && String(num) === String(raw).trim()) {
+      if (num < 0 || num > 255) {
+        throw new RangeError(`value "${num}" out of allowable range for alias "${alias}"`);
+      }
+      newColors[alias] = num;
+    } else {
+      deferred[alias] = String(raw);
+    }
+  }
+
+  for (const [alias, ref] of Object.entries(deferred)) {
+    if (newColors[ref] !== undefined) {
+      newColors[alias] = newColors[ref];
+    }
+  }
+
+  colorAliases = newColors;
+}
+
+/**
+ * Returns the RGB components for an ANSI 256 color code.
+ *
+ * @param {number} colorCode - 0-255
+ * @returns {{ r: number, g: number, b: number, hex: string }}
+ */
+function rgb(colorCode) {
+  if (colorCode < 0 || colorCode > 255) {
+    return { r: 0, g: 0, b: 0, hex: '000000' };
+  }
+  const [r, g, b] = ansi256[colorCode];
+  return { r, g, b, hex: colorHex(colorCode) };
+}
+
+const _exports = { parse, setAlias, setAliases, loadAliases, rgb };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = _exports;
+} else if (typeof window !== 'undefined') {
+  window.ansitags = _exports;
+}

--- a/_datafiles/html/admin/static/js/api.js
+++ b/_datafiles/html/admin/static/js/api.js
@@ -23,6 +23,22 @@
 const AdminAPI = (() => {
     'use strict';
 
+    const CACHE_TTL_MS = 30000; // how long GET results are cached (ms)
+
+    const _cache = new Map();
+
+    // /admin/api/v1/items/attack-messages -> /admin/api/v1/items
+    function _rootPath(path) {
+        return path.split('/').slice(0, 5).join('/');
+    }
+
+    function _invalidate(path) {
+        const prefix = _rootPath(path);
+        for (const key of _cache.keys()) {
+            if (key.startsWith(prefix)) _cache.delete(key);
+        }
+    }
+
     /**
      * @typedef {Object} APIResult
      * @property {boolean} ok          - true when HTTP status is 2xx
@@ -83,8 +99,15 @@ const AdminAPI = (() => {
      * @param {string} path
      * @returns {Promise<APIResult>}
      */
-    function get(path) {
-        return request('GET', path);
+    async function get(path) {
+        const cached = _cache.get(path);
+        if (cached && Date.now() < cached.expires) return cached.result;
+
+        const result = await request('GET', path);
+        if (result.ok) {
+            _cache.set(path, { result, expires: Date.now() + CACHE_TTL_MS });
+        }
+        return result;
     }
 
     /**
@@ -93,8 +116,10 @@ const AdminAPI = (() => {
      * @param {Object} body
      * @returns {Promise<APIResult>}
      */
-    function post(path, body) {
-        return request('POST', path, body);
+    async function post(path, body) {
+        const result = await request('POST', path, body);
+        _invalidate(path);
+        return result;
     }
 
     /**
@@ -104,7 +129,9 @@ const AdminAPI = (() => {
      * @returns {Promise<APIResult>}
      */
     function put(path, body) {
-        return request('PUT', path, body);
+        const result = request('PUT', path, body);
+        _invalidate(path);
+        return result;
     }
 
     /**
@@ -113,8 +140,10 @@ const AdminAPI = (() => {
      * @param {Object} body
      * @returns {Promise<APIResult>}
      */
-    function patch(path, body) {
-        return request('PATCH', path, body);
+    async function patch(path, body) {
+        const result = await request('PATCH', path, body);
+        _invalidate(path);
+        return result;
     }
 
     /**
@@ -123,8 +152,10 @@ const AdminAPI = (() => {
      * @param {Object|null} body
      * @returns {Promise<APIResult>}
      */
-    function del(path, body = null) {
-        return request('DELETE', path, body);
+    async function del(path, body = null) {
+        const result = await request('DELETE', path, body);
+        _invalidate(path);
+        return result;
     }
 
     /**

--- a/cmd/reset-admin-pw/main_test.go
+++ b/cmd/reset-admin-pw/main_test.go
@@ -118,7 +118,7 @@ character:
 func createUserIndex(t *testing.T) {
 	t.Helper()
 
-	index := users.NewUserIndex()
+	index := users.InitUserIndex()
 	if err := index.Create(); err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 require (
-	github.com/GoMudEngine/ansitags v1.1.0
+	github.com/GoMudEngine/ansitags v1.3.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/GoMudEngine/ansitags v1.1.0 h1:hnRaeXp2EbJAVwTDtjXQ/mtZWJ35cOjQ1laLdko+bo4=
-github.com/GoMudEngine/ansitags v1.1.0/go.mod h1:McpBTRYx4TE/+aVbK4veo7z6mDNrpi3Lka88FenWa3A=
+github.com/GoMudEngine/ansitags v1.3.0 h1:f0zZ0VGNmGC1G+qRO+Ers/OMkZU4dAE4Ip+Xo0z9soY=
+github.com/GoMudEngine/ansitags v1.3.0/go.mod h1:McpBTRYx4TE/+aVbK4veo7z6mDNrpi3Lka88FenWa3A=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/internal/items/admin.go
+++ b/internal/items/admin.go
@@ -3,9 +3,11 @@ package items
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
 	"github.com/GoMudEngine/GoMud/internal/fileloader"
+	"gopkg.in/yaml.v2"
 )
 
 // GetAllAttackMessages returns a copy of the loaded attack message groups keyed
@@ -16,6 +18,186 @@ func GetAllAttackMessages() map[ItemSubType]*WeaponAttackMessageGroup {
 		result[k] = v
 	}
 	return result
+}
+
+func AddAttackMessage(subtype ItemSubType, intensity Intensity, proximity, target, message string) error {
+	group, ok := attackMessages[subtype]
+	if !ok {
+		return fmt.Errorf("unknown subtype: %s", subtype)
+	}
+
+	opts, ok := group.Options[intensity]
+	if !ok {
+		return fmt.Errorf("unknown intensity: %s", intensity)
+	}
+
+	msg := ItemMessage(message)
+
+	switch proximity {
+	case "together":
+		switch target {
+		case "toattacker":
+			opts.Together.ToAttacker = append(opts.Together.ToAttacker, msg)
+		case "todefender":
+			opts.Together.ToDefender = append(opts.Together.ToDefender, msg)
+		case "toroom":
+			opts.Together.ToRoom = append(opts.Together.ToRoom, msg)
+		default:
+			return fmt.Errorf("unknown together target: %s", target)
+		}
+	case "separate":
+		switch target {
+		case "toattacker":
+			opts.Separate.ToAttacker = append(opts.Separate.ToAttacker, msg)
+		case "todefender":
+			opts.Separate.ToDefender = append(opts.Separate.ToDefender, msg)
+		case "toattackerroom":
+			opts.Separate.ToAttackerRoom = append(opts.Separate.ToAttackerRoom, msg)
+		case "todefenderroom":
+			opts.Separate.ToDefenderRoom = append(opts.Separate.ToDefenderRoom, msg)
+		default:
+			return fmt.Errorf("unknown separate target: %s", target)
+		}
+	default:
+		return fmt.Errorf("unknown proximity: %s (expected together or separate)", proximity)
+	}
+
+	group.Options[intensity] = opts
+
+	return SaveAttackMessageGroup(group)
+}
+
+func DeleteAttackMessage(subtype ItemSubType, intensity Intensity, proximity, target string, index int) error {
+	group, ok := attackMessages[subtype]
+	if !ok {
+		return fmt.Errorf("unknown subtype: %s", subtype)
+	}
+
+	opts, ok := group.Options[intensity]
+	if !ok {
+		return fmt.Errorf("unknown intensity: %s", intensity)
+	}
+
+	remove := func(sl MessageOptions, i int) (MessageOptions, error) {
+		if i < 0 || i >= len(sl) {
+			return nil, fmt.Errorf("index %d out of range (length %d)", i, len(sl))
+		}
+		return append(sl[:i], sl[i+1:]...), nil
+	}
+
+	var err error
+	switch proximity {
+	case "together":
+		switch target {
+		case "toattacker":
+			opts.Together.ToAttacker, err = remove(opts.Together.ToAttacker, index)
+		case "todefender":
+			opts.Together.ToDefender, err = remove(opts.Together.ToDefender, index)
+		case "toroom":
+			opts.Together.ToRoom, err = remove(opts.Together.ToRoom, index)
+		default:
+			return fmt.Errorf("unknown together target: %s", target)
+		}
+	case "separate":
+		switch target {
+		case "toattacker":
+			opts.Separate.ToAttacker, err = remove(opts.Separate.ToAttacker, index)
+		case "todefender":
+			opts.Separate.ToDefender, err = remove(opts.Separate.ToDefender, index)
+		case "toattackerroom":
+			opts.Separate.ToAttackerRoom, err = remove(opts.Separate.ToAttackerRoom, index)
+		case "todefenderroom":
+			opts.Separate.ToDefenderRoom, err = remove(opts.Separate.ToDefenderRoom, index)
+		default:
+			return fmt.Errorf("unknown separate target: %s", target)
+		}
+	default:
+		return fmt.Errorf("unknown proximity: %s (expected together or separate)", proximity)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	group.Options[intensity] = opts
+
+	return SaveAttackMessageGroup(group)
+}
+
+func SaveAttackMessageGroup(group *WeaponAttackMessageGroup) error {
+	basePath := configs.GetFilePathsConfig().DataFiles.String() + `/combat-messages/`
+	filePath := basePath + group.Filepath()
+
+	sectionComments := extractCombatComments(filePath)
+
+	bytes, err := yaml.Marshal(group)
+	if err != nil {
+		return fmt.Errorf("marshaling attack messages: %w", err)
+	}
+
+	bytes = insertCombatComments(bytes, sectionComments)
+
+	if err := os.WriteFile(filePath, bytes, 0644); err != nil {
+		return fmt.Errorf("writing attack messages file: %w", err)
+	}
+
+	attackMessages[group.OptionId] = group
+	return nil
+}
+
+func extractCombatComments(path string) map[string][]string {
+	comments := make(map[string][]string)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return comments
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var pending []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			pending = append(pending, line)
+			continue
+		}
+
+		if len(line) > 0 && line[0] != ' ' && line[0] != '\t' && strings.Contains(line, ":") {
+			key := strings.TrimSpace(line[:strings.Index(line, ":")])
+			if len(pending) > 0 {
+				comments[key] = append([]string{}, pending...)
+				pending = nil
+			}
+		} else {
+			pending = nil
+		}
+	}
+
+	return comments
+}
+
+func insertCombatComments(data []byte, comments map[string][]string) []byte {
+	if len(comments) == 0 {
+		return data
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var result []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if len(line) > 0 && line[0] != ' ' && line[0] != '\t' && trimmed != "" && strings.Contains(line, ":") {
+			key := strings.TrimSpace(line[:strings.Index(line, ":")])
+			if commentLines, ok := comments[key]; ok {
+				result = append(result, commentLines...)
+			}
+		}
+		result = append(result, line)
+	}
+
+	return []byte(strings.Join(result, "\n"))
 }
 
 // SaveItemSpec persists an existing ItemSpec back to its data file and updates

--- a/internal/keywords/admin.go
+++ b/internal/keywords/admin.go
@@ -3,6 +3,7 @@ package keywords
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
 	"gopkg.in/yaml.v2"
@@ -61,12 +62,17 @@ func SaveKeywords(a *Aliases) error {
 		return fmt.Errorf("keywords data cannot be nil")
 	}
 
+	path := configs.GetFilePathsConfig().DataFiles.String() + `/keywords.yaml`
+
+	sectionComments := extractSectionComments(path)
+
 	bytes, err := yaml.Marshal(a)
 	if err != nil {
 		return fmt.Errorf("marshaling keywords: %w", err)
 	}
 
-	path := configs.GetFilePathsConfig().DataFiles.String() + `/keywords.yaml`
+	bytes = insertSectionComments(bytes, sectionComments)
+
 	if err := os.WriteFile(path, bytes, 0644); err != nil {
 		return fmt.Errorf("writing keywords file: %w", err)
 	}
@@ -77,4 +83,63 @@ func SaveKeywords(a *Aliases) error {
 	}
 
 	return nil
+}
+
+// extractSectionComments reads the file at path and returns comment blocks
+// (including preceding blank lines) keyed by the top-level YAML key they precede.
+func extractSectionComments(path string) map[string][]string {
+	comments := make(map[string][]string)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return comments
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var pending []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			pending = append(pending, line)
+			continue
+		}
+
+		if len(line) > 0 && line[0] != ' ' && line[0] != '\t' && strings.Contains(line, ":") {
+			key := strings.TrimSpace(line[:strings.Index(line, ":")])
+			if len(pending) > 0 {
+				comments[key] = append([]string{}, pending...)
+				pending = nil
+			}
+		} else {
+			pending = nil
+		}
+	}
+
+	return comments
+}
+
+// insertSectionComments splices saved comment blocks back into marshaled YAML
+// output, placing each block immediately before its associated top-level key.
+func insertSectionComments(data []byte, comments map[string][]string) []byte {
+	if len(comments) == 0 {
+		return data
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var result []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if len(line) > 0 && line[0] != ' ' && line[0] != '\t' && trimmed != "" && strings.Contains(line, ":") {
+			key := strings.TrimSpace(line[:strings.Index(line, ":")])
+			if commentLines, ok := comments[key]; ok {
+				result = append(result, commentLines...)
+			}
+		}
+		result = append(result, line)
+	}
+
+	return []byte(strings.Join(result, "\n"))
 }

--- a/internal/keywords/admin.go
+++ b/internal/keywords/admin.go
@@ -1,0 +1,80 @@
+package keywords
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"gopkg.in/yaml.v2"
+)
+
+func GetKeywords() *Aliases {
+	if loadedKeywords == nil {
+		return &Aliases{}
+	}
+	cp := *loadedKeywords
+
+	cp.Help = make(map[string]map[string][]string, len(loadedKeywords.Help))
+	for k, v := range loadedKeywords.Help {
+		inner := make(map[string][]string, len(v))
+		for ik, iv := range v {
+			sl := make([]string, len(iv))
+			copy(sl, iv)
+			inner[ik] = sl
+		}
+		cp.Help[k] = inner
+	}
+
+	cp.HelpAliases = make(map[string][]string, len(loadedKeywords.HelpAliases))
+	for k, v := range loadedKeywords.HelpAliases {
+		sl := make([]string, len(v))
+		copy(sl, v)
+		cp.HelpAliases[k] = sl
+	}
+
+	cp.CommandAliases = make(map[string][]string, len(loadedKeywords.CommandAliases))
+	for k, v := range loadedKeywords.CommandAliases {
+		sl := make([]string, len(v))
+		copy(sl, v)
+		cp.CommandAliases[k] = sl
+	}
+
+	cp.DirectionAliases = make(map[string]string, len(loadedKeywords.DirectionAliases))
+	for k, v := range loadedKeywords.DirectionAliases {
+		cp.DirectionAliases[k] = v
+	}
+
+	cp.MapLegendOverrides = make(map[string]map[string]string, len(loadedKeywords.MapLegendOverrides))
+	for k, v := range loadedKeywords.MapLegendOverrides {
+		inner := make(map[string]string, len(v))
+		for ik, iv := range v {
+			inner[ik] = iv
+		}
+		cp.MapLegendOverrides[k] = inner
+	}
+
+	return &cp
+}
+
+func SaveKeywords(a *Aliases) error {
+	if a == nil {
+		return fmt.Errorf("keywords data cannot be nil")
+	}
+
+	bytes, err := yaml.Marshal(a)
+	if err != nil {
+		return fmt.Errorf("marshaling keywords: %w", err)
+	}
+
+	path := configs.GetFilePathsConfig().DataFiles.String() + `/keywords.yaml`
+	if err := os.WriteFile(path, bytes, 0644); err != nil {
+		return fmt.Errorf("writing keywords file: %w", err)
+	}
+
+	loadedKeywords = a
+	if err := loadedKeywords.Validate(); err != nil {
+		return fmt.Errorf("validating keywords after save: %w", err)
+	}
+
+	return nil
+}

--- a/internal/users/index.go
+++ b/internal/users/index.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/GoMud/internal/util"
 )
 
@@ -45,20 +47,35 @@ type IndexUserRecord struct {
 // UserIndex is the central struct that holds the index filename and methods
 // to work with the index.
 type UserIndex struct {
+	mu            sync.RWMutex
 	metaData      IndexMetaData
 	highestUserId int
 	Filename      string
+
+	records    []IndexUserRecord
+	byUsername map[string]int64
+	byUserId   map[int64]string
 }
 
-// NewUserIndex creates a new instance of UserIndex using the configured file path.
-func NewUserIndex() *UserIndex {
+var userIndex *UserIndex
+
+// InitUserIndex creates and initializes the singleton UserIndex. Called once at startup.
+func InitUserIndex() *UserIndex {
 	filename := util.FilePath(string(configs.GetFilePathsConfig().DataFiles), `/`, `users`, `/`, `users.idx`)
-	idx := &UserIndex{Filename: filename}
-	if idx.Exists() {
-		idx.metaData = idx.getMetaDataFromFile()
-		idx.calculateHighestUserId()
+	userIndex = &UserIndex{Filename: filename}
+	if userIndex.Exists() {
+		userIndex.metaData = userIndex.getMetaDataFromFile()
+		userIndex.loadRecords()
 	}
-	return idx
+	return userIndex
+}
+
+// GetUserIndex returns the singleton UserIndex, initializing it if needed.
+func GetUserIndex() *UserIndex {
+	if userIndex == nil {
+		return InitUserIndex()
+	}
+	return userIndex
 }
 
 func (idx *UserIndex) Exists() bool {
@@ -72,8 +89,54 @@ func (idx *UserIndex) Delete() {
 	}
 }
 
-// Writes a new index header then processes all user records to write a new index
+// loadRecords bulk-reads all records from disk into memory and builds lookup maps.
+func (idx *UserIndex) loadRecords() {
+	idx.byUsername = make(map[string]int64, idx.metaData.RecordCount)
+	idx.byUserId = make(map[int64]string, idx.metaData.RecordCount)
+	idx.highestUserId = 0
+
+	if idx.metaData.RecordCount == 0 {
+		idx.records = nil
+		return
+	}
+
+	f, err := os.Open(idx.Filename)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	dataSize := idx.metaData.RecordCount * idx.metaData.RecordSize
+	buf := make([]byte, dataSize)
+	if _, err := f.Seek(int64(idx.metaData.MetaDataSize), io.SeekStart); err != nil {
+		return
+	}
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return
+	}
+
+	idx.records = make([]IndexUserRecord, idx.metaData.RecordCount)
+
+	for i := uint64(0); i < idx.metaData.RecordCount; i++ {
+		offset := i * idx.metaData.RecordSize
+		rec := &idx.records[i]
+		copy(rec.Username[:], buf[offset:offset+80])
+		rec.UserID = int64(binary.LittleEndian.Uint64(buf[offset+80 : offset+88]))
+
+		username := string(bytes.TrimRight(rec.Username[:], "\x00"))
+		idx.byUsername[username] = rec.UserID
+		idx.byUserId[rec.UserID] = username
+
+		if int(rec.UserID) > idx.highestUserId {
+			idx.highestUserId = int(rec.UserID)
+		}
+	}
+}
+
+// Create initializes a new empty index file with a header.
 func (idx *UserIndex) Create() error {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
 
 	idx.Delete()
 
@@ -83,13 +146,16 @@ func (idx *UserIndex) Create() error {
 	}
 	defer f.Close()
 
-	// Reset metadata.
 	idx.metaData = IndexMetaData{
 		MetaDataSize: FixedHeaderTotalLength,
 		IndexVersion: IndexVersion,
 		RecordCount:  0,
 		RecordSize:   IndexRecordSizeV1,
 	}
+	idx.highestUserId = 0
+	idx.records = nil
+	idx.byUsername = make(map[string]int64)
+	idx.byUserId = make(map[int64]string)
 
 	headerBytes, err := idx.metaData.Format()
 	if err != nil {
@@ -102,186 +168,110 @@ func (idx *UserIndex) Create() error {
 	return nil
 }
 
-// Writes a new index header then processes all user records to write a new index
+// Rebuild recreates the index from all offline user records.
+// It calls Create() internally so it is self-contained.
 func (idx *UserIndex) Rebuild() error {
+	if err := idx.Create(); err != nil {
+		return fmt.Errorf("index create failed: %w", err)
+	}
 
-	// Example: Append each offline user record. The function SearchOfflineUsers
-	// and the type UserRecord are assumed to be defined elsewhere.
+	var firstErr error
 	SearchOfflineUsers(func(u *UserRecord) bool {
-		// Use the AppendUserRecord method to add the record.
 		if err := idx.AddUser(u.UserId, u.Username); err != nil {
-			// Handle error somehow?
+			mudlog.Error("UserIndex.Rebuild", "error", err.Error(), "userId", u.UserId, "username", u.Username)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 		return true
 	})
 
-	return nil
+	return firstErr
 }
 
 func (idx *UserIndex) GetMetaData() IndexMetaData {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 	return idx.metaData
 }
 
 func (idx *UserIndex) GetHighestUserId() int {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 	return idx.highestUserId
 }
 
-func (idx *UserIndex) calculateHighestUserId() {
+// ForEachRecord iterates over all index records, calling fn for each.
+// Returning false from fn stops iteration.
+func (idx *UserIndex) ForEachRecord(fn func(rec IndexUserRecord) bool) {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 
-	f, err := os.Open(idx.Filename)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-
-	for i := uint64(0); i < idx.metaData.RecordCount; i++ {
-		offset := int64(idx.metaData.MetaDataSize) + int64(i*idx.metaData.RecordSize)
-		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+	for _, rec := range idx.records {
+		if !fn(rec) {
 			return
-		}
-
-		var recUsername [80]byte
-		if n, err := io.ReadFull(f, recUsername[:]); err != nil || n != 80 {
-			return
-		}
-
-		var userId int64
-		if err := binary.Read(f, binary.LittleEndian, &userId); err != nil {
-			return
-		}
-
-		if int(userId) > idx.highestUserId {
-			idx.highestUserId = int(userId)
 		}
 	}
-
 }
 
-// FindByUsername opens the index file, reads its header, then iterates over
-func (idx *UserIndex) FindByUsername(username string) (int64, bool) {
+// FindByUsername searches the index for a username and returns its userId.
+func (idx *UserIndex) FindByUsername(username string) (int, bool) {
 	if len(username) > 80 {
 		return 0, false
 	}
 
-	f, err := os.Open(idx.Filename)
-	if err != nil {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	userId, ok := idx.byUsername[strings.ToLower(username)]
+	if !ok {
 		return 0, false
 	}
-	defer f.Close()
-
-	username = strings.ToLower(username)
-
-	for i := uint64(0); i < idx.metaData.RecordCount; i++ {
-		offset := int64(idx.metaData.MetaDataSize) + int64(i*idx.metaData.RecordSize)
-		if _, err := f.Seek(offset, io.SeekStart); err != nil {
-			return 0, false
-		}
-
-		var recUsername [80]byte
-		if n, err := io.ReadFull(f, recUsername[:]); err != nil || n != 80 {
-			return 0, false
-		}
-
-		var userId int64
-		if err := binary.Read(f, binary.LittleEndian, &userId); err != nil {
-			return 0, false
-		}
-
-		term := make([]byte, 1)
-		if _, err := f.Read(term); err != nil {
-			return 0, false
-		}
-		if term[0] != IndexLineTerminatorV1 {
-			return 0, false
-		}
-
-		// Compare only the first len(username) characters.
-		if len(username) < 80 && recUsername[len(username)] != 0 {
-			continue
-		}
-		match := true
-		for j := 0; j < len(username); j++ {
-			if username[j] != recUsername[j] {
-				match = false
-				break
-			}
-		}
-		if match {
-			return userId, true
-		}
-	}
-	return 0, false
+	return int(userId), true
 }
 
 // FindByUserId searches for a user record matching the provided userId.
-// If found, it returns the corresponding username.
-func (idx *UserIndex) FindByUserId(userId int64) (string, bool) {
-	f, err := os.Open(idx.Filename)
-	if err != nil {
+func (idx *UserIndex) FindByUserId(userId int) (string, bool) {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	username, ok := idx.byUserId[int64(userId)]
+	if !ok {
 		return "", false
 	}
-	defer f.Close()
-
-	for i := uint64(0); i < idx.metaData.RecordCount; i++ {
-		offset := int64(idx.metaData.MetaDataSize) + int64(i*idx.metaData.RecordSize)
-		if _, err := f.Seek(offset, io.SeekStart); err != nil {
-			return "", false
-		}
-
-		var recUsername [80]byte
-		if n, err := io.ReadFull(f, recUsername[:]); err != nil || n != 80 {
-			return "", false
-		}
-
-		var recUserId int64
-		if err := binary.Read(f, binary.LittleEndian, &recUserId); err != nil {
-			return "", false
-		}
-
-		term := make([]byte, 1)
-		if _, err := f.Read(term); err != nil {
-			return "", false
-		}
-		if term[0] != IndexLineTerminatorV1 {
-			return "", false
-		}
-
-		if recUserId == userId {
-			username := string(bytes.TrimRight(recUsername[:], "\x00"))
-			return username, true
-		}
-	}
-	return "", false
+	return username, true
 }
 
 func (idx *UserIndex) getMetaDataFromFile() IndexMetaData {
-
 	f, err := os.Open(idx.Filename)
 	if err != nil {
 		return IndexMetaData{}
 	}
 	defer f.Close()
 
-	headerBytes, err := idx.readFixedHeader(f)
-	if err != nil {
+	header := make([]byte, FixedHeaderTotalLength)
+	if _, err := io.ReadFull(f, header); err != nil {
 		return IndexMetaData{}
 	}
 
 	var meta IndexMetaData
-	meta.MetaDataSize = uint64(len(headerBytes))
-	headerContent := strings.TrimSpace(string(headerBytes[:FixedHeaderTotalLength-1]))
-	fmt.Sscanf(headerContent, "VERSION=%d,RECORDCOUNT=%d,RECORDSIZE=%d", &meta.IndexVersion, &meta.RecordCount, &meta.RecordSize)
+	meta.MetaDataSize = uint64(len(header))
+	headerContent := strings.TrimSpace(string(header[:FixedHeaderTotalLength-1]))
+	n, _ := fmt.Sscanf(headerContent, "VERSION=%d,RECORDCOUNT=%d,RECORDSIZE=%d", &meta.IndexVersion, &meta.RecordCount, &meta.RecordSize)
+	if n != 3 {
+		return IndexMetaData{}
+	}
 
 	return meta
 }
 
-// AppendUserRecord appends a new record to the index file and updates the header.
+// AddUser appends a new record to the index file and updates the header.
 func (idx *UserIndex) AddUser(userId int, username string) error {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
 
-	// We lowercase username so that we can ensure uniqueness
 	username = strings.ToLower(username)
 
-	// Create the new record
 	newRecord := IndexUserRecord{
 		UserID: int64(userId),
 	}
@@ -296,14 +286,13 @@ func (idx *UserIndex) AddUser(userId int, username string) error {
 	if _, err := f.Seek(0, io.SeekEnd); err != nil {
 		return fmt.Errorf("error seeking to file end: %w", err)
 	}
-	if _, err := f.Write(newRecord.Username[:]); err != nil {
-		return fmt.Errorf("error writing username: %w", err)
-	}
-	if err := binary.Write(f, binary.LittleEndian, newRecord.UserID); err != nil {
-		return fmt.Errorf("error writing userId: %w", err)
-	}
-	if _, err := f.Write([]byte{IndexLineTerminatorV1}); err != nil {
-		return fmt.Errorf("error writing record terminator: %w", err)
+
+	var recBuf [IndexRecordSizeV1]byte
+	copy(recBuf[:80], newRecord.Username[:])
+	binary.LittleEndian.PutUint64(recBuf[80:88], uint64(newRecord.UserID))
+	recBuf[88] = IndexLineTerminatorV1
+	if _, err := f.Write(recBuf[:]); err != nil {
+		return fmt.Errorf("error writing record: %w", err)
 	}
 
 	if userId > idx.highestUserId {
@@ -322,63 +311,59 @@ func (idx *UserIndex) AddUser(userId int, username string) error {
 	if _, err := f.Write(newHeaderBytes); err != nil {
 		return fmt.Errorf("error writing updated header: %w", err)
 	}
+
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("error syncing file: %w", err)
+	}
+
+	idx.records = append(idx.records, newRecord)
+	idx.byUsername[username] = int64(userId)
+	idx.byUserId[int64(userId)] = username
+
 	return nil
 }
 
-// RemoveUserRecordByUsername removes the first record that matches the provided username,
-// updates the header, and rewrites the file.
+// RemoveByUsername removes the first record matching the username and rewrites the index.
 func (idx *UserIndex) RemoveByUsername(username string) error {
-
-	f, err := os.Open(idx.Filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
 
 	username = strings.ToLower(username)
 
-	records := make([]IndexUserRecord, 0, idx.metaData.RecordCount)
-	recordFound := false
-
-	for i := uint64(0); i < idx.metaData.RecordCount; i++ {
-		offset := int64(idx.metaData.MetaDataSize) + int64(i*idx.metaData.RecordSize)
-		if _, err := f.Seek(offset, io.SeekStart); err != nil {
-			return fmt.Errorf("seek error: %w", err)
-		}
-
-		var rec IndexUserRecord
-		if n, err := f.Read(rec.Username[:]); err != nil || n != 80 {
-			return fmt.Errorf("error reading username: %w", err)
-		}
-		if err := binary.Read(f, binary.LittleEndian, &rec.UserID); err != nil {
-			return fmt.Errorf("error reading userId: %w", err)
-		}
-		term := make([]byte, 1)
-		if _, err := f.Read(term); err != nil {
-			return fmt.Errorf("error reading record terminator: %w", err)
-		}
-		if term[0] != IndexLineTerminatorV1 {
-			return fmt.Errorf("invalid record terminator")
-		}
-
-		recUserStr := string(bytes.TrimRight(rec.Username[:], "\x00"))
-		if recUserStr == username && !recordFound {
-			recordFound = true
-			continue // skip this record
-		}
-		records = append(records, rec)
-	}
-
-	if !recordFound {
+	if _, ok := idx.byUsername[username]; !ok {
 		return ErrNotFound
 	}
 
-	idx.metaData.RecordCount = uint64(len(records))
+	newRecords := make([]IndexUserRecord, 0, len(idx.records)-1)
+	removed := false
 
-	return idx.writeCompleteIndex(records)
+	for _, rec := range idx.records {
+		if !removed {
+			recUser := string(bytes.TrimRight(rec.Username[:], "\x00"))
+			if recUser == username {
+				removed = true
+				delete(idx.byUsername, username)
+				delete(idx.byUserId, rec.UserID)
+				continue
+			}
+		}
+		newRecords = append(newRecords, rec)
+	}
+
+	idx.records = newRecords
+	idx.metaData.RecordCount = uint64(len(newRecords))
+
+	idx.highestUserId = 0
+	for _, rec := range idx.records {
+		if int(rec.UserID) > idx.highestUserId {
+			idx.highestUserId = int(rec.UserID)
+		}
+	}
+
+	return idx.writeCompleteIndex(newRecords)
 }
 
-// formatFixedHeader formats the metadata header as a fixed-width string.
+// Format formats the metadata header as a fixed-width string.
 // The header (without newline) is exactly 99 bytes.
 func (m IndexMetaData) Format() ([]byte, error) {
 	headerContent := fmt.Sprintf("VERSION=%d,RECORDCOUNT=%d,RECORDSIZE=%d", m.IndexVersion, m.RecordCount, m.RecordSize)
@@ -389,45 +374,46 @@ func (m IndexMetaData) Format() ([]byte, error) {
 	return []byte(padded + string(IndexLineTerminatorV1)), nil
 }
 
-// readFixedHeader reads exactly 100 bytes (the fixed header) from the provided reader.
-func (idx *UserIndex) readFixedHeader(r io.Reader) ([]byte, error) {
-	header := make([]byte, FixedHeaderTotalLength)
-	n, err := io.ReadFull(r, header)
-	if err != nil {
-		return nil, err
-	}
-	if n != FixedHeaderTotalLength {
-		return nil, fmt.Errorf("expected %d bytes for header, got %d", FixedHeaderTotalLength, n)
-	}
-	return header, nil
-}
-
-// writeIndex writes the metadata header and all user records into the index file.
+// writeCompleteIndex writes metadata and all records atomically via temp file + rename.
 func (idx *UserIndex) writeCompleteIndex(records []IndexUserRecord) error {
-	f, err := os.Create(idx.Filename)
+	tmpFile := idx.Filename + ".tmp"
+	f, err := os.Create(tmpFile)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
-	headerBytes, err := idx.metaData.Format()
-	if err != nil {
-		return err
-	}
-	if _, err := f.Write(headerBytes); err != nil {
-		return err
+	writeErr := func() error {
+		headerBytes, err := idx.metaData.Format()
+		if err != nil {
+			return err
+		}
+
+		buf := make([]byte, 0, len(headerBytes)+len(records)*IndexRecordSizeV1)
+		buf = append(buf, headerBytes...)
+
+		var recBuf [IndexRecordSizeV1]byte
+		for _, rec := range records {
+			copy(recBuf[:80], rec.Username[:])
+			binary.LittleEndian.PutUint64(recBuf[80:88], uint64(rec.UserID))
+			recBuf[88] = IndexLineTerminatorV1
+			buf = append(buf, recBuf[:]...)
+		}
+
+		if _, err := f.Write(buf); err != nil {
+			return err
+		}
+
+		return f.Sync()
+	}()
+
+	if closeErr := f.Close(); writeErr == nil {
+		writeErr = closeErr
 	}
 
-	for _, rec := range records {
-		if _, err := f.Write(rec.Username[:]); err != nil {
-			return err
-		}
-		if err := binary.Write(f, binary.LittleEndian, rec.UserID); err != nil {
-			return err
-		}
-		if _, err := f.Write([]byte{IndexLineTerminatorV1}); err != nil {
-			return err
-		}
+	if writeErr != nil {
+		os.Remove(tmpFile)
+		return writeErr
 	}
-	return nil
+
+	return os.Rename(tmpFile, idx.Filename)
 }

--- a/internal/users/index_test.go
+++ b/internal/users/index_test.go
@@ -2,10 +2,152 @@ package users
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
 )
+
+func createBenchIndexFile(b *testing.B, filename string, recordCount int) *UserIndex {
+	b.Helper()
+	idx := &UserIndex{Filename: filename}
+	idx.Create()
+	for i := 1; i <= recordCount; i++ {
+		idx.AddUser(i*10, fmt.Sprintf("user_%d", i))
+	}
+	return idx
+}
+
+func benchTempFile(b *testing.B) (string, func()) {
+	b.Helper()
+	f, err := os.CreateTemp("", "bench_idx_*.idx")
+	if err != nil {
+		b.Fatal(err)
+	}
+	name := f.Name()
+	f.Close()
+	return name, func() { os.Remove(name) }
+}
+
+func BenchmarkFindByUsername_First(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := createBenchIndexFile(b, filename, 1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.FindByUsername("user_1")
+	}
+}
+
+func BenchmarkFindByUsername_Middle(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := createBenchIndexFile(b, filename, 1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.FindByUsername("user_500")
+	}
+}
+
+func BenchmarkFindByUsername_Last(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := createBenchIndexFile(b, filename, 1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.FindByUsername("user_1000")
+	}
+}
+
+func BenchmarkFindByUsername_Miss(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := createBenchIndexFile(b, filename, 1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.FindByUsername("nonexistent")
+	}
+}
+
+func BenchmarkFindByUserId_First(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := createBenchIndexFile(b, filename, 1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.FindByUserId(10)
+	}
+}
+
+func BenchmarkFindByUserId_Last(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := createBenchIndexFile(b, filename, 1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.FindByUserId(10000)
+	}
+}
+
+func BenchmarkFindByUserId_Miss(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := createBenchIndexFile(b, filename, 1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.FindByUserId(99999)
+	}
+}
+
+func BenchmarkAddUser(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := &UserIndex{Filename: filename}
+	idx.Create()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.AddUser(i, fmt.Sprintf("bench_user_%d", i))
+	}
+}
+
+func BenchmarkRemoveByUsername(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		idx := createBenchIndexFile(b, filename, 200)
+		b.StartTimer()
+		idx.RemoveByUsername("user_100")
+	}
+}
+
+func BenchmarkForEachRecord(b *testing.B) {
+	filename, cleanup := benchTempFile(b)
+	defer cleanup()
+	idx := createBenchIndexFile(b, filename, 1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.ForEachRecord(func(rec IndexUserRecord) bool {
+			return true
+		})
+	}
+}
+
+func BenchmarkFindByUsername_Scale(b *testing.B) {
+	for _, size := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("records_%d", size), func(b *testing.B) {
+			filename, cleanup := benchTempFile(b)
+			defer cleanup()
+			idx := createBenchIndexFile(b, filename, size)
+			target := fmt.Sprintf("user_%d", size/2)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				idx.FindByUsername(target)
+			}
+		})
+	}
+}
 
 // createTestIndexFile creates an index file with a fixed-width header and multiple user records.
 // It uses the UserIndex receiver method formatFixedHeader so that the header is exactly 100 bytes long.
@@ -157,12 +299,11 @@ func TestAppendUserRecord(t *testing.T) {
 	}
 	defer f.Close()
 
-	// Use the index instance's readFixedHeader method.
-	metaBytes, err := idx.readFixedHeader(f)
-	if err != nil {
+	header := make([]byte, FixedHeaderTotalLength)
+	if _, err = io.ReadFull(f, header); err != nil {
 		t.Fatalf("failed to read metadata header: %v", err)
 	}
-	headerStr := strings.TrimSpace(string(metaBytes[:FixedHeaderTotalLength-1]))
+	headerStr := strings.TrimSpace(string(header[:FixedHeaderTotalLength-1]))
 	var version, recordCount, recordSize int
 	if _, err := fmt.Sscanf(headerStr, "VERSION=%d,RECORDCOUNT=%d,RECORDSIZE=%d", &version, &recordCount, &recordSize); err != nil {
 		t.Fatalf("failed to parse metadata header: %v", err)
@@ -210,11 +351,11 @@ func TestRemoveUserRecordByUsername(t *testing.T) {
 	}
 	defer f.Close()
 
-	metaBytes, err := idx.readFixedHeader(f)
-	if err != nil {
+	header := make([]byte, FixedHeaderTotalLength)
+	if _, err = io.ReadFull(f, header); err != nil {
 		t.Fatalf("failed to read metadata header: %v", err)
 	}
-	headerStr := strings.TrimSpace(string(metaBytes[:FixedHeaderTotalLength-1]))
+	headerStr := strings.TrimSpace(string(header[:FixedHeaderTotalLength-1]))
 	var version, recordCount, recordSize int
 	if _, err := fmt.Sscanf(headerStr, "VERSION=%d,RECORDCOUNT=%d,RECORDSIZE=%d", &version, &recordCount, &recordSize); err != nil {
 		t.Fatalf("failed to parse metadata header: %v", err)

--- a/internal/users/search.go
+++ b/internal/users/search.go
@@ -2,9 +2,6 @@ package users
 
 import (
 	"bytes"
-	"encoding/binary"
-	"io"
-	"os"
 	"strings"
 )
 
@@ -30,7 +27,6 @@ func SearchUsers(searchName string) []UserSearchResult {
 
 	needle := strings.ToLower(searchName)
 
-	// Collect candidates: username -> userId from the index.
 	type candidate struct {
 		userId   int
 		username string
@@ -39,49 +35,20 @@ func SearchUsers(searchName string) []UserSearchResult {
 	var exact *candidate
 	var close []candidate
 
-	idx := NewUserIndex()
-	if idx.Exists() {
-		f, err := os.Open(idx.Filename)
-		if err == nil {
-			defer f.Close()
+	GetUserIndex().ForEachRecord(func(rec IndexUserRecord) bool {
+		raw := string(bytes.TrimRight(rec.Username[:], "\x00"))
+		lower := strings.ToLower(raw)
 
-			meta := idx.metaData
-			for i := uint64(0); i < meta.RecordCount; i++ {
-				offset := int64(meta.MetaDataSize) + int64(i*meta.RecordSize)
-				if _, err := f.Seek(offset, io.SeekStart); err != nil {
-					break
-				}
-
-				var recUsername [80]byte
-				if n, err := io.ReadFull(f, recUsername[:]); err != nil || n != 80 {
-					break
-				}
-
-				var userId int64
-				if err := binary.Read(f, binary.LittleEndian, &userId); err != nil {
-					break
-				}
-
-				// consume terminator byte
-				term := make([]byte, 1)
-				if _, err := f.Read(term); err != nil {
-					break
-				}
-
-				raw := string(bytes.TrimRight(recUsername[:], "\x00"))
-				lower := strings.ToLower(raw)
-
-				if lower == needle {
-					c := candidate{userId: int(userId), username: raw}
-					exact = &c
-					break
-				}
-				if strings.HasPrefix(lower, needle) && len(close) < 100 {
-					close = append(close, candidate{userId: int(userId), username: raw})
-				}
-			}
+		if lower == needle {
+			c := candidate{userId: int(rec.UserID), username: raw}
+			exact = &c
+			return false
 		}
-	}
+		if strings.HasPrefix(lower, needle) && len(close) < 100 {
+			close = append(close, candidate{userId: int(rec.UserID), username: raw})
+		}
+		return true
+	})
 
 	var matches []candidate
 	if exact != nil {
@@ -101,13 +68,10 @@ func SearchUsers(searchName string) []UserSearchResult {
 			Username: c.username,
 		}
 
-		// Populate role and email. Check online users first (free), then load
-		// from disk only if needed.
 		if u := GetByUserId(c.userId); u != nil {
 			result.Role = u.Role
 			result.Email = u.EmailAddress
 		} else {
-			// Load just enough from disk to fill role/email without full validation.
 			if loaded, err := LoadUser(c.username, true); err == nil {
 				result.Role = loaded.Role
 				result.Email = loaded.EmailAddress

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -343,7 +343,7 @@ func CreateUser(u *UserRecord) error {
 	u.UserId = GetUniqueUserId()
 	u.Role = RoleUser
 
-	idx := NewUserIndex()
+	idx := GetUserIndex()
 	idx.AddUser(u.UserId, u.Username)
 
 	if err := SaveUser(*u); err != nil {
@@ -360,14 +360,14 @@ func CreateUser(u *UserRecord) error {
 
 func LoadUser(username string, skipValidation ...bool) (*UserRecord, error) {
 
-	idx := NewUserIndex()
+	idx := GetUserIndex()
 	userId, found := idx.FindByUsername(username)
 
 	if !found {
 		return nil, errors.New("user doesn't exist")
 	}
 
-	userFilePath := util.FilePath(string(configs.GetFilePathsConfig().DataFiles), `/`, `users`, `/`, strconv.Itoa(int(userId))+`.yaml`)
+	userFilePath := util.FilePath(string(configs.GetFilePathsConfig().DataFiles), `/`, `users`, `/`, strconv.Itoa(userId)+`.yaml`)
 
 	userFileTxt, err := os.ReadFile(userFilePath)
 	if err != nil {
@@ -572,7 +572,7 @@ func GetUniqueUserId() int {
 
 	highestUserId := 0
 
-	idx := NewUserIndex()
+	idx := GetUserIndex()
 	if idx.Exists() {
 
 		highestUserId = idx.GetHighestUserId()
@@ -612,14 +612,14 @@ func Exists(name string) bool {
 		}
 	}
 
-	idx := NewUserIndex()
+	idx := GetUserIndex()
 	_, found := idx.FindByUsername(name)
 
 	return found
 }
 
 func FindUserId(username string) int {
-	idx := NewUserIndex()
+	idx := GetUserIndex()
 	userid, _ := idx.FindByUsername(username)
-	return int(userid)
+	return userid
 }

--- a/internal/web/admin_items.go
+++ b/internal/web/admin_items.go
@@ -86,3 +86,11 @@ func adminRaces(w http.ResponseWriter, r *http.Request) {
 func adminRacesAPI(w http.ResponseWriter, r *http.Request) {
 	serveAdminTemplate(w, r, "races-api.html", nil)
 }
+
+func adminKeywords(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "keywords.html", nil)
+}
+
+func adminKeywordsAPI(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "keywords-api.html", nil)
+}

--- a/internal/web/admin_items.go
+++ b/internal/web/admin_items.go
@@ -47,6 +47,14 @@ func adminItemsAPI(w http.ResponseWriter, r *http.Request) {
 	serveAdminTemplate(w, r, "items-api.html", nil)
 }
 
+func adminItemsAttackMessages(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "items-attack-messages.html", nil)
+}
+
+func adminItemsAttackMessagesAPI(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "items-attack-messages-api.html", nil)
+}
+
 func adminBuffs(w http.ResponseWriter, r *http.Request) {
 	serveAdminTemplate(w, r, "buffs.html", nil)
 }
@@ -77,6 +85,18 @@ func adminColorPatterns(w http.ResponseWriter, r *http.Request) {
 
 func adminColorPatternsAPI(w http.ResponseWriter, r *http.Request) {
 	serveAdminTemplate(w, r, "colorpatterns-api.html", nil)
+}
+
+func adminColorAliases(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "color-aliases.html", nil)
+}
+
+func adminColorAliasesAPI(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "color-aliases-api.html", nil)
+}
+
+func adminColorTester(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "color-tester.html", nil)
 }
 
 func adminRaces(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/admin_routes.go
+++ b/internal/web/admin_routes.go
@@ -29,6 +29,12 @@ func registerAdminRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/items-api", RunWithMUDLocked(
 		doBasicAuth(adminItemsAPI),
 	))
+	mux.HandleFunc("GET /admin/items-attack-messages", RunWithMUDLocked(
+		doBasicAuth(adminItemsAttackMessages),
+	))
+	mux.HandleFunc("GET /admin/items-attack-messages-api", RunWithMUDLocked(
+		doBasicAuth(adminItemsAttackMessagesAPI),
+	))
 
 	mux.HandleFunc("GET /admin/buffs", RunWithMUDLocked(
 		doBasicAuth(adminBuffs),
@@ -49,6 +55,17 @@ func registerAdminRoutes(mux *http.ServeMux) {
 	))
 	mux.HandleFunc("GET /admin/users-api", RunWithMUDLocked(
 		doBasicAuth(adminUsersAPI),
+	))
+
+	mux.HandleFunc("GET /admin/color-tester", RunWithMUDLocked(
+		doBasicAuth(adminColorTester),
+	))
+
+	mux.HandleFunc("GET /admin/color-aliases", RunWithMUDLocked(
+		doBasicAuth(adminColorAliases),
+	))
+	mux.HandleFunc("GET /admin/color-aliases-api", RunWithMUDLocked(
+		doBasicAuth(adminColorAliasesAPI),
 	))
 
 	mux.HandleFunc("GET /admin/colorpatterns", RunWithMUDLocked(

--- a/internal/web/admin_routes.go
+++ b/internal/web/admin_routes.go
@@ -65,5 +65,12 @@ func registerAdminRoutes(mux *http.ServeMux) {
 		doBasicAuth(adminRacesAPI),
 	))
 
+	mux.HandleFunc("GET /admin/keywords", RunWithMUDLocked(
+		doBasicAuth(adminKeywords),
+	))
+	mux.HandleFunc("GET /admin/keywords-api", RunWithMUDLocked(
+		doBasicAuth(adminKeywordsAPI),
+	))
+
 	registerAdminAPIRoutes(mux)
 }

--- a/internal/web/api_routes.go
+++ b/internal/web/api_routes.go
@@ -26,6 +26,12 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/api/v1/items/attack-messages", RunWithMUDLocked(
 		doBasicAuth(apiV1GetItemAttackMessages),
 	))
+	mux.HandleFunc("PUT /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}", RunWithMUDLocked(
+		doBasicAuth(apiV1PutItemAttackMessage),
+	))
+	mux.HandleFunc("DELETE /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}/{index}", RunWithMUDLocked(
+		doBasicAuth(apiV1DeleteItemAttackMessage),
+	))
 	mux.HandleFunc("GET /admin/api/v1/items", RunWithMUDLocked(
 		doBasicAuth(apiV1GetItems),
 	))
@@ -83,6 +89,17 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 	// {userId} pattern.
 	mux.HandleFunc("GET /admin/api/v1/users/search", RunWithMUDLocked(
 		doBasicAuth(apiV1SearchUsers),
+	))
+
+	// Color Aliases
+	mux.HandleFunc("GET /admin/api/v1/color-aliases", RunWithMUDLocked(
+		doBasicAuth(apiV1GetColorAliases),
+	))
+	mux.HandleFunc("PATCH /admin/api/v1/color-aliases", RunWithMUDLocked(
+		doBasicAuth(apiV1PatchColorAlias),
+	))
+	mux.HandleFunc("DELETE /admin/api/v1/color-aliases/{alias}", RunWithMUDLocked(
+		doBasicAuth(apiV1DeleteColorAlias),
 	))
 
 	// Color Patterns

--- a/internal/web/api_routes.go
+++ b/internal/web/api_routes.go
@@ -99,6 +99,14 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 		doBasicAuth(apiV1DeleteColorPattern),
 	))
 
+	// Keywords
+	mux.HandleFunc("GET /admin/api/v1/keywords", RunWithMUDLocked(
+		doBasicAuth(apiV1GetKeywords),
+	))
+	mux.HandleFunc("PATCH /admin/api/v1/keywords", RunWithMUDLocked(
+		doBasicAuth(apiV1PatchKeywords),
+	))
+
 	// Races
 	mux.HandleFunc("GET /admin/api/v1/races", RunWithMUDLocked(
 		doBasicAuth(apiV1GetRaces),

--- a/internal/web/api_v1_coloraliases.go
+++ b/internal/web/api_v1_coloraliases.go
@@ -1,0 +1,114 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/templates"
+	"github.com/GoMudEngine/GoMud/internal/util"
+	"github.com/GoMudEngine/ansitags"
+	"gopkg.in/yaml.v2"
+)
+
+// GET /admin/api/v1/color-aliases
+// Returns all currently loaded ANSI color aliases.
+func apiV1GetColorAliases(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, APIResponse[map[string]any]{
+		Success: true,
+		Data:    ansitags.GetAliases(),
+	})
+}
+
+// PATCH /admin/api/v1/color-aliases
+// Body: {"alias": "username", "value": 195}
+// Sets a single alias in memory and persists it to ansi-aliases.yaml.
+func apiV1PatchColorAlias(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Alias string `json:"alias"`
+		Value int    `json:"value"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(body.Alias) == "" {
+		writeAPIError(w, http.StatusBadRequest, "alias is required")
+		return
+	}
+	if body.Value < 0 || body.Value > 255 {
+		writeAPIError(w, http.StatusBadRequest, "value must be between 0 and 255")
+		return
+	}
+
+	if err := ansitags.SetAlias(body.Alias, body.Value); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := writeColorAliasYAML(ansitags.GetAliases()); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "alias set in memory but failed to persist: "+err.Error())
+		return
+	}
+
+	templates.LoadAliases()
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}
+
+// DELETE /admin/api/v1/color-aliases/{alias}
+// Removes the named alias from ansi-aliases.yaml and reloads.
+func apiV1DeleteColorAlias(w http.ResponseWriter, r *http.Request) {
+	alias := r.PathValue("alias")
+	if alias == "" {
+		writeAPIError(w, http.StatusBadRequest, "alias is required")
+		return
+	}
+
+	current := ansitags.GetAliases()
+	if _, exists := current[alias]; !exists {
+		writeAPIError(w, http.StatusNotFound, "alias not found: "+alias)
+		return
+	}
+
+	delete(current, alias)
+
+	if err := writeColorAliasYAML(current); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "failed to persist: "+err.Error())
+		return
+	}
+
+	templates.LoadAliases()
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}
+
+// writeColorAliasYAML serialises aliases back to the ansi-aliases.yaml file.
+// The file format wraps aliases under a top-level "colors:" key to match the
+// existing file structure that ansitags.LoadAliases expects.
+func writeColorAliasYAML(aliases map[string]any) error {
+	path := util.FilePath(string(configs.GetFilePathsConfig().DataFiles) + `/ansi-aliases.yaml`)
+
+	// Normalise: the in-memory map may contain int or float64 values depending
+	// on how they were loaded. Convert everything to int for clean YAML output.
+	clean := make(map[string]int, len(aliases))
+	for k, v := range aliases {
+		switch val := v.(type) {
+		case int:
+			clean[k] = val
+		case float64:
+			clean[k] = int(val)
+		}
+	}
+
+	doc := map[string]map[string]int{"colors": clean}
+
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}

--- a/internal/web/api_v1_items.go
+++ b/internal/web/api_v1_items.go
@@ -165,6 +165,54 @@ func apiV1GetItemScript(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// PUT /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}
+func apiV1PutItemAttackMessage(w http.ResponseWriter, r *http.Request) {
+	subtype := items.ItemSubType(r.PathValue("subtype"))
+	intensity := items.Intensity(r.PathValue("intensity"))
+	proximity := r.PathValue("proximity")
+	target := r.PathValue("target")
+
+	var body struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	if body.Message == "" {
+		writeAPIError(w, http.StatusBadRequest, "message is required")
+		return
+	}
+
+	if err := items.AddAttackMessage(subtype, intensity, proximity, target, body.Message); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}
+
+// DELETE /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}/{index}
+func apiV1DeleteItemAttackMessage(w http.ResponseWriter, r *http.Request) {
+	subtype := items.ItemSubType(r.PathValue("subtype"))
+	intensity := items.Intensity(r.PathValue("intensity"))
+	proximity := r.PathValue("proximity")
+	target := r.PathValue("target")
+
+	index, err := strconv.Atoi(r.PathValue("index"))
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid index: "+r.PathValue("index"))
+		return
+	}
+
+	if err := items.DeleteAttackMessage(subtype, intensity, proximity, target, index); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}
+
 // PUT /admin/api/v1/items/{itemId}/script
 func apiV1PutItemScript(w http.ResponseWriter, r *http.Request) {
 	idOrName := r.PathValue("itemId")

--- a/internal/web/api_v1_keywords.go
+++ b/internal/web/api_v1_keywords.go
@@ -1,0 +1,35 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/GoMudEngine/GoMud/internal/keywords"
+)
+
+// GET /admin/api/v1/keywords
+func apiV1GetKeywords(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, APIResponse[*keywords.Aliases]{
+		Success: true,
+		Data:    keywords.GetKeywords(),
+	})
+}
+
+// PATCH /admin/api/v1/keywords
+func apiV1PatchKeywords(w http.ResponseWriter, r *http.Request) {
+	var incoming keywords.Aliases
+	if err := json.NewDecoder(r.Body).Decode(&incoming); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+
+	if err := keywords.SaveKeywords(&incoming); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[*keywords.Aliases]{
+		Success: true,
+		Data:    keywords.GetKeywords(),
+	})
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -254,6 +254,14 @@ func buildAdminNav() []WebNavItem {
 				{Label: "API Docs", Target: "/admin/races-api"},
 			},
 		},
+		{
+			Name:   "Keywords",
+			Target: "/admin/keywords",
+			SubItems: []WebNavSub{
+				{Label: "View / Edit", Target: "/admin/keywords"},
+				{Label: "API Docs", Target: "/admin/keywords-api"},
+			},
+		},
 	}
 	nav = append(nav, defaultRegistrar.navItems...)
 	return nav

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -212,6 +212,8 @@ func buildAdminNav() []WebNavItem {
 			SubItems: []WebNavSub{
 				{Label: "View / Edit", Target: "/admin/items"},
 				{Label: "API Docs", Target: "/admin/items-api"},
+				{Label: "Attack Messages", Target: "/admin/items-attack-messages"},
+				{Label: "Attack Messages API Docs", Target: "/admin/items-attack-messages-api"},
 			},
 		},
 		{
@@ -239,11 +241,14 @@ func buildAdminNav() []WebNavItem {
 			},
 		},
 		{
-			Name:   "Color Patterns",
-			Target: "/admin/colorpatterns",
+			Name:   "Colors",
+			Target: "",
 			SubItems: []WebNavSub{
-				{Label: "View / Edit", Target: "/admin/colorpatterns"},
-				{Label: "API Docs", Target: "/admin/colorpatterns-api"},
+				{Label: "Color Patterns", Target: "/admin/colorpatterns"},
+				{Label: "Color Patterns API Docs", Target: "/admin/colorpatterns-api"},
+				{Label: "Color Aliases", Target: "/admin/color-aliases"},
+				{Label: "Color Aliases API Docs", Target: "/admin/color-aliases-api"},
+				{Label: "Color Tester", Target: "/admin/color-tester"},
 			},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func main() {
 	isCopyover := flags.CopyoverFd() >= 0
 
 	if !isCopyover {
-		idx := users.NewUserIndex()
+		idx := users.InitUserIndex()
 		if !idx.Exists() {
 			// Since it doesn't exist yet, that's a good indication we should do a quick format migration check
 			users.DoUserMigrations()

--- a/modules/mudmail/admin.go
+++ b/modules/mudmail/admin.go
@@ -211,8 +211,8 @@ func (m *MudmailModule) inboxForUser(userId int) (username string, inbox Inbox) 
 		return u.Username, m.inboxes[userId]
 	}
 	// Offline: find username from index then load from disk.
-	idx := users.NewUserIndex()
-	if name, ok := idx.FindByUserId(int64(userId)); ok {
+	idx := users.GetUserIndex()
+	if name, ok := idx.FindByUserId(userId); ok {
 		username = name
 	}
 	return username, m.load(userId)

--- a/modules/storage/admin.go
+++ b/modules/storage/admin.go
@@ -131,8 +131,8 @@ func (m *StorageModule) storageForUser(userId int) (username string, storageItem
 		return u.Username, data.getItems()
 	}
 	// Offline: find username from index then load from disk.
-	idx := users.NewUserIndex()
-	if name, ok := idx.FindByUserId(int64(userId)); ok {
+	idx := users.GetUserIndex()
+	if name, ok := idx.FindByUserId(userId); ok {
 		username = name
 	}
 	offlineData := m.load(userId)


### PR DESCRIPTION
# Description

Lots more admin pages, api's and some reorganizations. UX improvements overall, as it gradually gets converted to less "form html" to more alive javascript/css with pickers and such.

## Changes

- GET API requests cache for 5 minutes, or until an invalidation event (POST, PUT, DELETE)
- Optimized user memory index to O(1) complexity vs. O(n)
- `/admin/keywords` admin page (and api's)
- `/admin/items-attack-messages` editor (and api's)
- `/admin/color-tester` to preview colorization of string with ansi-tags
- Upgraded `ansitags` to use `v1.3.0` which is much faster and more efficient.
- Added a ansitag js library to admin pages
