### PR TITLE
Mapper cleanup and improvement

### DIFF
--- a/_datafiles/html/admin/mapper.html
+++ b/_datafiles/html/admin/mapper.html
@@ -210,6 +210,19 @@
     }
     .mapper-info-panel .info-sub-label { color: var(--color-text); }
     .mapper-info-panel .info-sub-val   { color: var(--color-text-dim); text-align: right; }
+    .info-zlevel-btn {
+        flex: 1;
+        padding: 4px 6px;
+        font-size: 0.72rem;
+        font-family: monospace;
+        background: var(--color-surface-white);
+        color: var(--color-text-dim);
+        border: 1px solid var(--color-border);
+        border-radius: 3px;
+        cursor: pointer;
+        white-space: nowrap;
+    }
+    .info-zlevel-btn:hover { color: var(--color-text); background: var(--color-surface); }
     .mapper-info-panel .info-row-block {
         flex-direction: column;
         align-items: flex-start;

--- a/_datafiles/html/admin/mapper.html
+++ b/_datafiles/html/admin/mapper.html
@@ -467,6 +467,109 @@
     .mapper-changelog-overlay .cl-entry.cl-exit-add .cl-action { color: #a8d86e; }
     .mapper-changelog-overlay .cl-entry.cl-exit-remove .cl-action { color: #d4a843; }
 
+    .mapper-legend-btn {
+        position: absolute;
+        top: 8px; left: 8px;
+        z-index: 8;
+        width: 26px; height: 26px;
+        padding: 0;
+        font-size: 15px; line-height: 1;
+        font-family: monospace;
+        font-weight: bold;
+        background: var(--color-surface);
+        color: var(--color-text-dim);
+        border: 1px solid var(--color-border);
+        border-radius: 4px;
+        cursor: pointer;
+        opacity: 0.7;
+    }
+    .mapper-legend-btn:hover { opacity: 1; color: var(--color-text); }
+
+    .mapper-legend-overlay {
+        position: absolute;
+        top: 42px; left: 8px;
+        z-index: 9;
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 4px;
+        padding: 0;
+        width: 260px;
+        max-height: calc(100% - 56px);
+        display: none;
+        box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+        font-family: monospace;
+        font-size: 0.75rem;
+        overflow: hidden;
+        flex-direction: column;
+    }
+    .mapper-legend-overlay.visible { display: flex; }
+    .legend-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--color-border);
+        flex-shrink: 0;
+    }
+    .legend-title {
+        font-size: 0.72rem;
+        color: var(--color-text-dim);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+    .legend-close {
+        background: none;
+        border: none;
+        color: var(--color-text-dim);
+        font-size: 1.1rem;
+        cursor: pointer;
+        padding: 0 2px;
+        line-height: 1;
+    }
+    .legend-close:hover { color: var(--color-text); }
+    .legend-body {
+        padding: 6px 10px 10px;
+        overflow-y: auto;
+    }
+    .legend-section {
+        font-size: 0.68rem;
+        color: var(--color-text-dim);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        margin: 8px 0 4px 0;
+        padding-bottom: 2px;
+        border-bottom: 1px solid var(--color-border);
+    }
+    .legend-section:first-child { margin-top: 0; }
+    .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 2px 0;
+        color: var(--color-text);
+        font-size: 0.74rem;
+        line-height: 1.5;
+    }
+    .legend-swatch {
+        width: 18px; height: 18px;
+        flex-shrink: 0;
+        border-radius: 2px;
+        box-sizing: border-box;
+    }
+    .legend-swatch-text {
+        width: 18px;
+        flex-shrink: 0;
+        text-align: center;
+        font-size: 14px;
+        font-weight: bold;
+        line-height: 18px;
+    }
+    .legend-line {
+        width: 18px; height: 4px;
+        flex-shrink: 0;
+        border-radius: 2px;
+    }
+
     .toggle-switch {
         display: inline-flex;
         align-items: center;
@@ -750,10 +853,6 @@
     <select id="zone-select"><option value="">-- select zone --</option></select>
     <button class="room-search-btn" onclick="searchRoom()" title="Go to room by ID">&#128269;</button>
     <span class="sep"></span>
-    <div class="mapper-tabs">
-        <button class="tab-btn active" data-tab="2d" onclick="switchTab('2d')">2D</button>
-    </div>
-    <span class="sep"></span>
     <div class="mapper-controls">
         <button onclick="zoomOut()" title="Zoom out">&minus;</button>
         <button onclick="zoomIn()" title="Zoom in">+</button>
@@ -810,6 +909,42 @@
             <div id="changelog-entries"></div>
         </div>
         <div class="mapper-toast-container" id="mapper-toast-container"></div>
+        <button class="mapper-legend-btn" id="mapper-legend-btn" onclick="toggleLegend()" title="Map legend">?</button>
+        <div class="mapper-legend-overlay" id="mapper-legend">
+            <div class="legend-header">
+                <span class="legend-title">Map Legend</span>
+                <button class="legend-close" onclick="toggleLegend()">&times;</button>
+            </div>
+            <div class="legend-body">
+                <div class="legend-section">Rooms</div>
+                <div class="legend-item"><span class="legend-swatch" style="background:#3a3a4a;border:2px solid #d9d9d9"></span> Standard room</div>
+                <div class="legend-item"><span class="legend-swatch" style="background:#1a6abf;border:2px solid #1a6abf"></span> Selected room</div>
+                <div class="legend-item"><span class="legend-swatch" style="background:#3a3a4a;border:2px solid #d9d9d9;box-shadow:0 0 6px #d4a843,inset 0 0 0 1px #d4a843"></span> Room with script</div>
+                <div class="legend-item"><span class="legend-swatch" style="background:#3a3a4a;border:2px solid rgb(255,90,90)"></span> Room with mob spawn</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#ff00ff">&#9652;</span> Exit goes up a Z-level</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#ff00ff">&#9662;</span> Exit goes down a Z-level</div>
+
+                <div class="legend-section">Connections</div>
+                <div class="legend-item"><span class="legend-line" style="background:#7a4a1a"></span> Standard exit</div>
+                <div class="legend-item"><span class="legend-line dashed" style="background:repeating-linear-gradient(90deg,#d4c050 0 4px,transparent 4px 8px)"></span> Non-directional / named exit</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#d4a843;font-weight:bold">?</span> Secret exit</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#9ab0d4">&#9919;</span> Locked exit</div>
+
+                <div class="legend-section">Biomes / Environments</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#1a6b1a">&clubs;</span> Forest</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#4a6b20">&#9832;</span> Swamp</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#b8d8f0">&#10052;</span> Snow</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#5a4a38">&#9004;</span> Cave / Dungeon</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#7a6a50">&#10837;</span> Mountains</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#8a7a5a">&#9660;</span> Cliffs</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#8a6a3a">&#8962;</span> House</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#d4aa55">*</span> Desert</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#6a8a30">'</span> Farmland</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#a07840">=</span> Road</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#2a53f7">~</span> Shore / Water</div>
+                <div class="legend-item"><span class="legend-swatch-text" style="color:#0033cd">&asymp;</span> Deep Water</div>
+            </div>
+        </div>
     </div>
     <div class="mapper-info-panel" id="mapper-info-panel">
         <h3>Room Info</h3>

--- a/_datafiles/html/admin/mapper.html
+++ b/_datafiles/html/admin/mapper.html
@@ -76,8 +76,32 @@
         background: var(--color-border);
         margin: 0 3px;
     }
-    .mapper-z-controls { display: flex; gap: 2px; align-items: center; }
+    .mapper-z-controls { display: flex; gap: 4px; align-items: center; }
     .mapper-z-controls span { font-size: 0.72rem; color: var(--color-text-dim); font-family: monospace; }
+    .mapper-z-controls select {
+        padding: 2px 4px;
+        font-size: 0.75rem;
+        font-family: monospace;
+        background: var(--color-surface-white);
+        color: var(--color-text);
+        border: 1px solid var(--color-border);
+        border-radius: 3px;
+        min-width: 48px;
+        text-align: center;
+    }
+    .z-nav-btn {
+        width: 22px; height: 22px;
+        padding: 0;
+        font-size: 10px; line-height: 1;
+        font-family: monospace;
+        background: var(--color-surface-white);
+        color: var(--color-text-dim);
+        border: 1px solid var(--color-border);
+        border-radius: 3px;
+        cursor: pointer;
+    }
+    .z-nav-btn:hover { color: var(--color-text); background: var(--color-surface); }
+    .z-nav-btn:disabled { opacity: 0.3; cursor: default; }
 
     .mapper-body {
         display: flex;
@@ -614,12 +638,104 @@
         font-family: monospace;
         margin-left: auto;
     }
+    .room-search-btn {
+        width: 26px; height: 26px;
+        padding: 0;
+        font-size: 13px; line-height: 1;
+        background: var(--color-surface-white);
+        color: var(--color-text-dim);
+        border: 1px solid var(--color-border);
+        border-radius: 3px;
+        cursor: pointer;
+    }
+    .room-search-btn:hover { color: var(--color-text); background: var(--color-surface); }
+
+    .mapper-stats .unmapped-link {
+        color: #d4a843;
+        cursor: pointer;
+        text-decoration: underline;
+        text-decoration-style: dotted;
+    }
+    .mapper-stats .unmapped-link:hover { color: #e8c060; }
+
+    .unmapped-backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.55);
+        z-index: 1002;
+        align-items: center;
+        justify-content: center;
+    }
+    .unmapped-backdrop.visible { display: flex; }
+    .unmapped-modal {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 6px;
+        padding: 16px 20px;
+        min-width: 340px;
+        max-width: 520px;
+        max-height: 70vh;
+        display: flex;
+        flex-direction: column;
+        box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+    }
+    .unmapped-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .unmapped-header h3 { margin: 0; font-size: 0.9rem; color: var(--color-text); }
+    .unmapped-close {
+        background: none;
+        border: none;
+        color: var(--color-text-dim);
+        font-size: 1.2rem;
+        cursor: pointer;
+        padding: 0 4px;
+        line-height: 1;
+    }
+    .unmapped-close:hover { color: var(--color-text); }
+    .unmapped-modal p {
+        margin: 4px 0 10px 0;
+        font-size: 0.75rem;
+        color: var(--color-text-dim);
+    }
+    .unmapped-list {
+        overflow-y: auto;
+        font-family: monospace;
+        font-size: 0.78rem;
+    }
+    .unmapped-list table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+    .unmapped-list th {
+        text-align: left;
+        color: var(--color-text-dim);
+        font-weight: normal;
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        padding: 3px 8px 5px 0;
+        border-bottom: 1px solid var(--color-border);
+        position: sticky;
+        top: 0;
+        background: var(--color-surface);
+    }
+    .unmapped-list td {
+        padding: 4px 8px 4px 0;
+        color: var(--color-text);
+        vertical-align: top;
+    }
+    .unmapped-list tr:nth-child(even) td { background: rgba(255,255,255,0.03); }
+    .unmapped-list a { color: var(--color-link); font-size: 0.72rem; }
 </style>
 
 <h1>Zone Mapper</h1>
 
 <div class="mapper-toolbar">
     <select id="zone-select"><option value="">-- select zone --</option></select>
