### PR TITLE
Adding "Waypoints" to zombiemode

### DIFF
--- a/modules/zombiemode/command.zombie.go
+++ b/modules/zombiemode/command.zombie.go
@@ -89,6 +89,7 @@ func (m *ZombieModule) zombieCommand(rest string, user *users.UserRecord, room *
 			RoamRadius:    cfg.RoamRadius,
 			RestThreshold: cfg.RestThreshold,
 			LootTargets:   append([]string{}, cfg.LootTargets...),
+			Waypoints:     append([]int{}, cfg.Waypoints...),
 		}
 		cfg.Profiles[profileName] = saved
 		m.configs[user.UserId] = cfg
@@ -114,6 +115,7 @@ func (m *ZombieModule) zombieCommand(rest string, user *users.UserRecord, room *
 		cfg.RoamRadius = p.RoamRadius
 		cfg.RestThreshold = p.RestThreshold
 		cfg.LootTargets = append([]string{}, p.LootTargets...)
+		cfg.Waypoints = append([]int{}, p.Waypoints...)
 		m.configs[user.UserId] = cfg
 		user.SendText(fmt.Sprintf(`Profile <ansi fg="yellow">%s</ansi> loaded.`, profileName))
 		return true, nil
@@ -153,6 +155,12 @@ func (m *ZombieModule) zombieCommand(rest string, user *users.UserRecord, room *
 				lootStr = `<ansi fg="yellow">` + strings.Join(p.LootTargets, `, `) + `</ansi>`
 			}
 			user.SendText(fmt.Sprintf(`    <ansi fg="white">Loot targets:  </ansi> %s`, lootStr))
+
+			wpStr := `<ansi fg="red">none</ansi>`
+			if len(p.Waypoints) > 0 {
+				wpStr = fmt.Sprintf(`<ansi fg="yellow">%d defined</ansi>`, len(p.Waypoints))
+			}
+			user.SendText(fmt.Sprintf(`    <ansi fg="white">Waypoints:     </ansi> %s`, wpStr))
 		}
 		return true, nil
 
@@ -170,6 +178,9 @@ func (m *ZombieModule) zombieCommand(rest string, user *users.UserRecord, room *
 		m.configs[user.UserId] = cfg
 		user.SendText(fmt.Sprintf(`Profile <ansi fg="yellow">%s</ansi> deleted.`, profileName))
 		return true, nil
+
+	case `waypoints`:
+		return m.handleWaypoints(args[1:], user, cfg)
 	}
 
 	user.SendText(`Unknown zombie subcommand. Type <ansi fg="command">help zombie</ansi> for usage.`)
@@ -309,8 +320,98 @@ func (m *ZombieModule) showConfig(user *users.UserRecord, cfg ZombieConfig) {
 	}
 	user.SendText(fmt.Sprintf(`  <ansi fg="white">Loot targets:  </ansi> %s`, lootStr))
 
+	wpStr := `<ansi fg="red">none</ansi>`
+	if len(cfg.Waypoints) > 0 {
+		wpStr = fmt.Sprintf(`<ansi fg="yellow">%d defined</ansi>`, len(cfg.Waypoints))
+	}
+	user.SendText(fmt.Sprintf(`  <ansi fg="white">Waypoints:     </ansi> %s`, wpStr))
+
 	user.SendText(``)
 	user.SendText(`Type <ansi fg="command">help zombie</ansi> for usage.`)
