### PR TITLE
Mutators

### DIFF
--- a/_datafiles/html/admin/mutators.html
+++ b/_datafiles/html/admin/mutators.html
@@ -140,6 +140,41 @@
     }
     .btn-icon:hover { color: #c00; }
 
+    /* tags */
+    .tag-wrap { display: flex; flex-wrap: wrap; gap: 0.3rem; align-items: center; }
+    .tag-chip {
+        display: inline-flex; align-items: center; gap: 0.25rem;
+        background: #e8eaf6; color: #3949ab; border-radius: 10px;
+        padding: 0.15rem 0.5rem; font-size: 0.78rem; cursor: default;
+    }
+    .tag-chip button { background: none; border: none; cursor: pointer; color: #3949ab; font-size: 0.82rem; line-height: 1; padding: 0; }
+    .tag-chip button:hover { color: #c00; }
+
+    /* tag picker */
+    .tag-picker-wrap { position: relative; display: inline-block; }
+    .tag-picker-dropdown {
+        display: none; position: absolute; top: 100%; left: 0; z-index: 200;
+        background: #fff; border: 1px solid #ccc; border-radius: 6px;
+        box-shadow: 0 4px 16px rgba(0,0,0,0.12); min-width: 260px; max-height: 320px;
+        overflow-y: auto; padding: 0.4rem 0;
+    }
+    .tag-picker-dropdown.open { display: block; }
+    .tag-picker-search { width: calc(100% - 1rem); margin: 0.3rem 0.5rem; padding: 0.3rem 0.5rem; border: 1px solid #ccc; border-radius: 4px; font-size: 0.82rem; }
+    .tag-picker-group { padding: 0.25rem 0.5rem 0; font-size: 0.7rem; font-weight: 700; color: #888; text-transform: uppercase; letter-spacing: 0.05em; }
+    .tag-picker-item {
+        padding: 0.3rem 0.75rem; cursor: pointer; font-size: 0.82rem; display: flex; align-items: center; gap: 0.4rem;
+    }
+    .tag-picker-item:hover { background: #f0f4ff; }
+    .tag-picker-item.selected { color: #3949ab; font-weight: 600; }
+    .tag-picker-item.selected::before { content: "\2713"; font-size: 0.75rem; }
+    .tag-picker-item:not(.selected)::before { content: ""; display: inline-block; width: 0.9em; }
+    .tag-picker-empty { padding: 0.75rem; text-align: center; color: #aaa; font-size: 0.82rem; }
+    .btn-tag-picker {
+        padding: 0.3rem 0.6rem; border: 1px dashed #7986cb; border-radius: 4px;
+        background: none; cursor: pointer; font-size: 0.8rem; color: #3949ab;
+    }
+    .btn-tag-picker:hover { background: #e8eaf6; }
+
     /* action bar */
     .action-bar { display: flex; gap: 0.6rem; margin-top: 1.25rem; align-items: center; flex-wrap: wrap; }
     .btn { padding: 0.45rem 1.1rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
@@ -329,6 +364,26 @@
                     <div class="field-hint">Overrides the room's PvP setting while the mutator is active. Only visible to players when global PvP is set to "limited" mode. Multiple mutators on the same room apply in order &mdash; the last one wins.</div>
                 </div>
 
+                <div class="section-title">Tags</div>
+
+                <div class="field span2">
+                    <label>Tags</label>
+                    <div class="tag-wrap" id="tags-list"></div>
+                    <div style="margin-top:0.4rem; display:flex; gap:0.4rem; align-items:center; flex-wrap:wrap;">
+                        <div class="tag-picker-wrap">
+                            <button class="btn-tag-picker" onclick="toggleTagPicker(event)">+ Pick Tag</button>
+                            <div class="tag-picker-dropdown" id="tag-picker-dropdown">
+                                <input type="search" class="tag-picker-search" id="tag-picker-search" placeholder="Filter tags..." oninput="filterTagPicker()" />
+                                <div id="tag-picker-list"></div>
+                            </div>
+                        </div>
+                        <span style="font-size:0.75rem; color:#aaa;">or type a custom tag:</span>
+                        <input type="text" id="tag-input" placeholder="custom tag..." style="flex:1; min-width:120px; padding:0.3rem 0.5rem; border:1px solid #ccc; border-radius:4px; font-size:0.82rem;" onkeydown="if(event.key==='Enter'){event.preventDefault();addCustomTag();}" />
+                        <button class="btn-add-sm" onclick="addCustomTag()">+</button>
+                    </div>
+                    <div class="field-hint">Tags applied to the room while this mutator is active. These do not modify the room's permanent tags. Modules and scripts can check for these tags at runtime.</div>
+                </div>
+
                 <div class="section-title">Exits</div>
 
                 <div class="field span2">
@@ -353,6 +408,7 @@
     'use strict';
 
     let allMutators = [];
+    let allTags = [];
     let currentMutatorId = null;
     let isNew = false;
 
@@ -360,11 +416,16 @@
     // Init
     // -------------------------------------------------------------------------
     async function init() {
-        const res = await AdminAPI.get('/admin/api/v1/mutators');
-        if (!res.ok) { showStatus('Failed to load mutators: ' + res.error, false); return; }
+        const [mutatorsRes, tagsRes] = await AdminAPI.all([
+            AdminAPI.get('/admin/api/v1/mutators'),
+            AdminAPI.get('/admin/api/v1/tags'),
+        ]);
+        if (!mutatorsRes.ok) { showStatus('Failed to load mutators: ' + mutatorsRes.error, false); return; }
 
-        allMutators = (res.data.data || []).sort((a, b) => a.MutatorId.localeCompare(b.MutatorId));
+        allMutators = (mutatorsRes.data.data || []).sort((a, b) => a.MutatorId.localeCompare(b.MutatorId));
+        allTags = (tagsRes.ok && tagsRes.data.data) || [];
         renderList(allMutators);
+        buildTagPickerList('');
         const hashId = decodeURIComponent(location.hash.slice(1));
         if (hashId) loadMutator(hashId);
     }
@@ -452,6 +513,9 @@
         setVal('f-decayrate', m.DecayRate || '');
         setVal('f-respawnrate', m.RespawnRate || '');
         setVal('f-decayintoid', m.DecayIntoId || '');
+
+        // Tags
+        renderTags(m.Tags || []);
 
         // Buffs
         renderBuffChips('playerbuffids-list', m.PlayerBuffIds || []);
@@ -735,6 +799,128 @@
     }
 
     // -------------------------------------------------------------------------
+    // Tags
+    // -------------------------------------------------------------------------
+    function renderTags(tags) {
+        const list = document.getElementById('tags-list');
+        list.innerHTML = '';
+        for (const t of tags) appendTagChip(list, t);
+    }
+
+    function appendTagChip(list, tag) {
+        const chip = document.createElement('span');
+        chip.className = 'tag-chip';
+        chip.dataset.tag = tag;
+        chip.innerHTML = esc(tag) + ' <button onclick="removeTag(this)" title="Remove tag">&times;</button>';
+        list.appendChild(chip);
+    }
+
+    window.removeTag = function (btn) {
+        btn.closest('.tag-chip').remove();
+        updateTagPickerState();
+    };
+
+    function collectTags() {
+        return Array.from(document.querySelectorAll('#tags-list .tag-chip')).map(c => c.dataset.tag);
+    }
+
+    window.addCustomTag = function () {
+        const input = document.getElementById('tag-input');
+        const val = input.value.trim().toLowerCase();
+        if (!val) return;
+        if (collectTags().includes(val)) { input.value = ''; return; }
+        appendTagChip(document.getElementById('tags-list'), val);
+        input.value = '';
+        updateTagPickerState();
+    };
+
+    // -------------------------------------------------------------------------
+    // Tag picker
+    // -------------------------------------------------------------------------
+    function buildTagPickerList(filter) {
+        const container = document.getElementById('tag-picker-list');
+        container.innerHTML = '';
+
+        if (allTags.length === 0) {
+            container.innerHTML = '<div class="tag-picker-empty">No registered tags found.<br>Modules register tags at startup.</div>';
+            return;
+        }
+
+        const current = collectTags();
+        const filterLc = filter.toLowerCase();
+
+        const groups = {};
+        for (const entry of allTags) {
+            if (filterLc && !entry.tag.toLowerCase().includes(filterLc) && !entry.module.toLowerCase().includes(filterLc)) continue;
+            if (!groups[entry.module]) groups[entry.module] = [];
+            groups[entry.module].push(entry.tag);
+        }
+
+        let anyItem = false;
+        for (const mod of Object.keys(groups).sort()) {
+            const grpEl = document.createElement('div');
+            grpEl.className = 'tag-picker-group';
+            grpEl.textContent = mod;
+            container.appendChild(grpEl);
+            for (const tag of groups[mod]) {
+                anyItem = true;
+                const item = document.createElement('div');
+                item.className = 'tag-picker-item' + (current.includes(tag) ? ' selected' : '');
+                item.dataset.tag = tag;
+                item.textContent = tag;
+                item.onclick = () => toggleTagFromPicker(tag, item);
+                container.appendChild(item);
+            }
+        }
+
+        if (!anyItem) {
+            container.innerHTML = '<div class="tag-picker-empty">No matching tags.</div>';
+        }
+    }
+
+    function updateTagPickerState() {
+        const current = collectTags();
+        document.querySelectorAll('#tag-picker-list .tag-picker-item').forEach(item => {
+            item.classList.toggle('selected', current.includes(item.dataset.tag));
+        });
+    }
+
+    function toggleTagFromPicker(tag, itemEl) {
+        const list = document.getElementById('tags-list');
+        const current = collectTags();
+        if (current.includes(tag)) {
+            list.querySelectorAll('.tag-chip').forEach(c => { if (c.dataset.tag === tag) c.remove(); });
+            itemEl.classList.remove('selected');
+        } else {
+            appendTagChip(list, tag);
+            itemEl.classList.add('selected');
+        }
+    }
+
+    window.toggleTagPicker = function (e) {
+        e.stopPropagation();
+        const dd = document.getElementById('tag-picker-dropdown');
+        const isOpen = dd.classList.contains('open');
+        closeTagPicker();
+        if (!isOpen) {
+            buildTagPickerList(document.getElementById('tag-picker-search').value);
+            dd.classList.add('open');
+        }
+    };
+
+    function closeTagPicker() {
+        document.getElementById('tag-picker-dropdown').classList.remove('open');
+    }
+
+    window.filterTagPicker = function () {
+        buildTagPickerList(document.getElementById('tag-picker-search').value);
+    };
+
+    document.addEventListener('click', function (e) {
+        if (!e.target.closest('.tag-picker-wrap')) closeTagPicker();
+    });
+
+    // -------------------------------------------------------------------------
     // Color pattern picker
     // -------------------------------------------------------------------------
     window.pickColorPattern = function (targetId) {
@@ -809,6 +995,7 @@
             PlayerBuffIds:       collectBuffIds('playerbuffids-list'),
             MobBuffIds:          collectBuffIds('mobbuffids-list'),
             NativeBuffIds:       collectBuffIds('nativebuffids-list'),
+            Tags:                collectTags(),
             LightMod:            parseInt(document.getElementById('f-lightmod').value, 10) || 0,
             Pvp: {
                 Enabled:  pvpVal === 'enabled',

--- a/_datafiles/html/public/static/js/windows/window-gear.js
+++ b/_datafiles/html/public/static/js/windows/window-gear.js
@@ -119,6 +119,8 @@
         }
 
         .gw-equip-name.empty  { color: var(--t-text-dim); font-style: italic; }
+        .gw-equip-row.empty  { cursor: default; }
+        .gw-equip-row.empty:hover { background: transparent; }
         .gw-equip-name.cursed { color: var(--t-cursed-text); }
         .gw-equip-name.quest  { color: var(--t-quest-text); }
 
@@ -573,14 +575,16 @@
             const badgeEl = document.getElementById('gw-eqb-'   + slot.key);
             if (!rowEl || !nameEl || !badgeEl) { return; }
 
-            if (!item || !item.name) {
-                nameEl.textContent = 'empty';
+            if (!item || !item.name || item.name === '-nothing-') {
+                nameEl.textContent = item && item.name === '-nothing-' ? '-nothing-' : 'empty';
                 nameEl.className   = 'gw-equip-name empty';
                 badgeEl.style.display = 'none';
+                rowEl.classList.add('empty');
                 rowItemData.delete(rowEl);
                 return;
             }
 
+            rowEl.classList.remove('empty');
             rowItemData.set(rowEl, item);
 
             const isCursed = item.details && item.details.includes('cursed');

--- a/_datafiles/html/public/webclient-pure.html
+++ b/_datafiles/html/public/webclient-pure.html
@@ -43,6 +43,7 @@
             flex: 1;
             min-width: 0;
             position: relative;
+            padding-left: 20px;
         }
 
         #input-area {

--- a/_datafiles/world/default/mutators/wildfire.yaml
+++ b/_datafiles/world/default/mutators/wildfire.yaml
@@ -2,12 +2,16 @@ mutatorid: wildfire
 namemodifier:
   behavior: replace
   colorpattern: flame
-descriptionmodifier: 
+descriptionmodifier:
   behavior: replace
   colorpattern: flame
-alertmodifier: 
+alertmodifier:
+  behavior: replace
   text: '!!!                A wildfire is burning here!                !!!'
   colorpattern: flame
+decayintoid: wildfire-scorched
+playerbuffids:
+- 22
+mobbuffids:
+- 22
 decayrate: 10 minutes
-playerbuffids: [22]
-mobbuffids: [22]

--- a/_datafiles/world/default/mutators/wildfire_scorched.yaml
+++ b/_datafiles/world/default/mutators/wildfire_scorched.yaml
@@ -1,0 +1,10 @@
+mutatorid: wildfire-scorched
+namemodifier:
+  behavior: append
+  text: (fire scorched)
+  colorpattern: gray
+descriptionmodifier:
+  behavior: append
+  text: The land is scorched from a recent fire.
+  colorpattern: gray
+decayrate: 3 hours

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 )
 
 require (
+	github.com/creack/pty v1.1.24
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/nicksnyder/go-i18n/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMn
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
 github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=

--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -125,6 +125,7 @@ type ConnectionDetails struct {
 	inputHandlerNames []string
 	inputHandlers     []InputHandler
 	inputDisabled     bool
+	outputSuppressed  bool
 	clientSettings    ClientSettings
 	heartbeat         *heartbeatManager
 }
@@ -199,6 +200,14 @@ func (cd *ConnectionDetails) RemoveInputHandler(name string) {
 
 }
 
+func (cd *ConnectionDetails) PrependInputHandler(name string, newInputHandler InputHandler) {
+	cd.handlerMutex.Lock()
+	defer cd.handlerMutex.Unlock()
+
+	cd.inputHandlerNames = append([]string{name}, cd.inputHandlerNames...)
+	cd.inputHandlers = append([]InputHandler{newInputHandler}, cd.inputHandlers...)
+}
+
 func (cd *ConnectionDetails) AddInputHandler(name string, newInputHandler InputHandler, after ...string) {
 	cd.handlerMutex.Lock()
 	defer cd.handlerMutex.Unlock()
@@ -217,7 +226,24 @@ func (cd *ConnectionDetails) AddInputHandler(name string, newInputHandler InputH
 	cd.inputHandlers = append(cd.inputHandlers, newInputHandler)
 }
 
+func (cd *ConnectionDetails) WriteRaw(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if cd.sshChannel != nil {
+		return cd.sshChannel.Write(p)
+	}
+	if cd.wsConn != nil {
+		return 0, errors.New("raw write not supported on WebSocket")
+	}
+	return cd.conn.Write(p)
+}
+
 func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
+
+	if cd.outputSuppressed {
+		return len(p), nil
+	}
 
 	p = []byte(strings.ReplaceAll(string(p), "\n", "\r\n"))
 
@@ -316,6 +342,13 @@ func (cd *ConnectionDetails) InputDisabled(setTo ...bool) bool {
 		cd.inputDisabled = setTo[0]
 	}
 	return cd.inputDisabled
+}
+
+func (cd *ConnectionDetails) OutputSuppressed(setTo ...bool) bool {
+	if len(setTo) > 0 {
+		cd.outputSuppressed = setTo[0]
+	}
+	return cd.outputSuppressed
 }
 
 func NewConnectionDetails(connId ConnectionId, c net.Conn, wsC *websocket.Conn, config *HeartbeatConfig) *ConnectionDetails {

--- a/internal/connections/connections.go
+++ b/internal/connections/connections.go
@@ -34,6 +34,8 @@ var (
 	// Channel to send a shutdown signal to
 	//
 	shutdownChannel chan os.Signal // channel to receive shutdown signals
+
+	windowChangeListeners []func(connId ConnectionId, cols, rows uint32)
 )
 
 func SignalShutdown(s os.Signal) {
@@ -208,6 +210,45 @@ func Broadcast(colorizedText []byte, skipConnectionIds ...ConnectionId) []Connec
 	}
 
 	return sentToIds
+}
+
+func RegisterWindowChangeListener(f func(connId ConnectionId, cols, rows uint32)) {
+	lock.Lock()
+	defer lock.Unlock()
+	windowChangeListeners = append(windowChangeListeners, f)
+}
+
+func NotifyWindowChange(connId ConnectionId, cols, rows uint32) {
+	lock.RLock()
+	listeners := make([]func(ConnectionId, uint32, uint32), len(windowChangeListeners))
+	copy(listeners, windowChangeListeners)
+	lock.RUnlock()
+
+	for _, f := range listeners {
+		f(connId, cols, rows)
+	}
+}
+
+func SendRawTo(b []byte, ids ...ConnectionId) {
+	lock.Lock()
+
+	removeIds := []ConnectionId{}
+
+	for _, id := range ids {
+		if cd, ok := netConnections[id]; ok {
+			if _, err := cd.WriteRaw(b); err != nil {
+				mudlog.Warn("SendRawTo()", "connectionId", id, "remoteAddr", cd.RemoteAddr().String(), "error", err)
+				removeIds = append(removeIds, id)
+				continue
+			}
+		}
+	}
+
+	lock.Unlock()
+
+	for _, id := range removeIds {
+		Remove(id)
+	}
 }
 
 func SendTo(b []byte, ids ...ConnectionId) {

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -401,3 +401,12 @@ type AggroChanged struct {
 }
 
 func (a AggroChanged) Type() string { return `AggroChanged` }
+
+type CLIRequest struct {
+	UserId       int
+	ConnectionId uint64
+	Command      string
+	Args         []string
+}
+
+func (c CLIRequest) Type() string { return `CLIRequest` }

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -410,3 +410,10 @@ type CLIRequest struct {
 }
 
 func (c CLIRequest) Type() string { return `CLIRequest` }
+
+// If a potentially fire-starting event occured in this room
+type FireBlaze struct {
+	RoomId int
+}
+
+func (c FireBlaze) Type() string { return `FireBlaze` }

--- a/internal/inputhandlers/term_iac.go
+++ b/internal/inputhandlers/term_iac.go
@@ -139,6 +139,7 @@ func TelnetIACHandler(clientInput *connections.ClientInput, sharedState map[stri
 					cs.Display.ScreenWidth = uint32(w)
 					cs.Display.ScreenHeight = uint32(h)
 					connections.OverwriteClientSettings(clientInput.ConnectionId, cs)
+					connections.NotifyWindowChange(clientInput.ConnectionId, uint32(w), uint32(h))
 
 				}
 

--- a/internal/mutators/mutators.go
+++ b/internal/mutators/mutators.go
@@ -70,6 +70,7 @@ type MutatorSpec struct {
 	LightMod      int                      `yaml:"lightmod,omitempty"`      //  -2 to 2 (change). If result is 0 = none. 1 = can see this room. 2 = can see this room and all exits
 	Exits         map[string]exit.RoomExit `yaml:"exits,omitempty"`         // name/roomId pairs of exits only available while mutator is live.
 	Pvp           PvpOverride              `yaml:"pvp,omitempty"`           // optionally force room pvp attributes.
+	Tags          []string                 `yaml:"tags,omitempty"`          // tags applied to the room while this mutator is active.
 }
 
 func GetAllMutatorSpecs() []MutatorSpec {

--- a/internal/mutators/mutators.go
+++ b/internal/mutators/mutators.go
@@ -331,5 +331,7 @@ func LoadDataFiles() {
 
 	allMutators = tmpMutators
 
+	loadPluginMutators(allMutators)
+
 	mudlog.Info("mutators.LoadDataFiles()", "loadedCount", len(allMutators), "Time Taken", time.Since(start))
 }

--- a/internal/mutators/plugin.go
+++ b/internal/mutators/plugin.go
@@ -1,0 +1,81 @@
+package mutators
+
+import (
+	"io/fs"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/fileloader"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	pluginFileSystems []fileloader.ReadableGroupFS
+)
+
+// RegisterFS registers a plugin file system to be searched when loading mutator
+// data files. Must be called before LoadDataFiles().
+func RegisterFS(f ...fileloader.ReadableGroupFS) {
+	pluginFileSystems = append(pluginFileSystems, f...)
+}
+
+// loadPluginMutators walks every sub-filesystem of every registered plugin FS,
+// reading mutator YAML files from a "mutators/" prefix and merging them into dst.
+func loadPluginMutators(dst map[string]*MutatorSpec) {
+	for _, groupFS := range pluginFileSystems {
+		for subFS := range groupFS.AllFileSubSystems {
+			loadMutatorsFromFS(subFS, dst)
+		}
+	}
+}
+
+func loadMutatorsFromFS(subFS fs.ReadFileFS, dst map[string]*MutatorSpec) {
+	if pl, ok := subFS.(fileloader.PathLister); ok {
+		for _, path := range pl.KnownPaths() {
+			if !strings.HasPrefix(path, `mutators/`) || !strings.HasSuffix(path, `.yaml`) {
+				continue
+			}
+			loadMutatorFileFromFS(subFS, path, dst)
+		}
+		return
+	}
+
+	_ = fs.WalkDir(subFS, `mutators`, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, `.yaml`) {
+			return nil
+		}
+		loadMutatorFileFromFS(subFS, path, dst)
+		return nil
+	})
+}
+
+func loadMutatorFileFromFS(subFS fs.ReadFileFS, path string, dst map[string]*MutatorSpec) {
+	b, err := subFS.ReadFile(path)
+	if err != nil {
+		mudlog.Error("mutators.loadMutatorsFromFS", "path", path, "error", err)
+		return
+	}
+
+	var spec MutatorSpec
+	if err := yaml.Unmarshal(b, &spec); err != nil {
+		mudlog.Error("mutators.loadMutatorsFromFS", "path", path, "error", err)
+		return
+	}
+
+	if !strings.HasSuffix(path, spec.Filepath()) {
+		mudlog.Error("mutators.loadMutatorsFromFS", "path", path, "expected suffix", spec.Filepath(), "error", "filepath mismatch")
+		return
+	}
+
+	if err := spec.Validate(); err != nil {
+		mudlog.Error("mutators.loadMutatorsFromFS", "path", path, "error", err)
+		return
+	}
+
+	if _, exists := dst[spec.MutatorId]; exists {
+		mudlog.Error("mutators.loadMutatorsFromFS", "mutatorId", spec.MutatorId, "path", path, "error", "duplicate mutator id")
+		return
+	}
+
+	dst[spec.MutatorId] = &spec
+}

--- a/internal/rooms/roomdetails.go
+++ b/internal/rooms/roomdetails.go
@@ -91,7 +91,7 @@ func GetDetails(r *Room, user *users.UserRecord, tinymap ...[]string) RoomTempla
 		IsNight:        gametime.IsNight(),
 		TrackingString: ``,
 		ShowPvp:        showPvp,
-		Tags:           append([]string{}, r.Tags...),
+		Tags:           r.GetTags(),
 	}
 
 	//

--- a/internal/rooms/rooms.go
+++ b/internal/rooms/rooms.go
@@ -2276,6 +2276,34 @@ func (r *Room) ActiveMutators(yield func(mutators.Mutator) bool) {
 	}
 }
 
+func (r *Room) HasTag(tag string) bool {
+	for _, t := range r.Tags {
+		if strings.EqualFold(t, tag) {
+			return true
+		}
+	}
+	for mut := range r.ActiveMutators {
+		if spec := mut.GetSpec(); spec != nil {
+			for _, t := range spec.Tags {
+				if strings.EqualFold(t, tag) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (r *Room) GetTags() []string {
+	tags := append([]string{}, r.Tags...)
+	for mut := range r.ActiveMutators {
+		if spec := mut.GetSpec(); spec != nil {
+			tags = append(tags, spec.Tags...)
+		}
+	}
+	return tags
+}
+
 // Returns true if Pvp is allowed in this room
 func (r *Room) IsPvp() bool {
 	roomPvp := r.Pvp

--- a/internal/scripting/room_func.go
+++ b/internal/scripting/room_func.go
@@ -363,12 +363,7 @@ func (r ScriptRoom) RemoveTemporaryExit(exitNameSimple string, exitNameFancy str
 }
 
 func (r ScriptRoom) HasTag(tag string) bool {
-	for _, t := range r.roomRecord.Tags {
-		if t == tag {
-			return true
-		}
-	}
-	return false
+	return r.roomRecord.HasTag(tag)
 }
 
 func (r ScriptRoom) SetTag(tag string) {

--- a/internal/usercommands/default.go
+++ b/internal/usercommands/default.go
@@ -1,8 +1,6 @@
 package usercommands
 
 import (
-	"strings"
-
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
 	"github.com/GoMudEngine/GoMud/internal/users"
@@ -31,13 +29,11 @@ func Default(rest string, user *users.UserRecord, room *rooms.Room, flags events
 	}
 
 	// If a storage location, "storage"
-	for _, t := range room.Tags {
-		if strings.EqualFold(t, `storage`) {
-			// Dispatch via the event queue so we do not create an init cycle
-			// with the storage module's RegisterCommand call.
-			user.Command(`storage`)
-			return true, nil
-		}
+	if room.HasTag(`storage`) {
+		// Dispatch via the event queue so we do not create an init cycle
+		// with the storage module's RegisterCommand call.
+		user.Command(`storage`)
+		return true, nil
 	}
 
 	// Default to "look"

--- a/main.go
+++ b/main.go
@@ -185,6 +185,7 @@ func main() {
 	// Register the plugin filesystem with the template system
 	templates.RegisterFS(plugins.GetPluginRegistry())
 	items.RegisterFS(plugins.GetPluginRegistry())
+	mutators.RegisterFS(plugins.GetPluginRegistry())
 	usercommands.AddFunctionExporter(plugins.GetPluginRegistry())
 	users.AddFunctionExporter(plugins.GetPluginRegistry())
 	usercommands.SetRoomTagProvider(plugins.GetRegisteredRoomTags)

--- a/main.go
+++ b/main.go
@@ -1317,6 +1317,7 @@ func handleSSHConnection(connDetails *connections.ConnectionDetails, reqs <-chan
 						cs.Display.ScreenWidth = cols
 						cs.Display.ScreenHeight = rows
 						connections.OverwriteClientSettings(connDetails.ConnectionId(), cs)
+						connections.NotifyWindowChange(connDetails.ConnectionId(), cols, rows)
 					}
 				}
 				if req.WantReply {

--- a/modules/all-modules.go
+++ b/modules/all-modules.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/GoMudEngine/GoMud/modules/alt-characters"
 	_ "github.com/GoMudEngine/GoMud/modules/auctions"
 	_ "github.com/GoMudEngine/GoMud/modules/cleanup"
+	_ "github.com/GoMudEngine/GoMud/modules/clibridge"
 	_ "github.com/GoMudEngine/GoMud/modules/follow"
 	_ "github.com/GoMudEngine/GoMud/modules/gambling"
 	_ "github.com/GoMudEngine/GoMud/modules/gmcp"

--- a/modules/alt-characters/alt_characters.go
+++ b/modules/alt-characters/alt_characters.go
@@ -259,12 +259,7 @@ func (m *AltCharactersModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.Room
 }
 
 func roomIsCharacter(room *rooms.Room) bool {
-	for _, t := range room.Tags {
-		if strings.EqualFold(t, characterTag) {
-			return true
-		}
-	}
-	return false
+	return room.HasTag(characterTag)
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/clibridge/clibridge.go
+++ b/modules/clibridge/clibridge.go
@@ -1,0 +1,467 @@
+package clibridge
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/connections"
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/suggestions"
+	"github.com/GoMudEngine/GoMud/internal/term"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/creack/pty"
+)
+
+var (
+	//go:embed files/*
+	files embed.FS
+)
+
+func init() {
+	m := &CLIBridgeModule{
+		plug:     plugins.New(`clibridge`, `1.0`),
+		sessions: make(map[connections.ConnectionId]*Session),
+	}
+
+	if err := m.plug.AttachFileSystem(files); err != nil {
+		panic(err)
+	}
+
+	m.plug.AddUserCommand(`cli`, m.cliCommand, false, true)
+
+	events.RegisterListener(events.CLIRequest{}, m.onCLIRequest)
+
+	connections.RegisterWindowChangeListener(m.onWindowChange)
+
+	suggestions.OnAutoComplete.Register(m.onAutoComplete)
+}
+
+type Session struct {
+	ConnectionId connections.ConnectionId
+	UserId       int
+	Cmd          *exec.Cmd
+	PtyFile      *os.File
+	Done         chan struct{}
+	mu           sync.Mutex
+	isTelnet     bool
+}
+
+type CLIBridgeModule struct {
+	plug     *plugins.Plugin
+	sessions map[connections.ConnectionId]*Session
+	mu       sync.Mutex
+}
+
+func (m *CLIBridgeModule) getSession(connId connections.ConnectionId) *Session {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sessions[connId]
+}
+
+func (m *CLIBridgeModule) setSession(connId connections.ConnectionId, s *Session) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessions[connId] = s
+}
+
+func (m *CLIBridgeModule) removeSession(connId connections.ConnectionId) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, connId)
+}
+
+func (m *CLIBridgeModule) isEnabled() bool {
+	v := m.plug.Config.Get(`Enabled`)
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return true
+}
+
+func (m *CLIBridgeModule) getAllowedTools() []string {
+	v := m.plug.Config.Get(`AllowedTools`)
+	if tools, ok := v.([]any); ok {
+		result := make([]string, 0, len(tools))
+		for _, t := range tools {
+			if s, ok := t.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	}
+	return nil
+}
+
+func (m *CLIBridgeModule) getAllowedPaths() []string {
+	v := m.plug.Config.Get(`AllowedPaths`)
+	if paths, ok := v.([]any); ok {
+		result := make([]string, 0, len(paths))
+		for _, p := range paths {
+			if s, ok := p.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	}
+	return []string{`/*`}
+}
+
+func (m *CLIBridgeModule) isToolAllowed(toolName string) bool {
+	for _, allowed := range m.getAllowedTools() {
+		if strings.EqualFold(allowed, toolName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *CLIBridgeModule) isPathAllowed(relPath string) bool {
+	dataDir := configs.GetFilePathsConfig().DataFiles.String()
+
+	absPath := filepath.Clean(filepath.Join(dataDir, relPath))
+
+	if !strings.HasPrefix(absPath, filepath.Clean(dataDir)) {
+		return false
+	}
+
+	for _, allowed := range m.getAllowedPaths() {
+		if allowed == `/*` {
+			return true
+		}
+		allowedAbs := filepath.Clean(filepath.Join(dataDir, allowed))
+		if strings.HasPrefix(absPath, allowedAbs) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *CLIBridgeModule) resolveArgs(args []string) ([]string, error) {
+	if len(args) == 0 {
+		return args, nil
+	}
+
+	resolved := make([]string, len(args))
+
+	for i, arg := range args {
+		if strings.HasPrefix(arg, `-`) {
+			resolved[i] = arg
+			continue
+		}
+
+		if !m.isPathAllowed(arg) {
+			return nil, fmt.Errorf("path %q is not within allowed paths", arg)
+		}
+		resolved[i] = arg
+	}
+
+	return resolved, nil
+}
+
+func (m *CLIBridgeModule) cliCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	if !m.isEnabled() {
+		user.SendText("CLI bridge is not enabled.")
+		return true, nil
+	}
+
+	connId := users.GetConnectionId(user.UserId)
+	connDetails := connections.Get(connId)
+	if connDetails == nil {
+		user.SendText("Connection not found.")
+		return true, nil
+	}
+
+	if connDetails.IsWebSocket() {
+		user.SendText("CLI tools are not supported over WebSocket connections.")
+		return true, nil
+	}
+
+	parts := strings.Fields(rest)
+	if len(parts) < 1 {
+		user.SendText("Usage: cli <tool> [args...]")
+		return true, nil
+	}
+
+	if m.getSession(connId) != nil {
+		user.SendText("A CLI session is already active on this connection.")
+		return true, nil
+	}
+
+	toolName := parts[0]
+	args := parts[1:]
+
+	if !m.isToolAllowed(toolName) {
+		user.SendText(fmt.Sprintf("Tool %q is not in the allowed tools list.", toolName))
+		return true, nil
+	}
+
+	events.AddToQueue(events.CLIRequest{
+		UserId:       user.UserId,
+		ConnectionId: connId,
+		Command:      toolName,
+		Args:         args,
+	})
+
+	return true, nil
+}
+
+func (m *CLIBridgeModule) onCLIRequest(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.CLIRequest)
+	if !ok {
+		return events.Continue
+	}
+
+	user := users.GetByUserId(evt.UserId)
+	if user == nil {
+		return events.Continue
+	}
+
+	connId := evt.ConnectionId
+	connDetails := connections.Get(connId)
+	if connDetails == nil {
+		return events.Continue
+	}
+
+	binaryPath, err := exec.LookPath(evt.Command)
+	if err != nil {
+		user.SendText(fmt.Sprintf("Tool %q not found on system: %s", evt.Command, err.Error()))
+		return events.Continue
+	}
+
+	resolvedArgs, err := m.resolveArgs(evt.Args)
+	if err != nil {
+		user.SendText(fmt.Sprintf("Path error: %s", err.Error()))
+		return events.Continue
+	}
+
+	cs := connections.GetClientSettings(connId)
+	cols := uint16(cs.Display.ScreenWidth)
+	rows := uint16(cs.Display.ScreenHeight)
+	if cols == 0 {
+		cols = 80
+	}
+	if rows == 0 {
+		rows = 24
+	}
+
+	cmd := exec.Command(binaryPath, resolvedArgs...)
+	cmd.Dir = configs.GetFilePathsConfig().DataFiles.String()
+	cmd.Env = append(os.Environ(),
+		"TERM=xterm-256color",
+		fmt.Sprintf("COLUMNS=%d", cols),
+		fmt.Sprintf("LINES=%d", rows),
+	)
+
+	winSize := &pty.Winsize{Cols: cols, Rows: rows}
+	ptmx, err := pty.StartWithSize(cmd, winSize)
+	if err != nil {
+		user.SendText(fmt.Sprintf("Failed to start CLI tool: %s", err.Error()))
+		return events.Continue
+	}
+
+	sess := &Session{
+		ConnectionId: connId,
+		UserId:       evt.UserId,
+		Cmd:          cmd,
+		PtyFile:      ptmx,
+		Done:         make(chan struct{}),
+		isTelnet:     !connDetails.IsSSH() && !connDetails.IsWebSocket(),
+	}
+
+	m.setSession(connId, sess)
+
+	inputHandler := m.makeInputHandler(connId)
+	if connDetails.IsSSH() {
+		connDetails.PrependInputHandler("CLIBridge", inputHandler)
+	} else {
+		connDetails.AddInputHandler("CLIBridge", inputHandler, "TelnetIACHandler")
+	}
+
+	connDetails.OutputSuppressed(true)
+
+	go m.ptyToClient(sess)
+	go m.waitForExit(sess, user)
+
+	return events.Continue
+}
+
+func (m *CLIBridgeModule) makeInputHandler(connId connections.ConnectionId) connections.InputHandler {
+	return func(ci *connections.ClientInput, handlerState map[string]any) bool {
+		sess := m.getSession(connId)
+		if sess == nil {
+			return true
+		}
+
+		if len(ci.DataIn) > 0 {
+			sess.mu.Lock()
+			if sess.PtyFile != nil {
+				sess.PtyFile.Write(ci.DataIn)
+			}
+			sess.mu.Unlock()
+		}
+
+		ci.DataIn = ci.DataIn[:0]
+		ci.Buffer = ci.Buffer[:0]
+		ci.EnterPressed = false
+		ci.TabPressed = false
+		ci.BSPressed = false
+
+		return false
+	}
+}
+
+func (m *CLIBridgeModule) ptyToClient(sess *Session) {
+	buf := make([]byte, 4096)
+	for {
+		n, err := sess.PtyFile.Read(buf)
+		if n > 0 {
+			data := buf[:n]
+			if sess.isTelnet {
+				data = escapeIAC(data)
+			}
+			connections.SendRawTo(data, sess.ConnectionId)
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func escapeIAC(data []byte) []byte {
+	count := 0
+	for _, b := range data {
+		if b == byte(term.TELNET_IAC) {
+			count++
+		}
+	}
+	if count == 0 {
+		return data
+	}
+	escaped := make([]byte, 0, len(data)+count)
+	for _, b := range data {
+		escaped = append(escaped, b)
+		if b == byte(term.TELNET_IAC) {
+			escaped = append(escaped, b)
+		}
+	}
+	return escaped
+}
+
+func (m *CLIBridgeModule) waitForExit(sess *Session, user *users.UserRecord) {
+	sess.Cmd.Wait()
+	close(sess.Done)
+
+	sess.mu.Lock()
+	sess.PtyFile.Close()
+	sess.PtyFile = nil
+	sess.mu.Unlock()
+
+	m.removeSession(sess.ConnectionId)
+
+	connDetails := connections.Get(sess.ConnectionId)
+	if connDetails != nil {
+		connDetails.OutputSuppressed(false)
+		connDetails.RemoveInputHandler("CLIBridge")
+	}
+
+	if user != nil {
+		user.SendText("\n[CLI tool exited. Returning to game.]")
+		events.AddToQueue(events.RedrawPrompt{UserId: sess.UserId})
+	}
+}
+
+func (m *CLIBridgeModule) onWindowChange(connId connections.ConnectionId, cols, rows uint32) {
+	sess := m.getSession(connId)
+	if sess == nil {
+		return
+	}
+
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+
+	if sess.PtyFile != nil {
+		pty.Setsize(sess.PtyFile, &pty.Winsize{
+			Cols: uint16(cols),
+			Rows: uint16(rows),
+		})
+	}
+}
+
+func (m *CLIBridgeModule) onAutoComplete(req suggestions.AutoCompleteRequest) suggestions.AutoCompleteRequest {
+	if req.Cmd != `cli` {
+		return req
+	}
+
+	if len(req.Parts) == 2 {
+		toolPrefix := strings.ToLower(req.Parts[1])
+		for _, tool := range m.getAllowedTools() {
+			if strings.HasPrefix(strings.ToLower(tool), toolPrefix) {
+				req.Results = append(req.Results, tool[len(toolPrefix):])
+			}
+		}
+		return req
+	}
+
+	if len(req.Parts) < 3 {
+		return req
+	}
+
+	partial := req.Parts[len(req.Parts)-1]
+	dataDir := configs.GetFilePathsConfig().DataFiles.String()
+
+	var searchDir string
+	var prefix string
+
+	if partial == `` || strings.HasSuffix(partial, `/`) {
+		searchDir = filepath.Join(dataDir, partial)
+		prefix = ``
+	} else {
+		searchDir = filepath.Join(dataDir, filepath.Dir(partial))
+		prefix = strings.ToLower(filepath.Base(partial))
+	}
+
+	entries, err := os.ReadDir(searchDir)
+	if err != nil {
+		return req
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(strings.ToLower(name), prefix) {
+			continue
+		}
+		suffix := name[len(prefix):]
+		if entry.IsDir() {
+			suffix += `/`
+		}
+		req.Results = append(req.Results, suffix)
+	}
+
+	return req
+}
+
+func (m *CLIBridgeModule) stopSession(sess *Session) {
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+
+	if sess.Cmd.Process != nil {
+		sess.Cmd.Process.Signal(syscall.SIGTERM)
+		go func() {
+			select {
+			case <-sess.Done:
+			case <-time.After(5 * time.Second):
+				sess.Cmd.Process.Kill()
+			}
+		}()
+	}
+}

--- a/modules/clibridge/files/data-overlays/config.yaml
+++ b/modules/clibridge/files/data-overlays/config.yaml
@@ -1,0 +1,10 @@
+Enabled: true
+AllowedTools:
+  - nano
+  - vim
+  - less
+  - htop
+  - top
+  - ls
+AllowedPaths:
+  - "/*"

--- a/modules/clibridge/files/data-overlays/keywords.yaml
+++ b/modules/clibridge/files/data-overlays/keywords.yaml
@@ -1,0 +1,4 @@
+help:
+  admin:
+    all:
+      - cli

--- a/modules/clibridge/files/datafiles/templates/admincommands/help/command.cli.template
+++ b/modules/clibridge/files/datafiles/templates/admincommands/help/command.cli.template
@@ -1,0 +1,15 @@
+The <ansi fg="command">cli</ansi> command launches an interactive CLI tool within your session.
+
+<ansi fg="command">cli &lt;tool&gt; [args...]</ansi>
+
+<ansi fg="yellow">Examples:</ansi>
+  <ansi fg="command">cli nano rooms/1.yaml</ansi>    - Edit a datafile with nano
+  <ansi fg="command">cli less items/1.yaml</ansi>    - View a datafile with less
+  <ansi fg="command">cli htop</ansi>                 - Launch htop
+  <ansi fg="command">cli vim rooms/1.yaml</ansi>     - Edit a datafile with vim
+
+<ansi fg="yellow">Notes:</ansi>
+  File paths are relative to the server datafiles directory.
+  Only allowed tools and paths may be used (see server config).
+  Not available over WebSocket connections.
+  Press the tool's normal exit key to return to the game.

--- a/modules/gambling/claw.go
+++ b/modules/gambling/claw.go
@@ -80,12 +80,7 @@ func (g *GamblingModule) buildClawPrizes() []clawPrize {
 
 // roomHasClaw returns true when the room carries a "claw machine" tag.
 func roomHasClaw(r *rooms.Room) bool {
-	for _, t := range r.Tags {
-		if strings.ToLower(t) == `claw machine` {
-			return true
-		}
-	}
-	return false
+	return r.HasTag(`claw machine`)
 }
 
 // clawPrizeWeight returns the configured weight for a prize, falling back to the default.

--- a/modules/gambling/gambling.go
+++ b/modules/gambling/gambling.go
@@ -3,10 +3,6 @@ package gambling
 import (
 	"embed"
 	"fmt"
-	"io/fs"
-	"strings"
-	"time"
-
 	"github.com/GoMudEngine/GoMud/internal/events"
 	"github.com/GoMudEngine/GoMud/internal/items"
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
@@ -14,7 +10,8 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/rooms"
 	"github.com/GoMudEngine/GoMud/internal/users"
 	"github.com/GoMudEngine/GoMud/internal/util"
-	lru "github.com/hashicorp/golang-lru/v2"
+	"io/fs"
+	"strings"
 )
 
 var (
@@ -26,11 +23,9 @@ const defaultCost = 10
 
 func init() {
 
-	roomTagCache, _ := lru.New[int, roomTagEntry](64)
 	g := &GamblingModule{
-		plug:         plugins.New(`gambling`, `1.0`),
-		state:        make(SlotState),
-		roomTagCache: roomTagCache,
+		plug:  plugins.New(`gambling`, `1.0`),
+		state: make(SlotState),
 	}
 
 	if err := g.plug.AttachFileSystem(files); err != nil {
@@ -119,14 +114,12 @@ func (g *GamblingModule) onLookInput(e events.Event) events.ListenerReturn {
 		return events.Continue
 	}
 
-	hasSlots, hasClaw := g.cachedRoomTags(room)
-
-	if _, c := util.FindMatchIn(target, `slot machine`, `slots`, `slot`); c != `` && hasSlots {
+	if _, c := util.FindMatchIn(target, `slot machine`, `slots`, `slot`); c != `` && roomHasSlots(room) {
 		g.sendLookDescription(user, room, `slot machine`, g.slotMachineNounDesc(room.RoomId))
 		return events.Cancel
 	}
 
-	if _, c := util.FindMatchIn(target, `claw machine`, `claw`); c != `` && hasClaw {
+	if _, c := util.FindMatchIn(target, `claw machine`, `claw`); c != `` && roomHasClaw(room) {
 		g.sendLookDescription(user, room, `claw machine`, g.clawMachineNounDesc())
 		return events.Cancel
 	}
@@ -152,20 +145,10 @@ func (g *GamblingModule) sendLookDescription(user *users.UserRecord, room *rooms
 	)
 }
 
-const roomTagCacheTTL = 30 * time.Second
-
-// roomTagEntry is a cached result of the tag checks for one room.
-type roomTagEntry struct {
-	hasSlots bool
-	hasClaw  bool
-	expiry   time.Time
-}
-
 // GamblingModule holds module-level state for the gambling plugin.
 type GamblingModule struct {
-	plug         *plugins.Plugin
-	state        SlotState
-	roomTagCache *lru.Cache[int, roomTagEntry]
+	plug  *plugins.Plugin
+	state SlotState
 }
 
 func (g *GamblingModule) load() {
@@ -174,22 +157,6 @@ func (g *GamblingModule) load() {
 
 func (g *GamblingModule) save() {
 	g.plug.WriteStruct(`slotstate`, g.state)
-}
-
-// cachedRoomTags returns the cached slot/claw tag results for the room,
-// recomputing them if the cache entry is absent or expired.
-func (g *GamblingModule) cachedRoomTags(r *rooms.Room) (hasSlots bool, hasClaw bool) {
-	if entry, ok := g.roomTagCache.Get(r.RoomId); ok && time.Now().Before(entry.expiry) {
-		return entry.hasSlots, entry.hasClaw
-	}
-	hasSlots = roomHasSlots(r)
-	hasClaw = roomHasClaw(r)
-	g.roomTagCache.Add(r.RoomId, roomTagEntry{
-		hasSlots: hasSlots,
-		hasClaw:  hasClaw,
-		expiry:   time.Now().Add(roomTagCacheTTL),
-	})
-	return hasSlots, hasClaw
 }
 
 // onRoomLook injects a slot machine alert when the room has the slots tag.
@@ -212,8 +179,7 @@ func (g *GamblingModule) playCommand(rest string, user *users.UserRecord, room *
 	arg := strings.TrimSpace(rest)
 
 	if m, c := util.FindMatchIn(arg, `slot machine`, `slots`, `slot`); m != `` || c != `` {
-		hasSlots, _ := g.cachedRoomTags(room)
-		if !hasSlots {
+		if !roomHasSlots(room) {
 			user.SendText(`There is no slot machine here.`)
 			return true, nil
 		}
@@ -222,8 +188,7 @@ func (g *GamblingModule) playCommand(rest string, user *users.UserRecord, room *
 	}
 
 	if m, c := util.FindMatchIn(arg, `claw machine`, `claw`); m != `` || c != `` {
-		_, hasClaw := g.cachedRoomTags(room)
-		if !hasClaw {
+		if !roomHasClaw(room) {
 			user.SendText(`There is no claw machine here.`)
 			return true, nil
 		}

--- a/modules/gambling/slots.go
+++ b/modules/gambling/slots.go
@@ -69,13 +69,7 @@ func minJackpot(cost int) int {
 
 // roomHasSlots returns true when the room carries a "slots" or "slot machine" tag.
 func roomHasSlots(r *rooms.Room) bool {
-	for _, t := range r.Tags {
-		tl := strings.ToLower(t)
-		if tl == `slots` || tl == `slot machine` {
-			return true
-		}
-	}
-	return false
+	return r.HasTag(`slots`) || r.HasTag(`slot machine`)
 }
 
 // coloredGlyph wraps a symbol glyph in its designated ANSI color tag.

--- a/modules/gmcp/gmcp.Room.go
+++ b/modules/gmcp/gmcp.Room.go
@@ -500,7 +500,7 @@ func (g *GMCPRoomModule) GetRoomNode(user *users.UserRecord, gmcpModule string) 
 			payload.Details = append(payload.Details, `pvp`)
 		}
 
-		for _, tag := range room.Tags {
+		for _, tag := range room.GetTags() {
 			payload.Details = append(payload.Details, tag)
 		}
 

--- a/modules/gmcp/gmcp.World.go
+++ b/modules/gmcp/gmcp.World.go
@@ -171,7 +171,7 @@ func (g *GMCPWorldModule) buildWorldMap(user *users.UserRecord) []GMCPWorldMap_R
 			if room.IsBank {
 				entry.Details = append(entry.Details, `bank`)
 			}
-			for _, tag := range room.Tags {
+			for _, tag := range room.GetTags() {
 				entry.Details = append(entry.Details, tag)
 			}
 			if room.IsPvp() {

--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -225,12 +225,7 @@ func (m *StorageModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTempla
 
 // roomIsStorage returns true if the room has the storage tag.
 func roomIsStorage(room *rooms.Room) bool {
-	for _, t := range room.Tags {
-		if strings.EqualFold(t, storageTag) {
-			return true
-		}
-	}
-	return false
+	return room.HasTag(storageTag)
 }
 
 // GetStorageItems is exported for use by other systems (e.g. autocomplete).


### PR DESCRIPTION
# Description

This expands mutator capability by allowing them to add ephemeral tags to rooms that disappear after the mutator expires. These can be used by scripts and modules. 

## Changes

- Added "tags" to mutators, and updated the mutator admin tool to include a picker tool for tags.
- Updated wildfire mutator, added a fire-scorched mutator.
- "CLI Tool" support - invoking command line binary commands from inside the MUD. Useful for file searching, editing and so on.
- Minor front end fixes like the "Equipment" window in the web client showing _nothing_ in slot.
- Added some padding to the terminal area for when windows "slide away" - prevents covering a little text on the left.