+    <button class="room-search-btn" onclick="searchRoom()" title="Go to room by ID">&#128269;</button>
     <span class="sep"></span>
     <div class="mapper-tabs">
         <button class="tab-btn active" data-tab="2d" onclick="switchTab('2d')">2D</button>
@@ -646,11 +762,18 @@
             <span class="toggle-track"></span>
             Show Bounds
         </label>
+        <label class="toggle-switch" title="Only render rooms in the selected zone">
+            <input type="checkbox" id="selected-zone-only-toggle" onchange="onSelectedZoneOnlyToggle(this.checked)">
+            <span class="toggle-track"></span>
+            Selected Zone Only
+        </label>
     </div>
     <div class="mapper-z-controls" id="z-controls">
         <span class="ctrl-sep"></span>
         <span>Z:</span>
-        <div id="z-buttons"></div>
+        <button class="z-nav-btn" id="z-prev" title="Previous Z level">&#9650;</button>
+        <select id="z-select"></select>
+        <button class="z-nav-btn" id="z-next" title="Next Z level">&#9660;</button>
     </div>
     <div class="mapper-save-controls" id="save-controls">
         <span class="sep"></span>
@@ -701,6 +824,17 @@
             <button class="btn-cancel-sm" id="zone-name-cancel">Cancel</button>
             <button class="btn-confirm" id="zone-name-confirm">Create Zone</button>
         </div>
+    </div>
+</div>
+
+<div class="unmapped-backdrop" id="unmapped-backdrop">
+    <div class="unmapped-modal">
+        <div class="unmapped-header">
+            <h3>Unmapped Rooms</h3>
+            <button class="unmapped-close" id="unmapped-close">&times;</button>
+        </div>
+        <p>These rooms have no map coordinates assigned. This may be intentional.</p>
+        <div class="unmapped-list" id="unmapped-list"></div>
     </div>
 </div>
 

--- a/_datafiles/html/admin/static/js/mapper/mapper-constants.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-constants.js
@@ -20,11 +20,11 @@ var CENTER_EASE_DURATION = 0.2;   // seconds for the smooth-scroll to a room
 var ROOM_SIZE_2D         = 28;
 var ROOM_GAP_2D          = 14;
 var BASE_STEP_2D         = ROOM_SIZE_2D + ROOM_GAP_2D;  // grid pitch in px
-var CONNECTION_WIDTH_2D  = 4;
-var ROOM_BORDER_WIDTH_2D = 1.5;
+var CONNECTION_WIDTH_2D  = 5;
+var ROOM_BORDER_WIDTH_2D = 3;
 var SYMBOL_FONT_SIZE_2D  = 14;
 var MAP_BG_2D            = '#111';
-var ROOM_BORDER_COLOR_2D = '#000000';
+var ROOM_BORDER_COLOR_2D = '#d9d9d9';
 
 var ZONE_BOX_PADDING      = 0.6;                      // extra grid cells of padding around the zone bounding box
 var ZONE_BOX_COLOR        = 'rgba(180,180,220,0.06)';  // fill for non-hovered zones
@@ -42,7 +42,7 @@ var SYMBOL_TEXT_COLOR          = '#e0e0e0';
 var DEFAULT_ROOM_COLOR        = '#3a3a4a';
 
 // Room border indicators
-var ROOM_BORDER_MOB_SPAWN     = '#cc2222';  // border color when room has a mob spawn
+var ROOM_BORDER_MOB_SPAWN     = 'rgb(255, 90, 90)';  // border color when room has a mob spawn
 var ROOM_BORDER_SCRIPT_GLOW   = '#d4a843';  // script glow border color
 var ROOM_ARROW_COLOR          = '#ff00ff';  // up/down Z-arrow color
 

