### PR TITLE
release: add workflow_dispatch release tag input

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -29,6 +29,8 @@ Recommended versioning for the next release line:
    - Run the `Release` workflow with `workflow_dispatch`.
    - Optionally set `release_tag` if you want the run to upload assets to a
      specific existing or new release tag instead of the default prerelease tag.
+   - Set `release_tag=latest` to target the repo's current latest GitHub
+     release tag automatically.
 
 2. **Monitor Release**
    - GitHub Actions will:
@@ -59,6 +61,8 @@ Recommended versioning for the next release line:
    - `workflow_dispatch` can be used to refresh the rolling `prerelease`
      without merging.
    - If you provide `release_tag`, the run publishes to that tag instead.
+   - If you set `release_tag=latest`, the run resolves the current latest
+     GitHub release tag and publishes to it.
 
 4. **Rolling release naming**
    - The release tag is always `prerelease`.
@@ -75,6 +79,8 @@ Recommended versioning for the next release line:
    - Leave `release_tag` blank to use the default manual prerelease naming.
    - Set `release_tag` when you want the run to upload assets to a specific
      existing or new release tag.
+   - Set `release_tag=latest` when you want the run to upload assets to
+     whichever tag GitHub currently considers the latest release.
 
 2. **Verify the GitHub release**
    - Confirm the workflow succeeds.
@@ -107,6 +113,7 @@ Recommended versioning for the next release line:
   Yes - run the `Release` workflow manually with `workflow_dispatch`. That keeps PR
   submissions clean while still allowing an on-demand refresh of `prerelease`.
   Set `release_tag` when you want the run to publish assets to a specific tag.
+  Set `release_tag=latest` when you want it to target the current latest release.
 
 - **Are workflow-created releases stable releases?**
   No - the workflow creates prereleases. A repo owner must manually promote a release

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -27,6 +27,8 @@ Recommended versioning for the next release line:
 
    Or, for a manual test without merging:
    - Run the `Release` workflow with `workflow_dispatch`.
+   - Optionally set `release_tag` if you want the run to upload assets to a
+     specific existing or new release tag instead of the default prerelease tag.
 
 2. **Monitor Release**
    - GitHub Actions will:
@@ -56,6 +58,7 @@ Recommended versioning for the next release line:
 3. **Manual test runs can also publish prereleases**
    - `workflow_dispatch` can be used to refresh the rolling `prerelease`
      without merging.
+   - If you provide `release_tag`, the run publishes to that tag instead.
 
 4. **Rolling release naming**
    - The release tag is always `prerelease`.
@@ -69,19 +72,24 @@ Recommended versioning for the next release line:
 1. **Run the release workflow manually**
    - Use `workflow_dispatch` when you want a test release
      without merging to `master`.
+   - Leave `release_tag` blank to use the default manual prerelease naming.
+   - Set `release_tag` when you want the run to upload assets to a specific
+     existing or new release tag.
 
 2. **Verify the GitHub release**
    - Confirm the workflow succeeds.
-   - Confirm the `prerelease` release now points at the expected commit.
+   - Confirm the targeted release now points at the expected commit.
    - Confirm the per-platform binaries are attached.
    - Confirm the `_datafiles` zip asset is attached.
    - Confirm the checksum manifest asset is attached.
-   - Confirm GitHub marks the release as a prerelease.
-   - Confirm GitHub does not mark it as `Latest`.
+   - For default manual prerelease runs, confirm GitHub marks the release as a
+     prerelease and does not mark it as `Latest`.
 
 3. **Clean up if needed**
-   - No cleanup is normally required because the next successful run replaces the
-     rolling `prerelease`.
+   - No cleanup is normally required for the rolling `prerelease` path because
+     the next successful run replaces it.
+   - Tag-targeted manual runs use the tag you requested, so cleanup is only
+     needed if you created a temporary release tag for testing.
 
 ---
 
@@ -98,6 +106,7 @@ Recommended versioning for the next release line:
 - **Can I create a test release without merging to `master`?**
   Yes - run the `Release` workflow manually with `workflow_dispatch`. That keeps PR
   submissions clean while still allowing an on-demand refresh of `prerelease`.
+  Set `release_tag` when you want the run to publish assets to a specific tag.
 
 - **Are workflow-created releases stable releases?**
   No - the workflow creates prereleases. A repo owner must manually promote a release

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -8,7 +8,7 @@ name: Release
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing or new release tag to publish assets to
+        description: Existing/new release tag, or latest, to publish assets to
         required: false
         type: string
 
@@ -22,6 +22,8 @@ permissions:
 jobs:
   prep:
     runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       binary_version: ${{ steps.meta.outputs.binary_version }}
       release_tag: ${{ steps.meta.outputs.release_tag }}
@@ -50,19 +52,34 @@ jobs:
           fi
 
           if [ -n "$requested_release_tag" ]; then
-            case "$requested_release_tag" in
-              *[!A-Za-z0-9._-]*)
-                echo \
-                  "release_tag may contain only letters, digits, ., _, and -" \
-                  >&2
+            if [ "$requested_release_tag" = "latest" ]; then
+              release_tag="$(
+                gh api "repos/${GITHUB_REPOSITORY}/releases/latest" \
+                  --jq '.tag_name'
+              )"
+              if [ -z "$release_tag" ]; then
+                echo "Could not determine latest release tag" >&2
                 exit 1