+}
+
+func (m *ZombieModule) handleWaypoints(args []string, user *users.UserRecord, cfg ZombieConfig) (bool, error) {
+
+	if len(args) == 0 {
+		if len(cfg.Waypoints) == 0 {
+			user.SendText(`No waypoints defined. Use <ansi fg="command">zombie waypoints add</ansi> to add your current room.`)
+			return true, nil
+		}
+		user.SendText(fmt.Sprintf(`<ansi fg="black-bold">.:.</ansi> <ansi fg="magenta">Zombie Waypoints</ansi> [<ansi fg="yellow">%d</ansi>]`, len(cfg.Waypoints)))
+		user.SendText(``)
+		for i, roomId := range cfg.Waypoints {
+			roomName := `unknown`
+			if r := rooms.LoadRoom(roomId); r != nil {
+				roomName = r.Title
+			}
+			marker := ``
+			if roomId == user.Character.RoomId {
+				marker = ` <ansi fg="green">(here)</ansi>`
+			}
+			user.SendText(fmt.Sprintf(`  <ansi fg="yellow">%d.</ansi> <ansi fg="white">Room %d</ansi> - %s%s`, i+1, roomId, roomName, marker))
+		}
+		return true, nil
+	}
+
+	switch args[0] {
+	case `add`:
+		maxWaypoints := 10
+		if maxWP, ok := m.plug.Config.Get(`MaxWaypoints`).(int); ok && maxWP > 0 {
+			maxWaypoints = maxWP
+		}
+		if len(cfg.Waypoints) >= maxWaypoints {
+			user.SendText(fmt.Sprintf(`Cannot add more than <ansi fg="yellow">%d</ansi> waypoints.`, maxWaypoints))
+			return true, nil
+		}
+
+		currentRoomId := user.Character.RoomId
+
+		for _, wp := range cfg.Waypoints {
+			if wp == currentRoomId {
+				user.SendText(`This room is already a waypoint.`)
+				return true, nil
+			}
+		}
+
+		if len(cfg.Waypoints) > 0 {
+			lastWP := cfg.Waypoints[len(cfg.Waypoints)-1]
+			if _, err := mapper.GetPath(lastWP, currentRoomId); err != nil {
+				user.SendText(fmt.Sprintf(`No valid path from the previous waypoint (room %d) to here. Cannot add.`, lastWP))
+				return true, nil
+			}
+		}
+
+		cfg.Waypoints = append(cfg.Waypoints, currentRoomId)
+		m.configs[user.UserId] = cfg
+
+		roomName := `unknown`
+		if r := rooms.LoadRoom(currentRoomId); r != nil {
+			roomName = r.Title
+		}
+		user.SendText(fmt.Sprintf(`Waypoint added: room %d (%s). Total: %d.`, currentRoomId, roomName, len(cfg.Waypoints)))
+
+		if len(cfg.Waypoints) > 1 {
+			if _, err := mapper.GetPath(currentRoomId, cfg.Waypoints[0]); err != nil {
+				user.SendText(fmt.Sprintf(`<ansi fg="yellow">Warning:</ansi> No path from here back to the first waypoint (room %d). The cycle may not complete.`, cfg.Waypoints[0]))
+			}
+		}
+
+		return true, nil
+
+	case `reset`:
+		cfg.Waypoints = nil
+		m.configs[user.UserId] = cfg
+		if rt, isActive := m.active[user.UserId]; isActive {
+			rt.WaypointIndex = 0
+			rt.WaypointPath = nil
+			m.active[user.UserId] = rt
+		}
+		user.SendText(`All waypoints cleared.`)
+		return true, nil
+	}
+
+	user.SendText(`Usage: <ansi fg="command">zombie waypoints</ansi>, <ansi fg="command">zombie waypoints add</ansi>, or <ansi fg="command">zombie waypoints reset</ansi>`)
+	return true, nil
 }
 
 func containsString(slice []string, s string) bool {

--- a/modules/zombiemode/files/data-overlays/config.yaml
+++ b/modules/zombiemode/files/data-overlays/config.yaml
@@ -12,3 +12,6 @@ Enabled: true
 # - MaximumRoam -
 #   Maximum roam radius a player may set. 0 means no limit.
 MaximumRoam: 0
+# - MaxWaypoints -
+#   Maximum number of waypoints a player may define. 0 means no limit.
+MaxWaypoints: 10

--- a/modules/zombiemode/files/datafiles/html/admin/zombiemode-config.html
+++ b/modules/zombiemode/files/datafiles/html/admin/zombiemode-config.html
@@ -83,6 +83,7 @@
     const DESCRIPTIONS = {
         'Enabled': 'Set to false to disable zombie mode server-wide.',
         'MaximumRoam': 'Maximum roam radius a player may set with "zombie set roam". Set to 0 for no limit.',
+        'MaxWaypoints': 'Maximum number of waypoints a player may define with "zombie waypoints add". Set to 0 for no limit.',
     };
     const pending = {};
     let configData = {};

--- a/modules/zombiemode/files/datafiles/templates/help/zombie.template
+++ b/modules/zombiemode/files/datafiles/templates/help/zombie.template
@@ -41,6 +41,16 @@ will immediately wake you up and execute that command normally.
   <ansi fg="command">zombie unset loot <name></ansi>
     Remove a loot target. Omit the name or use <ansi fg="command">all</ansi> to clear all loot targets.
 
+  <ansi fg="command">zombie waypoints</ansi>
+    Show your current waypoint list.
+
+  <ansi fg="command">zombie waypoints add</ansi>
+    Add your current room as the next waypoint. A valid path must exist
+    from the previous waypoint (if any) to the current room.
+
+  <ansi fg="command">zombie waypoints reset</ansi>
+    Clear all waypoints.
+
   <ansi fg="command">zombie save <name></ansi>
     Save your current configuration as a named profile.
 
@@ -56,5 +66,6 @@ will immediately wake you up and execute that command normally.
   2. Continue attacking current target
   3. Attack a matching mob in the room
   4. Loot matching items or gold from the floor
-  5. Roam to a random nearby room (within radius)
+  5. Follow waypoint path (if waypoints are defined)
+  5b. Roam to a random nearby room (if no waypoints, within radius)
   6. Idle - occasionally emote

--- a/modules/zombiemode/zombieact.go
+++ b/modules/zombiemode/zombieact.go
@@ -105,7 +105,16 @@ func (m *ZombieModule) zombieActCommand(rest string, user *users.UserRecord, roo
 		}
 	}
 
