### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/actions/discord-webhook/action.yml
+++ b/.github/actions/discord-webhook/action.yml
@@ -33,7 +33,10 @@ runs:
         import os
 
         title = os.environ.get("PR_TITLE") or "Pull request notification"
-        description = os.environ.get("PR_BODY") or "No pull request description provided."
+        description = (
+            os.environ.get("PR_BODY") or
+            "No pull request description provided."
+        )
         url = os.environ.get("PR_URL") or ""
 
         print(json.dumps({

--- a/.github/actions/discord-webhook/action.yml
+++ b/.github/actions/discord-webhook/action.yml
@@ -17,7 +17,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: tsickert/discord-webhook@v7.0.0
+    # tsickert/discord-webhook v7.0.0
+    - uses: >-
+        tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645
       with:
         webhook-url: ${{ inputs.webhook-url }}
         embed-title: ${{ inputs.pr-title }}

--- a/.github/actions/discord-webhook/action.yml
+++ b/.github/actions/discord-webhook/action.yml
@@ -17,11 +17,45 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # tsickert/discord-webhook v7.0.0
-    - uses: >-
-        tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645
-      with:
-        webhook-url: ${{ inputs.webhook-url }}
-        embed-title: ${{ inputs.pr-title }}
-        embed-description: ${{ inputs.pr-body }}
-        embed-url: ${{ inputs.pr-url }}
+    - name: Send Discord webhook
+      shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook-url }}
+        PR_TITLE: ${{ inputs.pr-title }}
+        PR_BODY: ${{ inputs.pr-body }}
+        PR_URL: ${{ inputs.pr-url }}
+      run: |
+        set -euo pipefail
+
+        payload="$(
+          python3 - <<'PY'
+        import json
+        import os
+
+        title = os.environ.get("PR_TITLE") or "Pull request notification"
+        description = os.environ.get("PR_BODY") or "No pull request description provided."
+        url = os.environ.get("PR_URL") or ""
+
+        print(json.dumps({
+            "allowed_mentions": {
+                "parse": [],
+            },
+            "embeds": [
+                {
+                    "title": title[:256],
+                    "description": description[:4096],
+                    "url": url,
+                },
+            ],
+        }))
+        PY
+        )"
+
+        curl \
+          --fail-with-body \
+          --silent \
+          --show-error \
+          --request POST \
+          --header "Content-Type: application/json" \
+          --data "$payload" \
+          "$WEBHOOK_URL"

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -5,8 +5,7 @@ runs:
   using: "composite"
   steps:
     # actions/setup-go v6.4.0
-    - uses: >-
-        actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: go.mod
         cache: true

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,7 +4,9 @@ description: "Setup Go using go.mod"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v6.4.0
+    # actions/setup-go v6.4.0
+    - uses: >-
+        actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: go.mod
         cache: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       - "go"
     commit-message:
       prefix: "deps"
-    ignore: # ignore golang updates for now, as go 1.24 is desired
+    ignore:  # ignore golang updates for now, as go 1.24 is desired
       - dependency-name: "golang"
     groups:
       go-minor-patch:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   prep:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       binary_version: ${{ steps.meta.outputs.binary_version }}
       release_tag: ${{ steps.meta.outputs.release_tag }}
@@ -27,8 +28,7 @@ jobs:
       checksums_file: ${{ steps.meta.outputs.checksums_file }}
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -72,13 +72,13 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     needs: prep
     env:
       BINARY_VERSION: ${{ needs.prep.outputs.binary_version }}
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go
@@ -127,14 +127,14 @@ jobs:
 
       - name: Upload bin
         # actions/upload-artifact v7.0.1
-        uses: >-
-          actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: bin-artifact
           path: bin/
 
   release:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: write
     needs:
@@ -151,15 +151,13 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Download builds
         # actions/download-artifact v8.0.1
-        uses: >-
-          actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: bin-artifact
           path: bin/

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   prep:
@@ -26,7 +26,9 @@ jobs:
       datafiles_archive: ${{ steps.meta.outputs.datafiles_archive }}
       checksums_file: ${{ steps.meta.outputs.checksums_file }}
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -74,7 +76,9 @@ jobs:
     env:
       BINARY_VERSION: ${{ needs.prep.outputs.binary_version }}
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go
@@ -94,41 +98,45 @@ jobs:
       - name: Build windows amd64
         run: >-
           env GOOS=windows GOARCH=amd64 go build -v
-          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-windows_x64.exe .
 
       - name: Build darwin/arm64
         run: >-
           env GOOS=darwin GOARCH=arm64 go build -v
-          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-darwin_arm64 .
 
       - name: Build darwin/amd64
         run: >-
           env GOOS=darwin GOARCH=amd64 go build -v
-          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-darwin_x64 .
 
       - name: Build linux/amd64
         run: >-
           env GOOS=linux GOARCH=amd64 go build -v
-          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-linux_x64 .
 
       - name: Build linux/arm5
         run: >-
           env GOOS=linux GOARCH=arm GOARM=5 go build -v