--- a/_datafiles/html/admin/static/js/mapper/mapper-helpers.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-helpers.js
@@ -80,6 +80,19 @@ function contrastColor(hex) {
 // Cache mapping biome IDs to their canonical environment name
 var biomeEnvMap = {};
 
+// --- Zone Bounds Cache ---
+// computeZonePaddedBounds is O(N*zones) and is called every render frame when
+// showBounds is enabled. Cache the result and invalidate it only when rooms
+// are added, removed, or moved -- camera pan/zoom does not affect grid bounds.
+
+var _zoneBoundsCache = null;
+var _zoneBoundsCacheZ = null;
+
+function invalidateZoneBoundsCache() {
+    _zoneBoundsCache = null;
+    _zoneBoundsCacheZ = null;
+}
+
 /**
  * Maps a biome identifier to its canonical environment name. Returns the
  * biomeId itself when it already matches an environment, otherwise falls
@@ -104,6 +117,15 @@ function biomeEnvName(biomeId) {
  *   { minX, maxX, minY, maxY }  (already padded, in grid units)
  */
 function computeZonePaddedBounds(rooms, activeZ) {
+    if (_zoneBoundsCache !== null && _zoneBoundsCacheZ === activeZ) {
+        return _zoneBoundsCache;
+    }
+    _zoneBoundsCacheZ = activeZ;
+    _zoneBoundsCache = _computeZonePaddedBounds(rooms, activeZ);
+    return _zoneBoundsCache;
+}
+
+function _computeZonePaddedBounds(rooms, activeZ) {
     var maxPad = ZONE_BOX_PADDING;
 
     // Collect raw (unpadded) grid bounds per zone

--- a/_datafiles/html/admin/static/js/mapper/mapper-init.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-init.js
@@ -179,7 +179,7 @@
         var ghostChanged = (prevGhost === null) !== (MapperState.hoveredGridCell === null) ||
             (prevGhost && MapperState.hoveredGridCell &&
              (prevGhost.gx !== MapperState.hoveredGridCell.gx || prevGhost.gy !== MapperState.hoveredGridCell.gy));
-        if (ghostChanged) MapperRender.render();
+        if (ghostChanged) MapperRender.scheduleRender();
 
         // Cursor: tools with a custom cursor override the default room/empty logic
         var activeTool = MapperTools.getActive();
@@ -212,7 +212,7 @@
         if (tool && tool.name === 'select' && MapperState.selRect.active) {
             MapperState.selRect.active = false;
             canvas.style.cursor = '';
-            MapperRender.render();
+            MapperRender.scheduleRender();
         }
         if (MapperState.roomDrag.active) {
             MapperState.roomDrag.active = false;
@@ -221,7 +221,7 @@
             MapperState.roomDrag.brokenExits = [];
             MapperState.roomDrag.allConstraints = [];
             canvas.style.cursor = '';
-            MapperRender.render();
+            MapperRender.scheduleRender();
         }
         if (MapperState.camera.dragActive) {
             MapperState.camera.dragActive = false;
@@ -229,7 +229,7 @@
         }
         if (MapperState.hoveredGridCell) {
             MapperState.hoveredGridCell = null;
-            MapperRender.render();
+            MapperRender.scheduleRender();
         }
         MapperState.mouseState.mousedownRoomId = null;
     });
@@ -284,7 +284,7 @@
         var factor = Math.pow(1.25, e.deltaY * 0.002);
         var cam = MapperState.camera;
         cam.zoomScale = Math.min(5.0, Math.max(0.15, cam.zoomScale / factor));
-        MapperRender.render();
+        MapperRender.scheduleRender();
     }, { passive: false });
 
     // Close context menu when clicking outside it
@@ -323,7 +323,7 @@
             if (e.key === 'ArrowRight') cam.panOffsetX += gridStep;
             if (e.key === 'ArrowUp')    cam.panOffsetY -= gridStep;
             if (e.key === 'ArrowDown')  cam.panOffsetY += gridStep;
