### PR TITLE
[Release] Bump GoMud version to v0.9.2

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ import (
 // When updating this version:
 // 1. Expect to update the github release version
 // 2. Consider whether any migration code is needed for breaking changes, particularly in datafiles (see internal/migration)
-const VERSION = "0.9.1"
+const VERSION = "0.9.2"
 
 var (
 	sigChan            = make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary

- Bump the embedded GoMud version from `0.9.1` to `0.9.2` in `main.go`

## Validation

- `make validate`