-          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-linux_arm5 .
 
       - name: Upload bin
-        uses: actions/upload-artifact@v7.0.1
+        # actions/upload-artifact v7.0.1
+        uses: >-
+          actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: bin-artifact
           path: bin/
 
   release:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     needs:
       - prep
       - build
@@ -142,12 +150,16 @@ jobs:
       CHECKSUMS_FILE: ${{ needs.prep.outputs.checksums_file }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Download builds
-        uses: actions/download-artifact@v8.0.1
+        # actions/download-artifact v8.0.1
+        uses: >-
+          actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: bin-artifact
           path: bin/
@@ -155,7 +167,7 @@ jobs:
       - name: Archive datafiles
         run: >-
           zip -r
-          bin/${{ env.DATAFILES_ARCHIVE }}
+          "bin/${DATAFILES_ARCHIVE}"
           bin/_datafiles
 
       - name: Generate release checksums
@@ -167,8 +179,8 @@ jobs:
             gomud-darwin_x64 \
             gomud-linux_x64 \
             gomud-linux_arm5 \
-            "${{ env.DATAFILES_ARCHIVE }}" \
-            > "${{ env.CHECKSUMS_FILE }}"
+            "${DATAFILES_ARCHIVE}" \
+            > "${CHECKSUMS_FILE}"
 
       - name: Write release notes
         run: |

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -14,10 +14,10 @@ jobs:
   notify-discord:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: Resolve Discord webhook URL

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -15,7 +15,11 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Resolve Discord webhook URL
         id: webhook
         run: |

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   package:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -28,8 +29,7 @@ jobs:
       id-token: write
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -39,13 +39,11 @@ jobs:
 
       - name: Set up Docker Buildx
         # docker/setup-buildx-action v4.0.0
-        uses: >-
-          docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to the Container registry ${{ env.REGISTRY }}
         # docker/login-action v4.1.0
-        uses: >-
-          docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -54,8 +52,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         # docker/metadata-action v6.0.0
-        uses: >-
-          docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -68,8 +65,7 @@ jobs:
       - name: Build and push Docker image
         id: push
         # docker/build-push-action v7.1.0
-        uses: >-
-          docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -84,8 +80,7 @@ jobs:
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
         # actions/attest-build-provenance v4.1.0
-        uses: >-
-          actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Set up Docker Buildx
         # docker/setup-buildx-action v4.0.0
+        # yamllint disable-line rule:line-length
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to the Container registry ${{ env.REGISTRY }}
@@ -80,6 +81,7 @@ jobs:
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
         # actions/attest-build-provenance v4.1.0
+        # yamllint disable-line rule:line-length
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -27,7 +27,9 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -36,10 +38,14 @@ jobs:
         run: echo "version=$(make go-version)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        # docker/setup-buildx-action v4.0.0
+        uses: >-
+          docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to the Container registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v4.1.0
+        # docker/login-action v4.1.0
+        uses: >-
+          docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -47,19 +53,23 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6.0.0
+        # docker/metadata-action v6.0.0
+        uses: >-
+          docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable=${{
-              github.ref == format('refs/heads/{0}', 'master')
+              github.ref == 'refs/heads/master'
               }}
             type=ref,event=pr
             type=sha
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v7.1.0
+        # docker/build-push-action v7.1.0
+        uses: >-
+          docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -73,7 +83,9 @@ jobs:
 
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@v4.1.0
+        # actions/attest-build-provenance v4.1.0
+        uses: >-
+          actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,13 +23,13 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       js_lint: >-
         ${{ steps.filter.outputs.js_lint }}
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -60,10 +60,10 @@ jobs:
 
   go-lint:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -74,20 +74,19 @@ jobs:
 
   js-lint:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     needs: detect-changes
     if: >-
       needs.detect-changes.outputs.js_lint == 'true'
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Set up Node.js
         # actions/setup-node v6.4.0
-        uses: >-
-          actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '22'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,9 @@ jobs:
       js_lint: >-
         ${{ steps.filter.outputs.js_lint }}
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -59,7 +61,9 @@ jobs:
   go-lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -74,12 +78,16 @@ jobs:
     if: >-
       needs.detect-changes.outputs.js_lint == 'true'
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        # actions/setup-node v6.4.0
+        uses: >-
+          actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '22'
 

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -23,10 +23,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -24,7 +24,9 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go

--- a/.github/workflows/update-go-toolchain.yml
+++ b/.github/workflows/update-go-toolchain.yml
@@ -21,13 +21,17 @@ jobs:
       BASE_BRANCH: master
       PR_BRANCH: automation/update-go-toolchain
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout v6.0.2
+      - uses: >-
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Detect latest stable Go release
         id: detect
-        uses: actions/github-script@v9
+        # actions/github-script v9.0.0
+        uses: >-
+          actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const fs = require('node:fs')
@@ -79,7 +83,9 @@ jobs:
 
       - name: Set up Go
         if: steps.detect.outputs.changed == 'true'
-        uses: actions/setup-go@v6.4.0
+        # actions/setup-go v6.4.0
+        uses: >-
+          actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: ${{ steps.detect.outputs.version }}
           cache: true
@@ -101,6 +107,7 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         env:
           BRANCH_NAME: ${{ env.PR_BRANCH }}
+          GO_VERSION: ${{ steps.detect.outputs.version }}
           PUSH_URL: >-
             https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{
             github.repository }}.git