-            MapperRender.render();
+            MapperRender.scheduleRender();
             return;
         }
         if (e.key === 'Delete' || e.key === 'Backspace') {

--- a/_datafiles/html/admin/static/js/mapper/mapper-init.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-init.js
@@ -36,7 +36,9 @@
         canvas:            canvas,
         viewport:          viewport,
         spacingCtrlEl:     document.getElementById('spacing-controls'),
-        zButtonsEl:        document.getElementById('z-buttons'),
+        zSelectEl:         document.getElementById('z-select'),
+        zPrevBtn:          document.getElementById('z-prev'),
+        zNextBtn:          document.getElementById('z-next'),
         saveCtrlEl:        document.getElementById('save-controls'),
         toastContainerEl:  document.getElementById('mapper-toast-container'),
         changelogEl:       document.getElementById('mapper-changelog'),
@@ -67,6 +69,36 @@
     MapperRender.setCanvas(canvas);
     MapperCtxMenu.init(domRefs.ctxMenuEl);
     MapperUI.init(domRefs);
+
+    if (domRefs.zSelectEl) {
+        domRefs.zSelectEl.addEventListener('change', function() {
+            MapperState.camera.activeZ2d = parseInt(this.value, 10);
+            MapperUI.updateZButtons();
+            MapperRender.render();
+        });
+    }
+    if (domRefs.zPrevBtn) {
+        domRefs.zPrevBtn.addEventListener('click', function() {
+            var levels = MapperState.data.zLevels;
+            var idx = levels.indexOf(MapperState.camera.activeZ2d);
+            if (idx < levels.length - 1) {
+                MapperState.camera.activeZ2d = levels[idx + 1];
+                MapperUI.updateZButtons();
+                MapperRender.render();
+            }
+        });
+    }
+    if (domRefs.zNextBtn) {
+        domRefs.zNextBtn.addEventListener('click', function() {
+            var levels = MapperState.data.zLevels;
+            var idx = levels.indexOf(MapperState.camera.activeZ2d);
+            if (idx > 0) {
+                MapperState.camera.activeZ2d = levels[idx - 1];
+                MapperUI.updateZButtons();
+                MapperRender.render();
+            }
+        });
+    }
 
     MapperEvents.on('room:createAt', function(data) {
         MapperUI.createRoomAt(data.gx, data.gy, data.gz);
@@ -346,6 +378,40 @@
         }
     };
 
+    window.searchRoom = function() {
+        var input = prompt('Enter a Room ID:');
+        if (!input) return;
+        var roomId = parseInt(input, 10);
+        if (isNaN(roomId)) return;
+        var room = MapperState.data.rooms.get(roomId);
+        if (!room) { alert('Room #' + roomId + ' not found.'); return; }
+        if (!room.HasCoordinates) { alert('Room #' + roomId + ' has no map coordinates.'); return; }
+        var cam = MapperState.camera;
+        cam.cameraX = room.MapX;
+        cam.cameraY = room.MapY;
+        cam.panOffsetX = 0;
+        cam.panOffsetY = 0;
+        cam.activeZ2d = room.MapZ;
+        MapperState.selected.clear();
+        MapperState.selected.add(roomId);
+        MapperUI.updateZButtons();
+        MapperUI.updateInfoPanel();
+        MapperRender.render();
+    };
+
+    window.addEventListener('beforeunload', function() {
+        var cam = MapperState.camera;
+        localStorage.setItem('mapper.cameraState', JSON.stringify({
+            zone: MapperState.data.currentZone,
+            zoomScale: cam.zoomScale,
+            cameraX: cam.cameraX,
+            cameraY: cam.cameraY,
+            panOffsetX: cam.panOffsetX,
+            panOffsetY: cam.panOffsetY,
+            activeZ2d: cam.activeZ2d
+        }));
+    });
+
     window.onSpacingSlider = function(val) {
         var v = Math.max(0.75, parseFloat(val));
         MapperState.camera.spacingScale2d = v;
@@ -358,6 +424,12 @@
     window.onShowBoundsToggle = function(checked) {
         MapperState.camera.showBounds = checked;
         localStorage.setItem('mapper.showBounds', checked);
+        MapperRender.render();
+    };
+
+    window.onSelectedZoneOnlyToggle = function(checked) {
+        MapperState.camera.selectedZoneOnly = checked;
+        localStorage.setItem('mapper.selectedZoneOnly', checked);
         MapperRender.render();
     };
 
@@ -386,6 +458,10 @@
         var boundsToggle = document.getElementById('show-bounds-toggle');
         if (boundsToggle) boundsToggle.checked = MapperState.camera.showBounds;
 
+        // Sync selected-zone-only toggle to persisted value
+        var zoneOnlyToggle = document.getElementById('selected-zone-only-toggle');
+        if (zoneOnlyToggle) zoneOnlyToggle.checked = MapperState.camera.selectedZoneOnly;
+
         // Restore last-used zone, falling back to the first available zone
         var lastZone = localStorage.getItem('mapper.lastZone');
         if (!lastZone || !MapperState.data.allZones.some(function(z) { return z.Name === lastZone; })) {
@@ -394,6 +470,25 @@
         if (lastZone) {
             domRefs.zoneSelect.value = lastZone;
             MapperState.centerOnZone(lastZone);
+        }
+
+        var savedCam = localStorage.getItem('mapper.cameraState');
+        if (savedCam) {
+            try {
+                var cs = JSON.parse(savedCam);
+                if (cs.zone === lastZone) {
+                    var cam = MapperState.camera;
+                    if (typeof cs.zoomScale === 'number') cam.zoomScale = cs.zoomScale;
+                    if (typeof cs.cameraX === 'number') cam.cameraX = cs.cameraX;
+                    if (typeof cs.cameraY === 'number') cam.cameraY = cs.cameraY;
+                    if (typeof cs.panOffsetX === 'number') cam.panOffsetX = cs.panOffsetX;
+                    if (typeof cs.panOffsetY === 'number') cam.panOffsetY = cs.panOffsetY;
+                    if (typeof cs.activeZ2d === 'number' && MapperState.data.zLevels.indexOf(cs.activeZ2d) !== -1) {
+                        cam.activeZ2d = cs.activeZ2d;
+                        MapperUI.updateZButtons();
+                    }
+                }
+            } catch(e) { /* ignore corrupt data */ }
         }
 
         MapperRender.resizeCanvas();

--- a/_datafiles/html/admin/static/js/mapper/mapper-init.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-init.js
@@ -362,7 +362,6 @@
     //  Global handler exposure (for inline HTML onclick attributes)
     // =====================================================================
 
-    window.switchTab        = MapperUI.switchTab;
     window.zoomIn           = MapperUI.zoomIn;
     window.zoomOut          = MapperUI.zoomOut;
     window.centerCamera     = MapperUI.centerCamera;
@@ -397,6 +396,11 @@
         MapperUI.updateZButtons();
         MapperUI.updateInfoPanel();
         MapperRender.render();
+    };
+
+    window.toggleLegend = function() {
+        var el = document.getElementById('mapper-legend');
+        if (el) el.classList.toggle('visible');
     };
 
     window.addEventListener('beforeunload', function() {
@@ -443,7 +447,6 @@
         await MapperState.loadMobNames();
         await MapperState.loadAllRooms();
         MapperUI.populateZoneDropdown();
-        MapperUI.switchTab('2d');
         MapperRender.initResizeObserver();
 
         // Sync spacing slider to persisted value

--- a/_datafiles/html/admin/static/js/mapper/mapper-render.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-render.js
@@ -67,16 +67,16 @@ var MapperRender = (function() {
     function roomAtPoint2d(cx, cy) {
         var cam = MapperState.camera;
         var half = (ROOM_SIZE_2D * cam.zoomScale) / 2;
-        var found = null;
-        MapperState.data.rooms.forEach(function(room, id) {
-            if (found !== null) return;
-            if (!room.HasCoordinates || room.MapZ !== cam.activeZ2d) return;
-            var p = gridToCanvas2d(room.MapX, room.MapY);
-            if (cx >= p.px - half && cx <= p.px + half && cy >= p.py - half && cy <= p.py + half) {
-                found = id;
-            }
-        });
-        return found;
+        var g = canvasToGrid2d(cx, cy);
+        var id = MapperState.data.roomsByCoord.get(g.gx + ',' + g.gy + ',' + cam.activeZ2d);
+        if (id === undefined) return null;
+        var room = MapperState.data.rooms.get(id);
+        if (!room || !room.HasCoordinates) return null;
+        var p = gridToCanvas2d(room.MapX, room.MapY);
+        if (cx >= p.px - half && cx <= p.px + half && cy >= p.py - half && cy <= p.py + half) {
+            return id;
+        }
+        return null;
     }
 
     // --- Current Z / Grid Occupancy ---
@@ -90,6 +90,68 @@ var MapperRender = (function() {
     }
 
     // --- 2D Drawing Primitives ---
+
+    /** Draws all deferred line badges in two batched passes (secret then key),
+     *  setting canvas state once per type instead of once per badge. */
+    function drawLineBadges2d(badges) {
+        var cam = MapperState.camera;
+        var sz = Math.max(7, Math.round(CONNECTION_WIDTH_2D * cam.zoomScale * 2.5));
+        var half = sz / 2;
+
+        // Partition by type
+        var secrets = [], keys = [];
+        for (var i = 0; i < badges.length; i++) {
+            if (badges[i].type === 'secret') secrets.push(badges[i]);
+            else keys.push(badges[i]);
+        }
+
+        // --- Secret badges ---
+        if (secrets.length > 0) {
+            ctx.save();
+            ctx.font = 'bold ' + Math.round(sz * 0.85) + 'px monospace';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            for (var si = 0; si < secrets.length; si++) {
+                var s = secrets[si];
+                ctx.fillStyle = MAP_BG_2D;
+                ctx.fillRect(s.mx - half, s.my - half, sz, sz);
+                ctx.fillStyle = BADGE_SECRET_COLOR;
+                ctx.fillText('?', s.mx, s.my);
+            }
+            ctx.restore();
+        }
+
+        // --- Key (lock) badges ---
+        if (keys.length > 0) {
+            ctx.save();
+            var kc = BADGE_LOCK_COLOR;
+            var lw = Math.max(1, sz * 0.14);
+            ctx.strokeStyle = kc;
+            ctx.fillStyle = kc;
+            ctx.lineWidth = lw;
+            ctx.lineCap = 'round';
+            var bowR = sz * 0.22;
+            var bowOffX = -sz * 0.14;
+            var toothH = sz * 0.18;
+            for (var ki = 0; ki < keys.length; ki++) {
+                var k = keys[ki];
+                ctx.fillStyle = MAP_BG_2D;
+                ctx.fillRect(k.mx - half, k.my - half, sz, sz);
+                ctx.fillStyle = kc;
+                var bowCx = k.mx + bowOffX;
+                ctx.beginPath(); ctx.arc(bowCx, k.my, bowR, 0, Math.PI * 2); ctx.stroke();
+                var shaftX1 = bowCx + bowR, shaftX2 = k.mx + half * 0.82;
+                ctx.beginPath(); ctx.moveTo(shaftX1, k.my); ctx.lineTo(shaftX2, k.my); ctx.stroke();
+                var t1x = shaftX1 + (shaftX2 - shaftX1) * 0.45;
+                var t2x = shaftX1 + (shaftX2 - shaftX1) * 0.72;
+                ctx.beginPath();
+                ctx.moveTo(t1x, k.my); ctx.lineTo(t1x, k.my + toothH);
+                ctx.moveTo(t2x, k.my); ctx.lineTo(t2x, k.my + toothH);
+                ctx.stroke();
+            }
+            ctx.restore();
+        }
+    }
 
     /** Draws a small badge (secret "?" or key icon) at the midpoint of a connection line. */
     function drawLineBadge2d(mx, my, type) {
@@ -154,7 +216,8 @@ var MapperRender = (function() {
             var glowColor = ROOM_BORDER_SCRIPT_GLOW;
             ctx.save();
             ctx.shadowColor = glowColor;
-            ctx.shadowBlur = Math.max(4, scaledSize * 0.35) * cam.zoomScale;
+            //Removing shadowBlue for performance reasons
+            //ctx.shadowBlur = Math.max(4, scaledSize * 0.35) * cam.zoomScale;
             ctx.strokeStyle = glowColor;
             ctx.lineWidth = scaledBorder//Math.max(1.5, scaledBorder * 1.5);
             ctx.strokeRect(rx - offset, ry - offset, scaledSize + offset * 2, scaledSize + offset * 2);
@@ -370,15 +433,25 @@ var MapperRender = (function() {
             drawRoom2d(gridToCanvas2d(room.MapX, room.MapY), room, id);
         });
 
-        for (var bi = 0; bi < deferredBadges.length; bi++) {
-            var b = deferredBadges[bi];
-            drawLineBadge2d(b.mx, b.my, b.type);
+        if (deferredBadges.length > 0) {
+            drawLineBadges2d(deferredBadges);
         }
 
         renderToolOverlays2d();
     }
 
     // --- Render Dispatch ---
+
+    var _renderScheduled = false;
+
+    function scheduleRender() {
+        if (_renderScheduled) return;
+        _renderScheduled = true;
+        requestAnimationFrame(function() {
+            _renderScheduled = false;
+            render();
+        });
+    }
 
     function render() {
         render2d();
@@ -401,7 +474,7 @@ var MapperRender = (function() {
         if (!canvas) return;
         viewport = canvas.parentElement;
         if (!viewport) return;
-        resizeObserver = new ResizeObserver(function() { resizeCanvas(); render(); });
+        resizeObserver = new ResizeObserver(function() { resizeCanvas(); scheduleRender(); });
         resizeObserver.observe(viewport);
     }
 
@@ -410,6 +483,7 @@ var MapperRender = (function() {
         initResizeObserver: initResizeObserver,
         resizeCanvas: resizeCanvas,
         render: render,
+        scheduleRender: scheduleRender,
         getRenderState: getRenderState,
         gridToCanvas2d: gridToCanvas2d,
         canvasToGrid2d: canvasToGrid2d,

--- a/_datafiles/html/admin/static/js/mapper/mapper-render.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-render.js
@@ -150,18 +150,15 @@ var MapperRender = (function() {
         ctx.strokeRect(rx, ry, scaledSize, scaledSize);
 
         if (!isSelected && room.HasScript) {
-            var offset = scaledBorder + Math.max(1, scaledBorder);
+            var offset = scaledBorder //+ Math.max(1, scaledBorder);
             var glowColor = ROOM_BORDER_SCRIPT_GLOW;
             ctx.save();
             ctx.shadowColor = glowColor;
             ctx.shadowBlur = Math.max(4, scaledSize * 0.35) * cam.zoomScale;
             ctx.strokeStyle = glowColor;
-            ctx.lineWidth = Math.max(1.5, scaledBorder * 1.5);
+            ctx.lineWidth = scaledBorder//Math.max(1.5, scaledBorder * 1.5);
             ctx.strokeRect(rx - offset, ry - offset, scaledSize + offset * 2, scaledSize + offset * 2);
             ctx.restore();
-            ctx.strokeStyle = glowColor;
-            ctx.lineWidth = Math.max(1, scaledBorder);
-            ctx.strokeRect(rx - offset, ry - offset, scaledSize + offset * 2, scaledSize + offset * 2);
         }
 
         ctx.fillStyle = isSelected ? SELECTED_ROOM_TEXT_COLOR : (room._symbolColor || SYMBOL_TEXT_COLOR);
@@ -298,6 +295,8 @@ var MapperRender = (function() {
         var rooms = data.rooms;
         if (rooms.size === 0) { renderToolOverlays2d(); return; }
 
+        var zoneOnly = cam.selectedZoneOnly ? data.currentZone : null;
+
         // Zone bounding boxes (drawn first, behind everything)
         if (MapperState.camera.showBounds) {
             drawZoneBounds2d(rooms, cam.activeZ2d, MapperState.hoveredRoomId);
@@ -306,17 +305,20 @@ var MapperRender = (function() {
         ctx.lineCap = 'round';
         var drawnEdges = new Set();
         var abnormalEdges = [];
+        var deferredBadges = [];
 
         // Pass 1: normal directional edges
         ctx.strokeStyle = CONNECTION_COLOR;
         ctx.lineWidth = CONNECTION_WIDTH_2D * cam.zoomScale;
         rooms.forEach(function(room, id) {
             if (!room.HasCoordinates || room.MapZ !== cam.activeZ2d) return;
+            if (zoneOnly && room.Zone !== zoneOnly) return;
             if (!room.Exits) return;
             for (var dir in room.Exits) {
                 var ex = room.Exits[dir];
                 var dest = rooms.get(ex.RoomId);
                 if (!dest || !dest.HasCoordinates) continue;
+                if (zoneOnly && dest.Zone !== zoneOnly) continue;
                 var key = Math.min(id, ex.RoomId) + '-' + Math.max(id, ex.RoomId) + ':' + dir;
                 if (drawnEdges.has(key)) continue;
                 drawnEdges.add(key);
@@ -332,7 +334,7 @@ var MapperRender = (function() {
                 var pB = gridToCanvas2d(dest.MapX, dest.MapY);
                 ctx.beginPath(); ctx.moveTo(pA.px, pA.py); ctx.lineTo(pB.px, pB.py); ctx.stroke();
                 if (ex.Secret || ex.HasLock) {
-                    drawLineBadge2d((pA.px + pB.px) / 2, (pA.py + pB.py) / 2, ex.Secret ? 'secret' : 'key');
+                    deferredBadges.push({ mx: (pA.px + pB.px) / 2, my: (pA.py + pB.py) / 2, type: ex.Secret ? 'secret' : 'key' });
                 }
             }
         });
@@ -340,8 +342,8 @@ var MapperRender = (function() {
         // Pass 2: abnormal edges (yellow dotted arcs)
         if (abnormalEdges.length > 0) {
             ctx.strokeStyle = ABNORMAL_CONNECTION_COLOR;
-            ctx.lineWidth = Math.max(1, CONNECTION_WIDTH_2D * cam.zoomScale * 0.7);
-            ctx.setLineDash([Math.max(3, 8 * cam.zoomScale), Math.max(4, 10 * cam.zoomScale)]);
+            ctx.lineWidth = Math.max(1, CONNECTION_WIDTH_2D * cam.zoomScale * 0.5);
+            ctx.setLineDash([Math.max(3, 4 * cam.zoomScale), Math.max(4, 5 * cam.zoomScale)]);
             abnormalEdges.forEach(function(ae) {
                 var pA = gridToCanvas2d(ae.room.MapX, ae.room.MapY);
                 var pB = gridToCanvas2d(ae.dest.MapX, ae.dest.MapY);
@@ -363,9 +365,15 @@ var MapperRender = (function() {
 
         rooms.forEach(function(room, id) {
             if (!room.HasCoordinates || room.MapZ !== cam.activeZ2d) return;
+            if (zoneOnly && room.Zone !== zoneOnly) return;
             if (dragGroupSet.has(id)) return;
             drawRoom2d(gridToCanvas2d(room.MapX, room.MapY), room, id);
         });
+
+        for (var bi = 0; bi < deferredBadges.length; bi++) {
+            var b = deferredBadges[bi];
+            drawLineBadge2d(b.mx, b.my, b.type);
+        }
 
         renderToolOverlays2d();
     }

--- a/_datafiles/html/admin/static/js/mapper/mapper-state.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-state.js
@@ -1,5 +1,5 @@
 /* jshint esversion: 11, browser: true */
-/* globals MapperEvents, AdminAPI, symbolForRoom, colorForSymbol, contrastColor, escapeHtml, isDirectionalExit, DIRECTION_DELTAS, isExitConstraintSatisfied, buildDragConstraints, breakExitLocally, BIOME_SYMBOLS, biomeEnvMap */
+/* globals MapperEvents, AdminAPI, symbolForRoom, colorForSymbol, contrastColor, escapeHtml, isDirectionalExit, DIRECTION_DELTAS, isExitConstraintSatisfied, buildDragConstraints, breakExitLocally, BIOME_SYMBOLS, biomeEnvMap, invalidateZoneBoundsCache */
 'use strict';
 
 /**
@@ -377,6 +377,7 @@ var MapperState = (function() {
         room.HasCoordinates = true;
         mapperData.roomsByCoord.set(newGx + ',' + newGy + ',' + room.MapZ, roomId);
 
+        invalidateZoneBoundsCache();
         logChange('cl-move', '<span class="cl-action">MOVE</span> ' + roomLabel(roomId) + ' (' + oldGx + ',' + oldGy + ') &rarr; (' + newGx + ',' + newGy + ')');
         updateSaveButtons();
     }
@@ -446,6 +447,7 @@ var MapperState = (function() {
 
         mapperData.rooms.delete(roomId);
         selectedRoomIds.delete(roomId);
+        invalidateZoneBoundsCache();
         logChange('cl-delete', '<span class="cl-action">DELETE</span> ' + label);
         updateSaveButtons();
         _updateInfoPanel();
@@ -469,6 +471,7 @@ var MapperState = (function() {
 
         mapperData.rooms.set(tempId, tempRoom);
         mapperData.roomsByCoord.set(gx + ',' + gy + ',' + gz, tempId);
+        invalidateZoneBoundsCache();
 
         if (!mapperData.zLevels.includes(gz)) {
             mapperData.zLevels.push(gz);
@@ -524,6 +527,7 @@ var MapperState = (function() {
             mapperData.roomsByCoord.set(rm.room.MapX + ',' + rm.room.MapY + ',' + rm.room.MapZ, rm.id);
             logChange('cl-move', '<span class="cl-action">MOVE Z</span> ' + roomLabel(rm.id) + ' Z ' + oldZ + ' &rarr; ' + rm.room.MapZ);
         }
+        invalidateZoneBoundsCache();
         var targetZ = rooms[0].room.MapZ;
         if (!mapperData.zLevels.includes(targetZ)) {
             mapperData.zLevels.push(targetZ);
@@ -607,6 +611,7 @@ var MapperState = (function() {
         // Populate all rooms directly by coordinates — no zone filtering or offsets
         mapperData.rooms.clear();
         mapperData.roomsByCoord.clear();
+        invalidateZoneBoundsCache();
         var zSet = new Set();
         mapperData.rawRooms.forEach(function(r) {
             mapperData.rooms.set(r.RoomId, r);

--- a/_datafiles/html/admin/static/js/mapper/mapper-state.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-state.js
@@ -255,6 +255,17 @@ var MapperState = (function() {
         }, 2900);
     }
 
+    function showToast(msg) {
+        if (!dom.toastContainerEl) return;
+        var el = document.createElement('div');
+        el.className = 'mapper-toast';
+        el.textContent = msg;
+        dom.toastContainerEl.appendChild(el);
+        setTimeout(function() {
+            if (el.parentNode) el.parentNode.removeChild(el);
+        }, 2900);
+    }
+
     function updateSaveButtons() {
         var d = isDirty();
         if (dom.saveCtrlEl) dom.saveCtrlEl.classList.toggle('visible', d);
@@ -484,6 +495,44 @@ var MapperState = (function() {
         });
     }
 
+    function moveRoomsZLocally(roomIds, deltaZ) {
+        var rooms = [];
+        for (var i = 0; i < roomIds.length; i++) {
+            var room = mapperData.rooms.get(roomIds[i]);
+            if (!room || !room.HasCoordinates) continue;
+            rooms.push({ id: roomIds[i], room: room });
+        }
+        var idSet = new Set(roomIds);
+        for (var j = 0; j < rooms.length; j++) {
+            var r = rooms[j];
+            var newZ = r.room.MapZ + deltaZ;
+            var key = r.room.MapX + ',' + r.room.MapY + ',' + newZ;
+            var occupant = mapperData.roomsByCoord.get(key);
+            if (occupant !== undefined && !idSet.has(occupant)) {
+                return false;
+            }
+        }
+        for (var k = 0; k < rooms.length; k++) {
+            var rm = rooms[k];
+            var wasTracked = dirty.movedRooms.has(rm.id);
+            if (!wasTracked) {
+                dirty.movedRooms.set(rm.id, { origGx: rm.room.MapX, origGy: rm.room.MapY, origGz: rm.room.MapZ });
+            }
+            var oldZ = rm.room.MapZ;
+            mapperData.roomsByCoord.delete(rm.room.MapX + ',' + rm.room.MapY + ',' + oldZ);
+            rm.room.MapZ = oldZ + deltaZ;
+            mapperData.roomsByCoord.set(rm.room.MapX + ',' + rm.room.MapY + ',' + rm.room.MapZ, rm.id);
+            logChange('cl-move', '<span class="cl-action">MOVE Z</span> ' + roomLabel(rm.id) + ' Z ' + oldZ + ' &rarr; ' + rm.room.MapZ);
+        }
+        var targetZ = rooms[0].room.MapZ;
+        if (!mapperData.zLevels.includes(targetZ)) {
+            mapperData.zLevels.push(targetZ);
+            mapperData.zLevels.sort(function(a, b) { return a - b; });
+        }
+        updateSaveButtons();
+        return true;
+    }
+
     // --- Selection ---
 
     function selectRoom(id) {
@@ -651,6 +700,8 @@ var MapperState = (function() {
         deleteRoomLocally: deleteRoomLocally,
         createRoomLocally: createRoomLocally,
         applyGroupMove: applyGroupMove,
+        moveRoomsZLocally: moveRoomsZLocally,
+        showToast: showToast,
         selectRoom: selectRoom,
         toggleRoomSelection: toggleRoomSelection,
         loadBiomes: loadBiomes,

--- a/_datafiles/html/admin/static/js/mapper/mapper-state.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-state.js
@@ -145,9 +145,10 @@ var MapperState = (function() {
     var activeZ2d = 0;
     var spacingScale2d = (function() {
         var s = parseFloat(localStorage.getItem('mapper.spacing2d'));
-        return (isFinite(s) && s >= 0.75 && s <= 3.0) ? s : 1.0;
+        return (isFinite(s) && s >= 0.75 && s <= 3.0) ? s : 1.30;
     })();
     var showBounds = localStorage.getItem('mapper.showBounds') === 'true';
+    var selectedZoneOnly = localStorage.getItem('mapper.selectedZoneOnly') === 'true';
     var tooltipHideTimer = null;
 
     // --- Mouse State Primitives ---
@@ -207,6 +208,8 @@ var MapperState = (function() {
         set spacingScale2d(v) { spacingScale2d = v; },
         get showBounds() { return showBounds; },
         set showBounds(v) { showBounds = v; },
+        get selectedZoneOnly() { return selectedZoneOnly; },
+        set selectedZoneOnly(v) { selectedZoneOnly = v; },
         get tooltipHideTimer() { return tooltipHideTimer; },
         set tooltipHideTimer(v) { tooltipHideTimer = v; }
     };

--- a/_datafiles/html/admin/static/js/mapper/mapper-tool-exit-draw.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-tool-exit-draw.js
@@ -179,7 +179,7 @@
             edm.hoveredTargetId = (roomId !== null && roomId !== edm.sourceRoomId) ? roomId : null;
             edm._mouseCx = cx;
             edm._mouseCy = cy;
-            MapperRender.render();
+            MapperRender.scheduleRender();
         },
 
         onMouseUp: function() {},

--- a/_datafiles/html/admin/static/js/mapper/mapper-tool-pan.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-tool-pan.js
@@ -55,7 +55,7 @@
                 var step = BASE_STEP_2D * cam.zoomScale;
                 cam.panOffsetX = cam.dragStartPanX - (e.clientX - cam.dragStartPxX) / step;
                 cam.panOffsetY = cam.dragStartPanY - (e.clientY - cam.dragStartPxY) / step;
-                MapperRender.render();
+                MapperRender.scheduleRender();
                 return;
             }
         },

--- a/_datafiles/html/admin/static/js/mapper/mapper-tool-room-drag.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-tool-room-drag.js
@@ -135,7 +135,7 @@
                         rd.allConstraints = allC;
 
                         MapperTools.activate('room-drag');
-                        MapperRender.render();
+                        MapperRender.scheduleRender();
                         return;
                     }
                 }
@@ -182,7 +182,7 @@
                     rd.brokenExits = [];
                 }
             }
-            MapperRender.render();
+            MapperRender.scheduleRender();
         },
 
         onMouseUp: function(e, cx, cy) {

--- a/_datafiles/html/admin/static/js/mapper/mapper-tool-room-drag.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-tool-room-drag.js
@@ -210,8 +210,12 @@
 
             MapperEvents.emit('pan:suppressClick');
 
-            if (wasDroppable && (dGx !== 0 || dGy !== 0)) {
-                MapperState.applyGroupMove(groupCopy, dGx, dGy);
+            if (dGx !== 0 || dGy !== 0) {
+                if (wasDroppable) {
+                    MapperState.applyGroupMove(groupCopy, dGx, dGy);
+                } else {
+                    MapperState.showToast('Cannot move — room collision detected');
+                }
             }
 
             MapperTools.activate('pan');

--- a/_datafiles/html/admin/static/js/mapper/mapper-tool-select.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-tool-select.js
@@ -87,6 +87,8 @@
                 });
             }
 
+            MapperUI.updateInfoPanel();
+
             // Suppress the click that would otherwise fire on the same mouseup
             document.getElementById('mapper-canvas').dataset.suppressClick = '1';
             MapperTools.activate('pan');

--- a/_datafiles/html/admin/static/js/mapper/mapper-tool-select.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-tool-select.js
@@ -56,7 +56,7 @@
             if (!sr.active) return;
             sr.endCx = cx;
             sr.endCy = cy;
-            MapperRender.render();
+            MapperRender.scheduleRender();
         },
 
         // -----------------------------------------------------------------

--- a/_datafiles/html/admin/static/js/mapper/mapper-ui.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-ui.js
@@ -162,6 +162,26 @@ var MapperUI = (function() {
     //  Info panel (single room detail or multi-select summary)
     // =====================================================================
 
+    function moveSelectedZ(deltaZ) {
+        var ids = Array.from(MapperState.selected);
+        var ok = MapperState.moveRoomsZLocally(ids, deltaZ);
+        if (!ok) {
+            MapperState.showToast('Cannot move — room collision detected');
+            return;
+        }
+        var newZ = null;
+        for (var i = 0; i < ids.length; i++) {
+            var r = MapperState.data.rooms.get(ids[i]);
+            if (r && r.HasCoordinates) { newZ = r.MapZ; break; }
+        }
+        if (newZ !== null) {
+            MapperState.camera.activeZ2d = newZ;
+            updateZButtons();
+        }
+        updateInfoPanel();
+        MapperRender.render();
+    }
+
     function updateInfoPanel() {
         if (!dom.infoEmptyEl || !dom.infoContentEl) return;
 
@@ -186,7 +206,14 @@ var MapperUI = (function() {
                 var title = r ? escapeHtml(r.Title) : '?';
                 html += '<div class="info-exit-row"><span class="info-exit-dir">#' + rid + '</span><span class="info-exit-id">' + title + '</span></div>';
             });
+            html += '<hr class="info-divider">';
+            html += '<div style="display:flex;gap:4px;margin-top:2px">';
+            html += '<button class="info-zlevel-btn" id="info-move-down">&#9660; Move Down</button>';
+            html += '<button class="info-zlevel-btn" id="info-move-up">&#9650; Move Up</button>';
+            html += '</div>';
             dom.infoContentEl.innerHTML = html;
+            document.getElementById('info-move-up').addEventListener('click', function() { moveSelectedZ(1); });
+            document.getElementById('info-move-down').addEventListener('click', function() { moveSelectedZ(-1); });
             return;
         }
 
@@ -259,8 +286,19 @@ var MapperUI = (function() {
 
         html += '<hr class="info-divider">';
         html += '<a class="info-link" href="/admin/rooms#' + selectedRoomId + '">Edit Room &rarr;</a>';
+        if (room.HasCoordinates) {
+            html += '<hr class="info-divider">';
+            html += '<div style="display:flex;gap:4px">';
+            html += '<button class="info-zlevel-btn" id="info-move-down">&#9660; Move Down</button>';
+            html += '<button class="info-zlevel-btn" id="info-move-up">&#9650; Move Up</button>';
+            html += '</div>';
+        }
 
         dom.infoContentEl.innerHTML = html;
+        var upBtn = document.getElementById('info-move-up');
+        var downBtn = document.getElementById('info-move-down');
+        if (upBtn) upBtn.addEventListener('click', function() { moveSelectedZ(1); });
+        if (downBtn) downBtn.addEventListener('click', function() { moveSelectedZ(-1); });
     }
 
     // =====================================================================

--- a/_datafiles/html/admin/static/js/mapper/mapper-ui.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-ui.js
@@ -23,7 +23,9 @@ var MapperUI = (function() {
     var dom = {
         viewport: null,
         spacingCtrlEl: null,
-        zButtonsEl: null,
+        zSelectEl: null,
+        zPrevBtn: null,
+        zNextBtn: null,
         saveCtrlEl: null,
         dirtyCountEl: null,
         changelogEl: null,
@@ -39,7 +41,9 @@ var MapperUI = (function() {
     function init(domRefs) {
         if (domRefs.viewport) dom.viewport = domRefs.viewport;
         if (domRefs.spacingCtrlEl) dom.spacingCtrlEl = domRefs.spacingCtrlEl;
-        if (domRefs.zButtonsEl) dom.zButtonsEl = domRefs.zButtonsEl;
+        if (domRefs.zSelectEl) dom.zSelectEl = domRefs.zSelectEl;
+        if (domRefs.zPrevBtn) dom.zPrevBtn = domRefs.zPrevBtn;
+        if (domRefs.zNextBtn) dom.zNextBtn = domRefs.zNextBtn;
         if (domRefs.saveCtrlEl) dom.saveCtrlEl = domRefs.saveCtrlEl;
         if (domRefs.dirtyCountEl) dom.dirtyCountEl = domRefs.dirtyCountEl;
         if (domRefs.changelogEl) dom.changelogEl = domRefs.changelogEl;
@@ -135,35 +139,23 @@ var MapperUI = (function() {
     // =====================================================================
 
     function updateZButtons() {
-        if (!dom.zButtonsEl) return;
-        dom.zButtonsEl.innerHTML = '';
-        if (MapperState.data.zLevels.length <= 1) return;
-
+        if (!dom.zSelectEl) return;
+        var levels = MapperState.data.zLevels;
         var cam = MapperState.camera;
         var current = cam.activeZ2d;
 
-        // Reverse so the highest Z is at the top, matching spatial intuition
-        MapperState.data.zLevels.slice().reverse().forEach(function(z) {
-            var btn = document.createElement('button');
-            btn.textContent = z;
-            btn.title = 'Z level ' + z;
-            btn.style.cssText = 'width:24px;height:20px;padding:0;font-size:0.7rem;font-family:monospace;' +
-                'border:1px solid var(--color-border);border-radius:3px;cursor:pointer;';
-            if (z === current) {
-                btn.style.background = 'var(--color-primary)';
-                btn.style.color = '#fff';
-                btn.style.borderColor = 'var(--color-primary)';
-            } else {
-                btn.style.background = 'var(--color-surface-white)';
-                btn.style.color = 'var(--color-text-dim)';
-            }
-            btn.addEventListener('click', function() {
-                cam.activeZ2d = z;
-                updateZButtons();
-                MapperRender.render();
-            });
-            dom.zButtonsEl.appendChild(btn);
+        dom.zSelectEl.innerHTML = '';
+        levels.slice().reverse().forEach(function(z) {
+            var opt = document.createElement('option');
+            opt.value = z;
+            opt.textContent = z;
+            if (z === current) opt.selected = true;
+            dom.zSelectEl.appendChild(opt);
         });
+
+        var idx = levels.indexOf(current);
+        if (dom.zPrevBtn) dom.zPrevBtn.disabled = (idx < 0 || idx >= levels.length - 1);
+        if (dom.zNextBtn) dom.zNextBtn.disabled = (idx <= 0);
     }
 
     // =====================================================================
@@ -339,11 +331,69 @@ var MapperUI = (function() {
         var coordinated = 0;
         data.rooms.forEach(function(r) { if (r.HasCoordinates) coordinated++; });
         var unmapped = total - coordinated;
-        var txt = total + ' rooms';
-        if (unmapped > 0) txt += ' (' + unmapped + ' unmapped)';
-        txt += ' | ' + data.zLevels.length + ' z-level' + (data.zLevels.length !== 1 ? 's' : '');
-        txt += ' | ' + data.allZones.length + ' zones';
-        dom.statsEl.textContent = txt;
+        dom.statsEl.innerHTML = '';
+        var prefix = document.createTextNode(total + ' rooms');
+        dom.statsEl.appendChild(prefix);
+        if (unmapped > 0) {
+            var link = document.createElement('span');
+            link.className = 'unmapped-link';
+            link.textContent = ' (' + unmapped + ' unmapped)';
+            link.title = 'Click to see unmapped rooms';
+            link.addEventListener('click', showUnmappedModal);
+            dom.statsEl.appendChild(link);
+        }
+        var suffix = document.createTextNode(
+            ' | ' + data.zLevels.length + ' z-level' + (data.zLevels.length !== 1 ? 's' : '') +
+            ' | ' + data.allZones.length + ' zones'
+        );
+        dom.statsEl.appendChild(suffix);
+    }
+
+    // =====================================================================
+    //  Unmapped rooms modal
+    // =====================================================================
+
+    function showUnmappedModal() {
+        var backdrop = document.getElementById('unmapped-backdrop');
+        var listEl = document.getElementById('unmapped-list');
+        var closeBtn = document.getElementById('unmapped-close');
+        if (!backdrop || !listEl) return;
+
+        var unmapped = [];
+        MapperState.data.rooms.forEach(function(room, id) {
+            if (!room.HasCoordinates) {
+                unmapped.push({ id: id, title: room.Title || '', zone: room.Zone || '' });
+            }
+        });
+        unmapped.sort(function(a, b) {
+            if (a.zone !== b.zone) return a.zone.localeCompare(b.zone);
+            return a.id - b.id;
+        });
+
+        var html = '<table><tr><th>ID</th><th>Title</th><th>Zone</th><th></th></tr>';
+        unmapped.forEach(function(r) {
+            html += '<tr>' +
+                '<td>' + r.id + '</td>' +
+                '<td>' + escapeHtml(r.title) + '</td>' +
+                '<td>' + escapeHtml(r.zone) + '</td>' +
+                '<td><a href="/admin/rooms#' + r.id + '">edit</a></td>' +
+                '</tr>';
+        });
+        html += '</table>';
+        listEl.innerHTML = html;
+
+        backdrop.classList.add('visible');
+
+        function close() {
+            backdrop.classList.remove('visible');
+            backdrop.removeEventListener('click', onBackdropClick);
+            closeBtn.removeEventListener('click', close);
+        }
+        function onBackdropClick(e) {
+            if (e.target === backdrop) close();
+        }
+        backdrop.addEventListener('click', onBackdropClick);
+        closeBtn.addEventListener('click', close);
     }
 
     // =====================================================================

--- a/_datafiles/html/admin/static/js/mapper/mapper-ui.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-ui.js
@@ -57,20 +57,6 @@ var MapperUI = (function() {
     }
 
     // =====================================================================
-    //  Tab switching
-    // =====================================================================
-
-    function switchTab(tab) {
-        MapperState.camera.activeTab = tab;
-        document.querySelectorAll('.mapper-tabs .tab-btn').forEach(function(b) {
-            b.classList.toggle('active', b.dataset.tab === tab);
-        });
-        MapperRender.resizeCanvas();
-        updateZButtons();
-        MapperRender.render();
-    }
-
-    // =====================================================================
     //  Zoom / spacing controls
     // =====================================================================
 
@@ -745,7 +731,7 @@ var MapperUI = (function() {
 
     return {
         init: init,
-        switchTab: switchTab, zoomIn: zoomIn, zoomOut: zoomOut,
+        zoomIn: zoomIn, zoomOut: zoomOut,
         centerCamera: centerCamera, setCameraTarget: setCameraTarget,
         updateZButtons: updateZButtons, updateInfoPanel: updateInfoPanel,
         showTooltip: showTooltip, positionTooltip: positionTooltip, hideTooltip: hideTooltip,

--- a/_datafiles/world/default/rooms/catacombs/138.yaml
+++ b/_datafiles/world/default/rooms/catacombs/138.yaml
@@ -18,3 +18,7 @@ spawninfo:
   message: Bones scattered about come together to form an undead lich.
   levelmod: 8
   respawnrate: 30 real minutes
+mapx: -3
+mapy: -1
+mapz: -2
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/633.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/633.yaml
@@ -40,5 +40,5 @@ spawninfo:
   respawnrate: 2 real minutes
 mapx: 32
 mapy: -7
-mapz: 3
+mapz: 4
 hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/634.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/634.yaml
@@ -26,3 +26,7 @@ spawninfo:
   message: A small spider hatches from a nearby egg.
   maxwander: 1
   respawnrate: 2 real minutes
+mapx: 31
+mapy: -7
+mapz: 4
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/635.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/635.yaml
@@ -26,3 +26,7 @@ spawninfo:
   message: A small spider hatches from a nearby egg.
   maxwander: 1
   respawnrate: 2 real minutes
+mapx: 31
+mapy: -8
+mapz: 4
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/636.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/636.yaml
@@ -26,3 +26,7 @@ spawninfo:
   message: A small spider hatches from a nearby egg.
   maxwander: 1
   respawnrate: 2 real minutes
+mapx: 32
+mapy: -8
+mapz: 4
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/637.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/637.yaml
@@ -26,3 +26,7 @@ spawninfo:
   message: A small spider hatches from a nearby egg.
   maxwander: 1
   respawnrate: 2 real minutes
+mapx: 33
+mapy: -8
+mapz: 4
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/638.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/638.yaml
@@ -26,3 +26,7 @@ spawninfo:
   message: A small spider hatches from a nearby egg.
   maxwander: 1
   respawnrate: 2 real minutes
+mapx: 33
+mapy: -7
+mapz: 4
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/639.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/639.yaml
@@ -26,3 +26,7 @@ spawninfo:
   message: A small spider hatches from a nearby egg.
   maxwander: 1
   respawnrate: 2 real minutes
+mapx: 33
+mapy: -6
+mapz: 4
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/640.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/640.yaml
@@ -26,3 +26,7 @@ spawninfo:
   message: A small spider hatches from a nearby egg.
   maxwander: 1
   respawnrate: 2 real minutes
+mapx: 32
+mapy: -6
+mapz: 4
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/641.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/641.yaml
@@ -26,3 +26,7 @@ spawninfo:
   message: A small spider hatches from a nearby egg.
   maxwander: 1
   respawnrate: 2 real minutes
+mapx: 31
+mapy: -6
+mapz: 4
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/830.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/830.yaml
@@ -21,3 +21,7 @@ skilltraining:
   tame:
     min: 1
     max: 4
+mapx: 40
+mapy: 0
+mapz: 0
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/872.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/872.yaml
@@ -17,3 +17,7 @@ exits:
     roomid: 568
   west:
     roomid: 875
+mapx: 42
+mapy: 4
+mapz: -1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/873.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/873.yaml
@@ -17,3 +17,7 @@ exits:
     roomid: 565
   east:
     roomid: 874
+mapx: 39
+mapy: 4
+mapz: -1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/874.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/874.yaml
@@ -19,3 +19,7 @@ exits:
     roomid: 876
   west:
     roomid: 873
+mapx: 40
+mapy: 4
+mapz: -1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/875.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/875.yaml
@@ -19,3 +19,7 @@ exits:
     roomid: 877
   south:
     roomid: 876
+mapx: 41
+mapy: 4
+mapz: -1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/876.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/876.yaml
@@ -18,3 +18,7 @@ exits:
     roomid: 875
   northwest:
     roomid: 874
+mapx: 41
+mapy: 5
+mapz: -1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/877.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/877.yaml
@@ -18,3 +18,7 @@ exits:
   waterfall:
     roomid: 878
     secret: true
+mapx: 40
+mapy: 3
+mapz: -1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/dark_forest/878.yaml
+++ b/_datafiles/world/default/rooms/dark_forest/878.yaml
@@ -25,3 +25,7 @@ spawninfo:
   itemid: 25
   gold: 1
   respawnrate: 1 real day
+mapx: 40
+mapy: 2
+mapz: -1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/frost_lake/828.yaml
+++ b/_datafiles/world/default/rooms/frost_lake/828.yaml
@@ -16,3 +16,7 @@ exits:
 idlemessages:
 - A gust of wind sends a chill throgh the air.
 - A large wave crashes against the shore.
+mapx: 21
+mapy: 17
+mapz: 0
+hascoordinates: true

--- a/_datafiles/world/default/rooms/frostfang/1003.yaml
+++ b/_datafiles/world/default/rooms/frostfang/1003.yaml
@@ -14,3 +14,7 @@ exits:
     mapdirection: west
     lock:
       difficulty: 32
+mapx: 2
+mapy: -4
+mapz: 1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/frostfang/432.yaml
+++ b/_datafiles/world/default/rooms/frostfang/432.yaml
@@ -19,3 +19,7 @@ exits:
     roomid: 61
     exitmessage: You gather your belongings and head back towards the main room of
       the Inn.
+mapx: 4
+mapy: 1
+mapz: 1
+hascoordinates: true

--- a/_datafiles/world/default/rooms/stormshards/1001.yaml
+++ b/_datafiles/world/default/rooms/stormshards/1001.yaml
@@ -8,3 +8,7 @@ biome: mountains
 exits:
   road:
     roomid: 593
+mapx: 58
+mapy: -1
+mapz: 0
+hascoordinates: true


### PR DESCRIPTION
# Description

Admin mapper improvements and cleanup/fixing of stranded rooms without coordinates.

## Changes

- Fixed a lot of rooms that didnt' have solid positions. These would still work, but it's better to have a visual space for them in the editor.
- mapper remembers your position (x/y/z) when reloading from other pages
- Added a key explaining special mapper representations of information (border colors etc)
- Added a "room ID" input to jump to a specific room in the mapper.
- Rooms can be moved up/down (z-plane) one at a time or by group.
- Optimizations for render speed and hit detection
- Z-level selection cleaner, supports many z-levels better

