### PR TITLE
[CI] Update Dependabot Config

### DIFF
--- a/.github/Dockerfile.act
+++ b/.github/Dockerfile.act
@@ -1,6 +1,8 @@
 # check=skip=InvalidDefaultArgInFrom
 ARG GO_VERSION
-FROM golang:${GO_VERSION}
+# GoMud currently uses Go 1.24,
+# but `actionlint` used below requires 1.25
+FROM golang:1.25
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV GOBIN=/usr/local/bin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
@@ -18,6 +19,8 @@ updates:
       - "go"
     commit-message:
       prefix: "deps"
+    ignore: # ignore golang updates for now, as go 1.24 is desired
+      - dependency-name: "golang"
     groups:
       go-minor-patch:
         update-types:
@@ -28,13 +31,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "monday"
-      time: "06:15"
+      time: "06:00"
       timezone: "UTC"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "ci"
+      - "github-actions"
     commit-message:
       prefix: "deps"
     groups:
@@ -43,39 +45,35 @@ updates:
           - "*"
 
   - package-ecosystem: "docker"
-    directory: "/provisioning"
+    directory: "/docker/provisioning"
     schedule:
       interval: "monthly"
-      day: "monday"
-      time: "06:30"
+      time: "06:00"
       timezone: "UTC"
-    open-pull-requests-limit: 2
     labels:
       - "dependencies"
       - "docker"
     commit-message:
       prefix: "deps"
     groups:
-      docker-minor-patch:
+      docker-provisioning-minor-patch:
         update-types:
           - "minor"
           - "patch"
 
   - package-ecosystem: "docker"
-    directory: "/provisioning/terminal"
+    directory: "/docker/terminal"
     schedule:
       interval: "monthly"
-      day: "monday"
-      time: "06:35"
+      time: "06:00"
       timezone: "UTC"
-    open-pull-requests-limit: 2
     labels:
       - "dependencies"
       - "docker"
     commit-message:
       prefix: "deps"
     groups:
-      docker-minor-patch:
+      docker-terminal-minor-patch:
         update-types:
           - "minor"
           - "patch"
@@ -84,17 +82,15 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "monday"
-      time: "06:40"
+      time: "06:00"
       timezone: "UTC"
-    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "docker"
     commit-message:
       prefix: "deps"
     groups:
-      compose-minor-patch:
+      docker-compose-minor-patch:
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Overview

1) Update `.github/dependabot.yml`  so that Dependabot does not submit PRs to upgrade `golang` 
    - (Go 1.24 is still desired for GoMud)

2) Update `.github/Dockerfile.act` (used for `make ci-local`) to use Go 1.25
    - As the `actionlint` tool in it requires >=1.25