@@ -118,7 +125,7 @@ jobs:
           git switch -C "$BRANCH_NAME"
           git add go.mod go.sum
           git commit -m \
-            "deps: update Go toolchain to ${{ steps.detect.outputs.version }}"
+            "deps: update Go toolchain to ${GO_VERSION}"
           if [ -n "$remote_sha" ]; then
             git push \
               --force-with-lease="$BRANCH_NAME:$remote_sha" \
@@ -134,24 +141,27 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GO_VERSION: ${{ steps.detect.outputs.version }}
           PR_BODY_FILE: /tmp/update-go-toolchain-pr.md
           PR_TITLE: >-
             deps: update Go toolchain to ${{ steps.detect.outputs.version }}
         run: |
-          cat >"$PR_BODY_FILE" <<'EOF'
-          ## Summary
-
-          Updates the repository's pinned Go version in `go.mod` to
-          `${{ steps.detect.outputs.version }}`.
-
-          Other Go toolchain consumers derive their version from `go.mod`.
-
-          ## Validation
-
-          - `go mod tidy`
-          - `make validate`
-          - `go test -race ./...`
-          EOF
+          {
+            echo '## Summary'
+            echo
+            echo "Updates the repository's pinned Go version in \`go.mod\` to"
+            echo "\`${GO_VERSION}\`."
+            echo
+            printf '%s %s\n' \
+              'Other Go toolchain consumers derive their version from' \
+              "\`go.mod\`."
+            echo
+            echo '## Validation'
+            echo
+            echo "- \`go mod tidy\`"
+            echo "- \`make validate\`"
+            echo "- \`go test -race ./...\`"
+          } >"$PR_BODY_FILE"
 
           pr_url="$(gh pr list \
             --base "$BASE_BRANCH" \

--- a/.github/workflows/update-go-toolchain.yml
+++ b/.github/workflows/update-go-toolchain.yml
@@ -17,21 +17,20 @@ permissions:
 jobs:
   update-go-toolchain:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     env:
       BASE_BRANCH: master
       PR_BRANCH: automation/update-go-toolchain
     steps:
       # actions/checkout v6.0.2
-      - uses: >-
-          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Detect latest stable Go release
         id: detect
         # actions/github-script v9.0.0
-        uses: >-
-          actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const fs = require('node:fs')
@@ -84,8 +83,7 @@ jobs:
       - name: Set up Go
         if: steps.detect.outputs.changed == 'true'
         # actions/setup-go v6.4.0
-        uses: >-
-          actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: ${{ steps.detect.outputs.version }}
           cache: true

--- a/provisioning/copy-rpi.sh
+++ b/provisioning/copy-rpi.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 #
 # Helper script to compile/copy binary to test server on raspberry pi
 #
@@ -12,12 +13,16 @@ make build_rpi_zero2w
 
 # Kill the process before overwriting the binary
 echo "Killing process on RaspPi: ${RPI_HOST}"
-ssh ${RPI_HOST} 'sudo pkill mud-server'
+ssh "${RPI_HOST}" 'sudo pkill mud-server'
 
-# Copy the binary over, delete the local binary, run the server again using the script setup ont he server
+# Copy the binary over, delete the local binary, run the server again using the script setup on the server
 echo "Copying bin to RaspPi: ${RPI_HOST}"
-scp ./${RPI_BIN} ${RPI_HOST}:${RPI_HOST_PATH}/mud/${RPI_BIN} && \
+if ! scp "./${RPI_BIN}" "${RPI_HOST}:${RPI_HOST_PATH}/mud/${RPI_BIN}"; then
+	exit 1
+fi
 
 echo "Starting Server on RaspPi: ${RPI_HOST}"
-rm ${RPI_BIN} && \
-ssh ${RPI_HOST} -f 'cd ${RPI_HOST_PATH}; sudo ./startup-run-mud.sh'
+if ! rm "${RPI_BIN}"; then
+	exit 1
+fi
+ssh "${RPI_HOST}" -f "cd ${RPI_HOST_PATH}; sudo ./startup-run-mud.sh"


### PR DESCRIPTION
## Summary

- Hardens the GitHub Actions workflows by pinning third-party actions to commit SHAs, narrowing release permissions to the job that needs write access, and adding job timeouts.

- Replaces the Discord webhook action with a local composite action that builds the payload directly and disables Discord mentions (reason: reduce supply chain attacks by slowly removing 3rd-party GitHub Actions workflows)

- Improves shell script for `copy-rpi.sh`

## Validation

- actionlint
- yamllint .github/actions .github/workflows .github/dependabot.yml
- shellcheck provisioning/copy-rpi.sh
- shfmt -d provisioning/copy-rpi.sh