### PR TITLE
security: harden admin user mutation endpoints

### DIFF
--- a/_datafiles/html/admin/users-api.html
+++ b/_datafiles/html/admin/users-api.html
@@ -198,15 +198,16 @@
         </summary>
         <div class="api-body">
             <p>
-                Merges the supplied JSON fields into the existing <code>UserRecord</code> and
-                persists the result to disk. Only fields present in the request body are
-                applied. The <code>UserId</code> is always preserved from the URL and cannot
-                be changed.
+                Applies an allowlisted profile or character patch to the existing
+                <code>UserRecord</code> and persists the result to disk. Account identity
+                and security fields such as <code>UserId</code>, <code>Username</code>,
+                <code>Role</code>, and <code>Password</code> cannot be changed through
+                this endpoint.
             </p>
             <p>
-                To change a password use <code>SetPassword</code> via the in-game admin
-                commands; the <code>password</code> field written here is stored as-is and
-                must already be a valid bcrypt hash if you supply it.
+                To change a password use the dedicated password reset endpoint,
+                password reset tooling, or <code>SetPassword</code> via the in-game
+                admin commands.
             </p>
 
             <table class="params-table">
@@ -223,7 +224,7 @@
             <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
      <span class="flag">-X</span> PATCH \
      <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
-     <span class="flag">-d</span> <span class="str">'{"role":"admin","emailaddress":"newemail@example.com"}'</span> \
+     <span class="flag">-d</span> <span class="str">'{"EmailAddress":"newemail@example.com","Character":{"Gold":250}}'</span> \
      <span class="str">"http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/users/42"</span></div>
 
             <div class="response-examples">
@@ -235,7 +236,7 @@
   "success": true,
   "data": {
     "userid": 42,
-    "role": "admin",
+    "role": "user",
     "username": "alice",
     "emailaddress": "newemail@example.com",
     ...
@@ -253,6 +254,55 @@
                     <summary><span class="method resp-label status-err">404</span> <span class="resp-label">Not Found</span></summary>
                     <div class="resp-body">
                         <div class="curl-block">{"success":false,"error":"user not found"}</div>
+                    </div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-post">POST</span>
+            <span class="api-path">/admin/api/v1/users/{userid}/password</span>
+            <span class="api-desc">Reset a user password</span>
+        </summary>
+        <div class="api-body">
+            <p>
+                Sets a new password for the given user. The supplied plain-text password
+                is validated and stored with the same bcrypt hashing path used by user
+                creation.
+            </p>
+
+            <table class="params-table">
+                <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
+                <tbody>
+                    <tr>
+                        <td>Password <span class="required">required</span></td>
+                        <td>string</td>
+                        <td>New plain-text password. It is hashed before storage.</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> POST \
+     <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
+     <span class="flag">-d</span> <span class="str">'{"Password":"new-s3cr3t"}'</span> \
+     <span class="str">"http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/users/42/password"</span></div>
+
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body">
+                        <p>Returns the updated <code>UserRecord</code>.</p>
+                        <div class="curl-block">{"success":true,"data":{"userid":42,"username":"alice",...}}</div>
+                    </div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">Bad Request</span></summary>
+                    <div class="resp-body">
+                        <p>Returned when the body is malformed or the password fails validation.</p>
+                        <div class="curl-block">{"success":false,"error":"Password is required"}</div>
                     </div>
                 </details>
             </div>
@@ -290,11 +340,6 @@
                         <td>Plain-text password. Hashed with bcrypt before storage. Optional - account will have no password if omitted.</td>
                     </tr>
                     <tr>
-                        <td>Role</td>
-                        <td>string</td>
-                        <td>Account role (<code>user</code>, <code>admin</code>, etc.). Defaults to <code>user</code> when omitted.</td>
-                    </tr>
-                    <tr>
                         <td>EmailAddress</td>
                         <td>string</td>
                         <td>Optional email address.</td>
@@ -305,7 +350,7 @@
             <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
      <span class="flag">-X</span> POST \
      <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
-     <span class="flag">-d</span> <span class="str">'{"Username":"bob","Password":"s3cr3t","Role":"user","EmailAddress":"bob@example.com"}'</span> \
+     <span class="flag">-d</span> <span class="str">'{"Username":"bob","Password":"s3cr3t","EmailAddress":"bob@example.com"}'</span> \
      <span class="str">"http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/users"</span></div>
 
             <div class="response-examples">
@@ -329,7 +374,7 @@
                 <details class="resp-entry">
                     <summary><span class="method resp-label status-err">400</span> <span class="resp-label">Bad Request</span></summary>
                     <div class="resp-body">
-                        <p>Returned when the body is malformed, <code>Username</code> is missing, or the name fails validation.</p>
+                        <p>Returned when the body is malformed, <code>Username</code> is missing, <code>Role</code> is supplied, or the name fails validation.</p>
                         <div class="curl-block">{"success":false,"error":"Username is required"}</div>
                     </div>
                 </details>

--- a/_datafiles/html/admin/users.html
+++ b/_datafiles/html/admin/users.html
@@ -272,12 +272,12 @@
 
                 <div class="field">
                     <label>Username</label>
-                    <input type="text" id="f-username" placeholder="username" />
-                    <div class="field-hint">Changing the username does not update the login index - use with care.</div>
+                    <input type="text" id="f-username" placeholder="username" readonly />
+                    <div class="field-hint">Account identity changes are handled outside this editor.</div>
                 </div>
                 <div class="field">
                     <label>Role</label>
-                    <select id="f-role">
+                    <select id="f-role" disabled>
                         <option value="user">user</option>
                         <option value="admin">admin</option>
                         <option value="guest">guest</option>
@@ -291,7 +291,7 @@
                 <div class="field">
                     <label>New Password</label>
                     <input type="password" id="f-password" placeholder="leave blank to keep current" autocomplete="new-password" />
-                    <div class="field-hint">Will be bcrypt-hashed before saving. Leave blank to keep the existing password.</div>
+                    <div class="field-hint">Saved through the password reset endpoint. Leave blank to keep the existing password.</div>
                 </div>
 
                 <div class="field">
@@ -1172,8 +1172,6 @@
         }
 
         const payload = {
-            Username:     document.getElementById('f-username').value.trim(),
-            Role:         document.getElementById('f-role').value,
             EmailAddress: document.getElementById('f-email').value.trim(),
             Muted:        document.getElementById('f-muted').checked,
             ScreenReader: document.getElementById('f-screenreader').checked,
@@ -1216,18 +1214,25 @@
             },
         };
 
