### PR TITLE
[CI] Fix: Update `.jsintignore` with vendored/3rd-party bundles

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -2,4 +2,5 @@ _datafiles/html/public/static/js/xterm.4.19.0.js
 _datafiles/html/public/static/js/xterm-addon-fit.js
 _datafiles/html/public/static/js/winbox.bundle.min.js
 _datafiles/html/admin/static/js/htmx.2.0.3.js
-
+_datafiles/html/admin/static/js/highlight.js
+_datafiles/html/admin/static/js/ansitags.js


### PR DESCRIPTION
## Summary
- add the vendored admin `highlight.js` bundle to `.jshintignore`
- add the vendored admin `ansitags.js` bundle to `.jshintignore`
- keep `js-lint` blocking for repo-owned JavaScript while excluding upstream bundles

## Why
`make js-lint` was failing on inherited JSHint errors from vendored admin assets, not on changes made by the current branch. Excluding those bundles from JSHint keeps the lint check focused on GoMud-maintained JavaScript.

## Validation
- `make js-lint`