-                ;;
-            esac
+              fi
+              release_title="$release_tag"
+              release_notes_intro="Manual release build for current latest \
+          release \`${release_tag}\` from \`${GITHUB_REF_NAME}\`."
+            else
+              case "$requested_release_tag" in
+                *[!A-Za-z0-9._-]*)
+                  echo \
+                    "release_tag may contain only letters, digits, ., _, and \
+          -" \
+                    >&2
+                  exit 1
+                  ;;
+              esac
 
-            release_tag="$requested_release_tag"
-            release_title="$requested_release_tag"
-            release_notes_intro="Manual release build for \
+              release_tag="$requested_release_tag"
+              release_title="$requested_release_tag"
+              release_notes_intro="Manual release build for \
           \`${requested_release_tag}\` from \`${GITHUB_REF_NAME}\`."
+            fi
             release_notes_summary="This run publishes assets to the \
           requested release tag."
           elif [ "$GITHUB_REF" = "refs/heads/master" ]; then

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -6,6 +6,11 @@ name: Release
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing or new release tag to publish assets to
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,6 +40,7 @@ jobs:
         run: |
           short_sha="$(printf '%s' "$GITHUB_SHA" | cut -c1-7)"
           timestamp="$(date -u +'%Y%m%d%H%M%S')"
+          requested_release_tag="${{ github.event.inputs.release_tag || '' }}"
           binary_version="$(
             awk -F'"' '/^const VERSION = "/ { print $2; exit }' main.go
           )"
@@ -43,7 +49,23 @@ jobs:
             exit 1
           fi
 
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
+          if [ -n "$requested_release_tag" ]; then
+            case "$requested_release_tag" in
+              *[!A-Za-z0-9._-]*)
+                echo \
+                  "release_tag may contain only letters, digits, ., _, and -" \
+                  >&2
+                exit 1
+                ;;
+            esac
+
+            release_tag="$requested_release_tag"
+            release_title="$requested_release_tag"
+            release_notes_intro="Manual release build for \
+          \`${requested_release_tag}\` from \`${GITHUB_REF_NAME}\`."
+            release_notes_summary="This run publishes assets to the \
+          requested release tag."
+          elif [ "$GITHUB_REF" = "refs/heads/master" ]; then
             release_tag="prerelease"
             release_title="prerelease"
             release_notes_intro="Rolling prerelease build from \`master\`."
@@ -141,6 +163,7 @@ jobs:
       DATAFILES_ARCHIVE: ${{ needs.prep.outputs.datafiles_archive }}
       CHECKSUMS_FILE: ${{ needs.prep.outputs.checksums_file }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REQUESTED_RELEASE_TAG: ${{ github.event.inputs.release_tag || '' }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -221,20 +244,36 @@ jobs:
             "bin/$CHECKSUMS_FILE"
           )
 
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
-            gh release edit "$RELEASE_TAG" \
-              --title "$RELEASE_TITLE" \
-              --target "$GITHUB_SHA" \
-              --prerelease \
-              --latest=false \
-              --notes-file release-notes.md
+          if [ -n "$REQUESTED_RELEASE_TAG" ]; then
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+              gh release edit "$RELEASE_TAG" \
+                --title "$RELEASE_TITLE" \
+                --target "$GITHUB_SHA" \
+                --notes-file release-notes.md
+            else
+              gh release create "$RELEASE_TAG" \
+                "${assets[@]}" \
+                --title "$RELEASE_TITLE" \
+                --target "$GITHUB_SHA" \
+                --notes-file release-notes.md
+            fi
           else
-            gh release create "$RELEASE_TAG" \
-              "${assets[@]}" \
-              --title "$RELEASE_TITLE" \
-              --target "$GITHUB_SHA" \
-              --prerelease \
-              --latest=false \
-              --notes-file release-notes.md
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+              gh release edit "$RELEASE_TAG" \
+                --title "$RELEASE_TITLE" \
+                --target "$GITHUB_SHA" \
+                --prerelease \
+                --latest=false \
+                --notes-file release-notes.md
+            else
+              gh release create "$RELEASE_TAG" \
+                "${assets[@]}" \
+                --title "$RELEASE_TITLE" \
+                --target "$GITHUB_SHA" \
+                --prerelease \
+                --latest=false \
+                --notes-file release-notes.md
+            fi
           fi

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ import (
 // When updating this version:
 // 1. Expect to update the github release version
 // 2. Consider whether any migration code is needed for breaking changes, particularly in datafiles (see internal/migration)
-const VERSION = "0.9.1"
+const VERSION = "0.9.2"
 
 var (
 	sigChan            = make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary

- Add an optional `workflow_dispatch` `release_tag` input to the release workflow
- Publish manual runs to the requested tag when provided, while keeping the existing rolling `prerelease` behavior otherwise
- Document the new manual release path in `.github/RELEASING.md`

## Validation

- `actionlint .github/workflows/build-and-release.yml`
- `yamllint .github/workflows/build-and-release.yml`