-        // Only include password if the admin typed a new one.
-        const pw = document.getElementById('f-password').value;
-        if (pw) payload.Password = pw;
-
         const res = await AdminAPI.patch('/admin/api/v1/users/' + currentUserId, payload);
 
-        btn.disabled = false; btn.textContent = 'Save User';
-
         if (!res.ok) {
+            btn.disabled = false; btn.textContent = 'Save User';
             showStatus('Save failed: ' + res.error, false);
             return;
         }
+
+        const pw = document.getElementById('f-password').value;
+        if (pw) {
+            const pwRes = await AdminAPI.post('/admin/api/v1/users/' + currentUserId + '/password', { Password: pw });
+            if (!pwRes.ok) {
+                btn.disabled = false; btn.textContent = 'Save User';
+                showStatus('User saved, but password reset failed: ' + pwRes.error, false);
+                return;
+            }
+        }
+
+        btn.disabled = false; btn.textContent = 'Save User';
 
         const saved = res.data.data;
 

--- a/internal/web/api_routes.go
+++ b/internal/web/api_routes.go
@@ -125,6 +125,9 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/api/v1/users/{userid}", RunWithMUDLocked(
 		doBasicAuth(apiV1GetUser),
 	))
+	mux.HandleFunc("POST /admin/api/v1/users/{userid}/password", RunWithMUDLocked(
+		doBasicAuth(apiV1ResetUserPassword),
+	))
 	mux.HandleFunc("PATCH /admin/api/v1/users/{userid}", RunWithMUDLocked(
 		doBasicAuth(apiV1PatchUser),
 	))

--- a/internal/web/api_v1_users.go
+++ b/internal/web/api_v1_users.go
@@ -2,10 +2,13 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
+	"github.com/GoMudEngine/GoMud/internal/characters"
 	"github.com/GoMudEngine/GoMud/internal/users"
 )
 