-	// 5. Roam: pick a random exit within radius of the home room.
+	// 5. Waypoint patrol: follow pre-computed path to next waypoint.
+	if len(cfg.Waypoints) > 0 && user.Character.Aggro == nil {
+		if exitName := m.followWaypointPath(user, &rt, cfg); exitName != `` {
+			m.active[user.UserId] = rt
+			zombieCommand(user, fmt.Sprintf(`go %s`, exitName))
+			return true, nil
+		}
+	}
+
+	// 5b. Roam fallback: pick a random exit within radius of the home room.
 	if cfg.RoamRadius > 0 && user.Character.Aggro == nil {
 		if exitName := m.pickRoamExit(user.Character.RoomId, rt.HomeRoom, cfg.RoamRadius); exitName != `` {
 			zombieCommand(user, fmt.Sprintf(`go %s`, exitName))
@@ -201,6 +210,58 @@ func (m *ZombieModule) exitTowardHome(currentRoomId, homeRoomId int) string {
 	}
 
 	return ``
+}
+
+func (m *ZombieModule) followWaypointPath(user *users.UserRecord, rt *zombieRuntime, cfg ZombieConfig) string {
+
+	if len(cfg.Waypoints) == 0 {
+		return ``
+	}
+
+	if rt.WaypointIndex >= len(cfg.Waypoints) {
+		rt.WaypointIndex = 0
+	}
+
+	targetRoomId := cfg.Waypoints[rt.WaypointIndex]
+
+	if user.Character.RoomId == targetRoomId {
+		rt.WaypointIndex = (rt.WaypointIndex + 1) % len(cfg.Waypoints)
+		rt.WaypointPath = nil
+		targetRoomId = cfg.Waypoints[rt.WaypointIndex]
+
+		if user.Character.RoomId == targetRoomId {
+			return ``
+		}
+	}
+
+	if len(rt.WaypointPath) == 0 {
+		path, err := mapper.GetPath(user.Character.RoomId, targetRoomId)
+		if err != nil || len(path) == 0 {
+			rt.WaypointPath = nil
+			return ``
+		}
+		rt.WaypointPath = make([]pathStepRecord, len(path))
+		for i, step := range path {
+			rt.WaypointPath[i] = pathStepRecord{
+				exitName: step.ExitName(),
+				roomId:   step.RoomId(),
+			}
+		}
+	}
+
+	step := rt.WaypointPath[0]
+	rt.WaypointPath = rt.WaypointPath[1:]
+
+	currentRoom := rooms.LoadRoom(user.Character.RoomId)
+	if currentRoom != nil {
+		exitInfo, hasExit := currentRoom.Exits[step.exitName]
+		if !hasExit || exitInfo.RoomId != step.roomId {
+			rt.WaypointPath = nil
+			return ``
+		}
+	}
+
+	return step.exitName
 }
 
 // matchesCombatTarget returns true if the mob name matches any combat target.

--- a/modules/zombiemode/zombiemode.go
+++ b/modules/zombiemode/zombiemode.go
@@ -45,6 +45,7 @@ func init() {
 	events.RegisterListener(events.ItemOwnership{}, m.onItemOwnership)
 	events.RegisterListener(events.GainExperience{}, m.onGainExperience)
 	events.RegisterListener(events.LevelUp{}, m.onLevelUp)
+	events.RegisterListener(events.RoomChange{}, m.onRoomChange)
 	events.RegisterListener(zombieSummary{}, m.onZombieSummary)
 }
 
@@ -55,6 +56,7 @@ type ZombieConfig struct {
 	RoamRadius    int                     `yaml:"roamradius,omitempty"`
 	RestThreshold int                     `yaml:"restthreshold,omitempty"`
 	LootTargets   []string                `yaml:"loottargets,omitempty"`
+	Waypoints     []int                   `yaml:"waypoints,omitempty"`
 	Profiles      map[string]ZombieConfig `yaml:"profiles,omitempty"`
 }
 
@@ -65,6 +67,7 @@ type zombieStats struct {
 	ItemsLooted      map[string]int
 	ExperienceGained int
 	LevelsGained     int
+	RoomsTravelled   int
 }
 
 func newZombieStats() zombieStats {
@@ -74,10 +77,18 @@ func newZombieStats() zombieStats {
 	}
 }
 
+// pathStepRecord stores a single path step for waypoint navigation.
+type pathStepRecord struct {
+	exitName string
+	roomId   int
+}
+
 // zombieRuntime holds transient state that is only valid while zombie mode is active.
 type zombieRuntime struct {
-	HomeRoom int
-	Stats    zombieStats
+	HomeRoom      int
+	Stats         zombieStats
+	WaypointIndex int              // index into cfg.Waypoints of the next target
+	WaypointPath  []pathStepRecord // remaining steps to reach current target waypoint
 }
 
 // zombieSummary is a module-local event that carries a completed session's stats
@@ -232,8 +243,12 @@ func (m *ZombieModule) onInput(e events.Event) events.ListenerReturn {
 		return events.Continue
 	}
 
-	// Allow "zombie status" without waking up.
-	if strings.TrimSpace(strings.ToLower(evt.InputText)) == `zombie status` {
+	// Allow certain zombie subcommands without waking up.
+	inputLower := strings.TrimSpace(strings.ToLower(evt.InputText))
+	if inputLower == `zombie status` {
+		return events.Continue
+	}
+	if inputLower == `zombie waypoints` || strings.HasPrefix(inputLower, `zombie waypoints `) {
 		return events.Continue
 	}
 
@@ -368,6 +383,27 @@ func (m *ZombieModule) onLevelUp(e events.Event) events.ListenerReturn {
 	return events.Continue
 }
 
+func (m *ZombieModule) onRoomChange(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.RoomChange)
+	if !ok {
+		return events.Continue
+	}
+
+	if evt.UserId == 0 {
+		return events.Continue
+	}
+
+	rt, isActive := m.active[evt.UserId]
+	if !isActive {
+		return events.Continue
+	}
+
+	rt.Stats.RoomsTravelled++
+	m.active[evt.UserId] = rt
+
+	return events.Continue
+}
+
 // sendSummary sends the zombie session summary to the player.
 func (m *ZombieModule) sendSummary(user *users.UserRecord, stats zombieStats) {
 	border := `<ansi fg="black-bold">+--------------------------------------------------+</ansi>`
@@ -398,6 +434,7 @@ func (m *ZombieModule) sendSummary(user *users.UserRecord, stats zombieStats) {
 	lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Gold collected:</ansi>    <ansi fg="gold">%d</ansi>`, stats.GoldGained))
 	lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Experience gained:</ansi> <ansi fg="experience">%d</ansi>`, stats.ExperienceGained))
 	lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Levels gained:</ansi>     <ansi fg="stat">%d</ansi>`, stats.LevelsGained))
+	lines = append(lines, fmt.Sprintf(`  <ansi fg="white">Rooms travelled:</ansi>   <ansi fg="stat">%d</ansi>`, stats.RoomsTravelled))
 
 	lines = append(lines, ``)
 	lines = append(lines, `  <ansi fg="white">Items looted:</ansi>`)


### PR DESCRIPTION
# Description

This adds basic waypoints to zombie mode. This will use the internal `A*` pathfinder to plot a course to each waypoint (looping) while in zombie mode. It is saved to the zombie mode profile.

# Changes
- `zombie waypoints add` - add a new waypoint
- `zombie waypoints reset` - clears all waypoints
- zombie stats summary now shows a count of rooms travelled