@@ -64,35 +67,15 @@ func apiV1PatchUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Capture the plaintext password from the request before decoding into the
-	// UserRecord, because UserRecord.Password stores a bcrypt hash and we need
-	// to call SetPassword to hash a new plaintext value.
-	var raw struct {
-		Password string `json:"Password"`
-	}
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		writeAPIError(w, http.StatusBadRequest, "failed to read request body: "+err.Error())
-		return
-	}
-	_ = json.Unmarshal(body, &raw)
+	updated := u.Clone()
 
-	updated := *u
-	if err := json.Unmarshal(body, &updated); err != nil {
+	if err := applyUserPatch(&updated, r.Body); err != nil {
 		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
 		return
 	}
 
 	// Preserve the canonical ID; callers cannot change it via PATCH.
 	updated.UserId = userId
-
-	// If a plaintext password was supplied, hash it properly.
-	if raw.Password != "" && !isBcryptHash(raw.Password) {
-		if err := updated.SetPassword(raw.Password); err != nil {
-			writeAPIError(w, http.StatusBadRequest, "invalid password: "+err.Error())
-			return
-		}
-	}
 
 	if updated.Character.Gold < 0 {
 		updated.Character.Gold = 0
@@ -116,10 +99,175 @@ func apiV1PatchUser(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// isBcryptHash returns true when s already looks like a bcrypt hash so we do
-// not double-hash a value that was round-tripped through the API.
-func isBcryptHash(s string) bool {
-	return len(s) > 4 && (s[:4] == "$2a$" || s[:4] == "$2b$")
+// POST /admin/api/v1/users/{userid}/password
+func apiV1ResetUserPassword(w http.ResponseWriter, r *http.Request) {
+	userId := resolveUserId(w, r.PathValue("userid"))
+	if userId == 0 {
+		return
+	}
+
+	u := loadUserRecord(w, userId)
+	if u == nil {
+		return
+	}
+
+	var body struct {
+		Password string `json:"Password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	if body.Password == "" {
+		writeAPIError(w, http.StatusBadRequest, "Password is required")
+		return
+	}
+
+	updated := u.Clone()
+	if err := updated.SetPassword(body.Password); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := users.SaveUser(updated); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	users.UpdateOnlineUser(updated)
+
+	writeJSON(w, http.StatusOK, APIResponse[*users.UserRecord]{
+		Success: true,
+		Data:    &updated,
+	})
+}
+
+func applyUserPatch(u *users.UserRecord, body io.Reader) error {
+	var fields map[string]json.RawMessage
+	if err := json.NewDecoder(body).Decode(&fields); err != nil {
+		return err
+	}
+
+	for key, raw := range fields {
+		switch strings.ToLower(key) {
+		case "emailaddress":
+			if err := json.Unmarshal(raw, &u.EmailAddress); err != nil {
+				return err
+			}
+		case "muted":
+			if err := json.Unmarshal(raw, &u.Muted); err != nil {
+				return err
+			}
+		case "screenreader":
+			if err := json.Unmarshal(raw, &u.ScreenReader); err != nil {
+				return err
+			}
+		case "character":
+			if err := applyCharacterPatch(u.Character, raw); err != nil {
+				return err
+			}
+		case "userid", "role", "username", "password", "joined", "macros", "aliases", "configoptions", "tipscomplete":
+			return jsonFieldError(key, "field cannot be changed through this endpoint")
+		default:
+			return jsonFieldError(key, "unsupported user patch field")
+		}
+	}
+
+	return nil
+}
+
+func applyCharacterPatch(c *characters.Character, body json.RawMessage) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return err
+	}
+
+	for key, raw := range fields {
+		switch strings.ToLower(key) {
+		case "name":
+			var name string
+			if err := json.Unmarshal(raw, &name); err != nil {
+				return err
+			}
+			c.Name = name
+		case "description":
+			if err := json.Unmarshal(raw, &c.Description); err != nil {
+				return err
+			}
+		case "raceid":
+			if err := json.Unmarshal(raw, &c.RaceId); err != nil {
+				return err
+			}
+		case "experience":
+			if err := json.Unmarshal(raw, &c.Experience); err != nil {
+				return err
+			}
+		case "roomid":
+			if err := json.Unmarshal(raw, &c.RoomId); err != nil {
+				return err
+			}
+		case "alignment":
+			if err := json.Unmarshal(raw, &c.Alignment); err != nil {
+				return err
+			}
+		case "gold":
+			if err := json.Unmarshal(raw, &c.Gold); err != nil {
+				return err
+			}
+		case "bank":
+			if err := json.Unmarshal(raw, &c.Bank); err != nil {
+				return err
+			}
+		case "trainingpoints":
+			if err := json.Unmarshal(raw, &c.TrainingPoints); err != nil {
+				return err
+			}
+		case "statpoints":
+			if err := json.Unmarshal(raw, &c.StatPoints); err != nil {
+				return err
+			}
+		case "extralives":
+			if err := json.Unmarshal(raw, &c.ExtraLives); err != nil {
+				return err
+			}
+		case "stats":
+			if err := json.Unmarshal(raw, &c.Stats); err != nil {
+				return err
+			}
+		case "skills":
+			if err := json.Unmarshal(raw, &c.Skills); err != nil {
+				return err
+			}
+		case "equipment":
+			if err := json.Unmarshal(raw, &c.Equipment); err != nil {
+				return err
+			}
+		case "items":
+			if err := json.Unmarshal(raw, &c.Items); err != nil {
+				return err
+			}
+		case "shop":
+			if err := json.Unmarshal(raw, &c.Shop); err != nil {
+				return err
+			}
+		case "spellbook":
+			if err := json.Unmarshal(raw, &c.SpellBook); err != nil {
+				return err
+			}
+		case "pet":
+			if err := json.Unmarshal(raw, &c.Pet); err != nil {
+				return err
+			}
+		default:
+			return jsonFieldError("Character."+key, "unsupported character patch field")
+		}
+	}
+
+	return nil
+}
+
+func jsonFieldError(field string, reason string) error {
+	return fmt.Errorf("%s: %s", field, reason)
 }
 
 // POST /admin/api/v1/users
@@ -127,8 +275,8 @@ func apiV1CreateUser(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Username string `json:"Username"`
 		Password string `json:"Password"`
-		Role     string `json:"Role"`
 		Email    string `json:"EmailAddress"`
+		Role     string `json:"Role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
@@ -144,6 +292,10 @@ func apiV1CreateUser(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusConflict, "username already exists")
 		return
 	}
+	if body.Role != "" {
+		writeAPIError(w, http.StatusBadRequest, "Role cannot be set through this endpoint")
+		return
+	}
 
 	u := users.NewUserRecord(0, 0)
 	if err := u.SetUsername(body.Username); err != nil {
@@ -155,9 +307,6 @@ func apiV1CreateUser(w http.ResponseWriter, r *http.Request) {
 			writeAPIError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-	}
-	if body.Role != "" {
-		u.Role = body.Role
 	}
 	if body.Email != "" {
 		u.EmailAddress = body.Email

--- a/internal/web/api_v1_users_test.go
+++ b/internal/web/api_v1_users_test.go
@@ -1,0 +1,250 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/characters"
+	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+func TestAPIV1PatchUserRejectsSensitiveFields(t *testing.T) {
+	setupAuthTestUsers(t, "correct-password", map[string]string{
+		"player": users.RoleUser,
+	})
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "user id", body: `{"UserId":2}`},
+		{name: "role", body: `{"Role":"admin"}`},
+		{name: "username", body: `{"Username":"renamed"}`},
+		{name: "password", body: `{"Password":"new-password"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPatch, "/admin/api/v1/users/1", bytes.NewBufferString(tt.body))
+			req.SetPathValue("userid", "1")
+			rec := httptest.NewRecorder()
+
+			apiV1PatchUser(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+
+			u, err := users.LoadUserById(1)
+			if err != nil {
+				t.Fatalf("LoadUserById: %v", err)
+			}
+			if u.Role != users.RoleUser {
+				t.Fatalf("Role = %q, want %q", u.Role, users.RoleUser)
+			}
+			if u.UserId != 1 {
+				t.Fatalf("UserId = %d, want 1", u.UserId)
+			}
+			if u.Username != "player" {
+				t.Fatalf("Username = %q, want player", u.Username)
+			}
+			if !u.PasswordMatches("correct-password") {
+				t.Fatal("stored password no longer matches original password")
+			}
+		})
+	}
+}
+
+func TestAPIV1PatchUserAllowsProfileAndCharacterFields(t *testing.T) {
+	setupAuthTestUsers(t, "correct-password", map[string]string{
+		"player": users.RoleUser,
+	})
+
+	req := httptest.NewRequest(http.MethodPatch, "/admin/api/v1/users/1", bytes.NewBufferString(`{
+		"EmailAddress":"player@example.com",
+		"Muted":true,
+		"ScreenReader":true,
+		"character":{"Name":"Hero","Gold":-50,"Bank":-25}
+	}`))
+	req.SetPathValue("userid", "1")
+	rec := httptest.NewRecorder()
+
+	apiV1PatchUser(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	u, err := users.LoadUserById(1)
+	if err != nil {
+		t.Fatalf("LoadUserById: %v", err)
+	}
+	if u.EmailAddress != "player@example.com" {
+		t.Fatalf("EmailAddress = %q, want player@example.com", u.EmailAddress)
+	}
+	if !u.Muted || !u.ScreenReader {
+		t.Fatalf("Muted/ScreenReader = %t/%t, want true/true", u.Muted, u.ScreenReader)
+	}
+	if u.Character.Name != "Hero" {
+		t.Fatalf("Character.Name = %q, want Hero", u.Character.Name)
+	}
+	if u.Character.Gold != 0 || u.Character.Bank != 0 {
+		t.Fatalf("Gold/Bank = %d/%d, want 0/0", u.Character.Gold, u.Character.Bank)
+	}
+}
+
+func TestUserRecordCloneDoesNotShareMutableCharacterFields(t *testing.T) {
+	original := users.NewUserRecord(1, 0)
+	original.Character = characters.New()
+	original.Character.Skills["stealth"] = 3
+	original.Character.Items = []items.Item{{
+		ItemId:     1001,
+		Adjectives: []string{"old"},
+	}}
+	original.Character.Equipment.Weapon = items.Item{
+		ItemId:     2001,
+		Adjectives: []string{"sharp"},
+	}
+	original.Character.Pet.Items = []items.Item{{
+		ItemId:     3001,
+		Adjectives: []string{"pet-old"},
+	}}
+	original.Character.SpellBook = map[string]int{"spark": 1}
+	original.Character.Shop = characters.Shop{{ItemId: 4001, Quantity: 1}}
+
+	updated := original.Clone()
+	updated.Character.Skills["stealth"] = 9
+	updated.Character.Items[0].ItemId = 1002
+	updated.Character.Items[0].Adjectives[0] = "new"
+	updated.Character.Equipment.Weapon.ItemId = 2002
+	updated.Character.Equipment.Weapon.Adjectives[0] = "dull"
+	updated.Character.Pet.Items[0].ItemId = 3002
+	updated.Character.Pet.Items[0].Adjectives[0] = "pet-new"
+	updated.Character.SpellBook["spark"] = 2
+	updated.Character.Shop[0].Quantity = 5
+
+	if original.Character.Skills["stealth"] != 3 {
+		t.Fatalf("original skill level = %d, want 3", original.Character.Skills["stealth"])
+	}
+	if original.Character.Items[0].ItemId != 1001 || original.Character.Items[0].Adjectives[0] != "old" {
+		t.Fatalf("original item = %+v, want item 1001 with old adjective", original.Character.Items[0])
+	}
+	if original.Character.Equipment.Weapon.ItemId != 2001 || original.Character.Equipment.Weapon.Adjectives[0] != "sharp" {
+		t.Fatalf("original weapon = %+v, want item 2001 with sharp adjective", original.Character.Equipment.Weapon)
+	}
+	if original.Character.Pet.Items[0].ItemId != 3001 || original.Character.Pet.Items[0].Adjectives[0] != "pet-old" {
+		t.Fatalf("original pet item = %+v, want item 3001 with pet-old adjective", original.Character.Pet.Items[0])
+	}
+	if original.Character.SpellBook["spark"] != 1 {
+		t.Fatalf("original spell level = %d, want 1", original.Character.SpellBook["spark"])
+	}
+	if original.Character.Shop[0].Quantity != 1 {
+		t.Fatalf("original shop quantity = %d, want 1", original.Character.Shop[0].Quantity)
+	}
+}
+
+func TestAPIV1CreateUserRejectsRoleAssignment(t *testing.T) {
+	setupAuthTestUsers(t, "correct-password", map[string]string{
+		"admin": users.RoleAdmin,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/users", bytes.NewBufferString(`{
+		"Username":"newadmin",
+		"Password":"correct-password",
+		"role":"admin"
+	}`))
+	rec := httptest.NewRecorder()
+
+	apiV1CreateUser(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if users.Exists("newadmin") {
+		t.Fatal("newadmin should not have been created")
+	}
+}
+
+func TestAPIV1ResetUserPasswordUpdatesStoredHash(t *testing.T) {
+	setupAuthTestUsers(t, "correct-password", map[string]string{
+		"player": users.RoleUser,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/users/1/password", bytes.NewBufferString(`{
+		"Password":"new-password"
+	}`))
+	req.SetPathValue("userid", "1")
+	rec := httptest.NewRecorder()
+
+	apiV1ResetUserPassword(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	u, err := users.LoadUserById(1)
+	if err != nil {
+		t.Fatalf("LoadUserById: %v", err)
+	}
+	if !u.PasswordMatches("new-password") {
+		t.Fatal("stored password does not match new password")
+	}
+	if u.Password == "new-password" {
+		t.Fatal("password was stored in plaintext")
+	}
+}
+
+func TestAPIV1ResetUserPasswordRequiresPassword(t *testing.T) {
+	setupAuthTestUsers(t, "correct-password", map[string]string{
+		"player": users.RoleUser,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/users/1/password", bytes.NewBufferString(`{}`))
+	req.SetPathValue("userid", "1")
+	rec := httptest.NewRecorder()
+
+	apiV1ResetUserPassword(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	u, err := users.LoadUserById(1)
+	if err != nil {
+		t.Fatalf("LoadUserById: %v", err)
+	}
+	if !u.PasswordMatches("correct-password") {
+		t.Fatal("stored password no longer matches original password")
+	}
+}
+
+func TestAPIV1CreateUserDefaultsToUserRole(t *testing.T) {
+	setupAuthTestUsers(t, "correct-password", map[string]string{
+		"admin": users.RoleAdmin,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/users", bytes.NewBufferString(`{
+		"Username":"newuser",
+		"Password":"correct-password",
+		"EmailAddress":"newuser@example.com"
+	}`))
+	rec := httptest.NewRecorder()
+
+	apiV1CreateUser(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var response APIResponse[*users.UserRecord]
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Unmarshal response: %v", err)
+	}
+	if response.Data.Role != users.RoleUser {
+		t.Fatalf("Role = %q, want %q", response.Data.Role, users.RoleUser)
+	}
+}


### PR DESCRIPTION
## Summary

This narrows the admin user mutation API so generic create and patch routes cannot mutate sensitive account-owned fields.

- PATCH accepts only explicit supported user/profile and character fields.
- Sensitive account fields such as role, username, password, joined time, macros, aliases, config options, and completed tips are rejected with clear errors.
- API-created users always start as `user`; role changes stay with dedicated admin tooling.
- Password resets use `POST /admin/api/v1/users/{userid}/password`.
- Admin Users UI and API docs are updated for the restricted behavior.
- Tests cover rejected sensitive fields, allowed profile/character updates, defensive cloning, password reset, and create-user role rejection.

## Stack

1. #568: mapper JavaScript lint cleanup
2. #569: domain clone helpers
3. This PR: admin user mutation endpoint hardening

## Compatibility

- `POST /admin/api/v1/users` still creates users, but no longer accepts `Role`.
- `PATCH /admin/api/v1/users/{userid}` no longer changes role, username, or password.
- Existing password reset flows should use `POST /admin/api/v1/users/{userid}/password`.
- Admin role changes should use existing role tooling such as `modify role`.

## Validation

Previously run before the branch split:

- `go test ./internal/web`
- `go test ./internal/web ./internal/users ./internal/characters ./internal/items ./internal/pets ./internal/buffs`
- `make validate`
- `go test ./...`
- `make js-lint`
- `make test`

Not rerun after the branch split; commits were cherry-picked into the stack.