### PR TITLE
Fast Travel Module

### DIFF
--- a/_datafiles/world/default/rooms/frostfang/1067.yaml
+++ b/_datafiles/world/default/rooms/frostfang/1067.yaml
@@ -1,0 +1,21 @@
+roomid: 1067
+zone: Frostfang
+title: Magic Academy Back Room
+description: The dusty back room of the Magic Academy is seldom visited, its air thick
+  with the quiet weight of forgotten knowledge and the faint scent of old parchment.
+  Shelves sag beneath the burden of neglected tomes and curious relics, their secrets
+  long undisturbed. At the heart of the chamber, a glowing dais hums with a steady,
+  almost breathing rhythm, its light spilling softly across the worn stone floor in
+  rippling patterns. Arcane sigils flicker and coil along its surface like living
+  things, whispering of distant places and unseen pathways. The very air around it
+  shimmers, charged with restrained energy.
+biome: city
+exits:
+  southeast:
+    roomid: 879
+tags:
+- fast travel
+mapx: -3
+mapy: -6
+mapz: 0
+hascoordinates: true

--- a/_datafiles/world/default/rooms/frostfang/879.yaml
+++ b/_datafiles/world/default/rooms/frostfang/879.yaml
@@ -13,14 +13,12 @@ maplegend: Trainer
 exits:
   east:
     roomid: 5
+  northwest:
+    roomid: 1067
 spawninfo:
 - mobid: 50
   message: A mage enters the room.
   respawnrate: 2 real minutes
-skilltraining:
-  cast:
-    min: 1
-    max: 4
 mapx: -1
 mapy: -4
 mapz: 0

--- a/_datafiles/world/default/rooms/mystarion/844.yaml
+++ b/_datafiles/world/default/rooms/mystarion/844.yaml
@@ -10,9 +10,12 @@ description: At the very end of Bloodroot Way, the shadows converge, and the air
   Shelves are lined with ancient, leather-bound tomes etched with glowing runes, alongside
   vials of mysterious, shimmering elixirs. Enchanted relics float in eerie stillness,
   their soft glow casting an otherworldly light.
+biome: city
 exits:
   south:
     roomid: 843
+tags:
+- fast travel
 mapx: 71
 mapy: -4
 mapz: 0

--- a/internal/mapper/mapper_test.go
+++ b/internal/mapper/mapper_test.go
@@ -52,13 +52,13 @@ func TestArrowForDelta(t *testing.T) {
 		dx, dy, dz int
 		want       rune
 	}{
-		{0, -1, 0, '\u2502'}, // north: vertical bar
-		{0, 1, 0, '\u2502'},  // south: vertical bar
-		{-1, 0, 0, '\u2500'}, // west: horizontal bar
-		{1, 0, 0, '\u2500'},  // east: horizontal bar
-		{1, -1, 0, '\u2571'}, // northeast: slash
-		{-1, 1, 0, '\u2571'}, // southwest: slash
-		{1, 1, 0, '\u2572'},  // southeast: backslash
+		{0, -1, 0, '\u2502'},  // north: vertical bar
+		{0, 1, 0, '\u2502'},   // south: vertical bar
+		{-1, 0, 0, '\u2500'},  // west: horizontal bar
+		{1, 0, 0, '\u2500'},   // east: horizontal bar
+		{1, -1, 0, '\u2571'},  // northeast: slash
+		{-1, 1, 0, '\u2571'},  // southwest: slash
+		{1, 1, 0, '\u2572'},   // southeast: backslash
 		{-1, -1, 0, '\u2572'}, // northwest: backslash
 		{0, 0, 1, '^'},        // up
 		{0, 0, -1, 'v'},       // down

--- a/modules/all-modules.go
+++ b/modules/all-modules.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/GoMudEngine/GoMud/modules/auctions"
 	_ "github.com/GoMudEngine/GoMud/modules/cleanup"
 	_ "github.com/GoMudEngine/GoMud/modules/clibridge"
+	_ "github.com/GoMudEngine/GoMud/modules/fasttravel"
 	_ "github.com/GoMudEngine/GoMud/modules/follow"
 	_ "github.com/GoMudEngine/GoMud/modules/gambling"
 	_ "github.com/GoMudEngine/GoMud/modules/gmcp"

--- a/modules/fasttravel/fasttravel.go
+++ b/modules/fasttravel/fasttravel.go
@@ -1,0 +1,290 @@
+package fasttravel
+
+import (
+	"embed"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/term"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+var (
+	//go:embed files/*
+	files embed.FS
+)
+
+const (
+	fastTravelTag = "fast travel"
+	dataKeyFmt    = "fasttravel-user-%d"
+)
+
+func init() {
+	m := &FastTravelModule{
+		plug:    plugins.New(`fasttravel`, `1.0`),
+		players: make(map[int]FastTravelData),
+	}
+
+	if err := m.plug.AttachFileSystem(files); err != nil {
+		panic(err)
+	}
+
+	m.plug.AddUserCommand(`fasttravel`, m.fastTravelCommand, false, false)
+
+	m.plug.Web.AdminPage("Config", "fasttravel-config", "html/admin/fasttravel-config.html", true, "Modules", "Fast Travel", nil)
+
+	m.plug.ReserveTags(fastTravelTag)
+
+	m.plug.Callbacks.SetOnSave(m.onSave)
+
+	events.RegisterListener(events.PlayerSpawn{}, m.onPlayerSpawn)
+	events.RegisterListener(events.PlayerDespawn{}, m.onPlayerDespawn)
+
+	rooms.OnRoomLook.Register(m.onRoomLook)
+}
+
+// FastTravelData holds the unlocked fast travel room IDs for a single user.
+type FastTravelData struct {
+	UnlockedRoomIds []int `yaml:"unlockedroomids,omitempty"`
+}
+
+// FastTravelModule owns all fast travel state.
+type FastTravelModule struct {
+	plug    *plugins.Plugin
+	players map[int]FastTravelData // keyed by userId; loaded on PlayerSpawn
+}
+
+func dataKey(userId int) string {
+	return fmt.Sprintf(dataKeyFmt, userId)
+}
+
+func (m *FastTravelModule) load(userId int) FastTravelData {
+	var data FastTravelData
+	m.plug.ReadIntoStruct(dataKey(userId), &data)
+	return data
+}
+
+func (m *FastTravelModule) save(userId int, data FastTravelData) {
+	m.plug.WriteStruct(dataKey(userId), data)
+}
+
+func (m *FastTravelModule) onSave() {
+	for userId, data := range m.players {
+		m.save(userId, data)
+	}
+}
+
+func (m *FastTravelModule) onPlayerSpawn(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerSpawn)
+	if !ok {
+		return events.Continue
+	}
+	m.players[evt.UserId] = m.load(evt.UserId)
+	return events.Continue
+}
+
+func (m *FastTravelModule) onPlayerDespawn(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerDespawn)
+	if !ok {
+		return events.Continue
+	}
+	if data, exists := m.players[evt.UserId]; exists {
+		m.save(evt.UserId, data)
+		delete(m.players, evt.UserId)
+	}
+	return events.Continue
+}
+
+// onRoomLook injects a fast travel alert when the room has the fast travel tag.
+func (m *FastTravelModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
+	for _, t := range d.Tags {
+		if strings.EqualFold(t, fastTravelTag) {
+			d.RoomAlerts = append(d.RoomAlerts,
+				` <ansi fg="yellow-bold">This is a fast travel station!</ansi> <ansi fg="command">fasttravel</ansi> lists destinations.`,
+			)
+			return d
+		}
+	}
+	return d
+}
+
+// roomIsFastTravel returns true if the room has the fast travel tag.
+func roomIsFastTravel(room *rooms.Room) bool {
+	return room.HasTag(fastTravelTag)
+}
+
+// hasUnlocked returns true if the user has unlocked the given room.
+func (m *FastTravelModule) hasUnlocked(userId, roomId int) bool {
+	data := m.players[userId]
+	for _, id := range data.UnlockedRoomIds {
+		if id == roomId {
+			return true
+		}
+	}
+	return false
+}
+
+// unlock adds the roomId to the user's unlocked list if not already present.
+// Returns true if the room was newly unlocked, false if it was already known.
+func (m *FastTravelModule) unlock(userId, roomId int) bool {
+	if m.hasUnlocked(userId, roomId) {
+		return false
+	}
+	data := m.players[userId]
+	data.UnlockedRoomIds = append(data.UnlockedRoomIds, roomId)
+	m.players[userId] = data
+	return true
+}
+
+// travelCost reads the configured gold cost and required item ID from the module config.
+// A cost of 0 means no gold is required. An itemId of 0 means no item is required.
+func (m *FastTravelModule) travelCost() (goldCost int, itemId int) {
+	if v, ok := m.plug.Config.Get(`GoldCost`).(int); ok && v > 0 {
+		goldCost = v
+	}
+	if v, ok := m.plug.Config.Get(`RequiredItemId`).(int); ok && v > 0 {
+		itemId = v
+	}
+	return goldCost, itemId
+}
+
+// destEntry holds a resolved fast travel destination for display and matching.
+type destEntry struct {
+	roomId int
+	title  string
+}
+
+func (m *FastTravelModule) fastTravelCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	if !roomIsFastTravel(room) {
+		user.SendText(`You must be at a fast travel station to use fast travel.` + term.CRLFStr)
+		return true, nil
+	}
+
+	// Always unlock the current room when the player uses the command here.
+	if m.unlock(user.UserId, room.RoomId) {
+		user.SendText(`<ansi fg="yellow-bold">You have discovered a new fast travel station: </ansi><ansi fg="room-title">` + room.Title + `</ansi><ansi fg="yellow-bold">!</ansi>` + term.CRLFStr)
+	}
+
+	// Build the list of unlocked destinations, excluding the current room.
+	data := m.players[user.UserId]
+	destinations := make([]destEntry, 0, len(data.UnlockedRoomIds))
+	for _, id := range data.UnlockedRoomIds {
+		if id == room.RoomId {
+			continue
+		}
+		r := rooms.LoadRoom(id)
+		if r == nil {
+			continue
+		}
+		destinations = append(destinations, destEntry{roomId: id, title: r.Title})
+	}
+	sort.Slice(destinations, func(i, j int) bool {
+		return destinations[i].title < destinations[j].title
+	})
+
+	// List mode.
+	if rest == `` {
+		if len(destinations) == 0 {
+			user.SendText(`<ansi fg="yellow">You have not discovered any other fast travel stations yet.</ansi>` + term.CRLFStr)
+			return true, nil
+		}
+
+		var sb strings.Builder
+		sb.WriteString(`<ansi fg="yellow-bold">Fast Travel Destinations:</ansi>` + "\n")
+		for i, dest := range destinations {
+			sb.WriteString(fmt.Sprintf(`  <ansi fg="cyan">%d)</ansi> <ansi fg="room-title">%s</ansi>`+"\n", i+1, dest.title))
+		}
+		user.SendText(sb.String())
+		return true, nil
+	}
+
+	// Travel mode: match the argument against destination titles.
+	titles := make([]string, len(destinations))
+	for i, dest := range destinations {
+		titles[i] = dest.title
+	}
+
+	closeMatch, exactMatch := util.FindMatchIn(rest, titles...)
+
+	matchTitle := exactMatch
+	if matchTitle == `` {
+		matchTitle = closeMatch
+	}
+	if matchTitle == `` {
+		user.SendText(fmt.Sprintf(`No fast travel destination matching "<ansi fg="cyan">%s</ansi>" found.`+term.CRLFStr, rest))
+		return true, nil
+	}
+
+	var destRoomId int
+	for _, dest := range destinations {
+		if strings.EqualFold(dest.title, matchTitle) {
+			destRoomId = dest.roomId
+			break
+		}
+	}
+	if destRoomId == 0 {
+		user.SendText(fmt.Sprintf(`No fast travel destination matching "<ansi fg="cyan">%s</ansi>" found.`+term.CRLFStr, rest))
+		return true, nil
+	}
+
+	destRoom := rooms.LoadRoom(destRoomId)
+	if destRoom == nil {
+		user.SendText(`That fast travel destination is no longer available.` + term.CRLFStr)
+		return true, nil
+	}
+
+	// Enforce travel cost before moving.
+	goldCost, requiredItemId := m.travelCost()
+
+	if goldCost > 0 {
+		if user.Character.Gold < goldCost {
+			user.SendText(fmt.Sprintf(`You need at least <ansi fg="gold">%d gold</ansi> to use the fast travel network.`+term.CRLFStr, goldCost))
+			return true, nil
+		}
+	}
+
+	var requiredItem items.Item
+	if requiredItemId > 0 {
+		itm, found := user.Character.FindInBackpack(fmt.Sprintf(`!%d`, requiredItemId))
+		if !found {
+			iSpec := items.GetItemSpec(requiredItemId)
+			itemName := fmt.Sprintf(`item #%d`, requiredItemId)
+			if iSpec != nil {
+				itemName = iSpec.Name
+			}
+			user.SendText(fmt.Sprintf(`You need a <ansi fg="itemname">%s</ansi> to use the fast travel network.`+term.CRLFStr, itemName))
+			return true, nil
+		}
+		requiredItem = itm
+	}
+
+	// Deduct gold cost.
+	if goldCost > 0 {
+		user.Character.Gold -= goldCost
+		events.AddToQueue(events.EquipmentChange{
+			UserId:     user.UserId,
+			GoldChange: -goldCost,
+		})
+	}
+
+	// Consume required item.
+	if requiredItem.ItemId > 0 {
+		user.Character.RemoveItem(requiredItem)
+		events.AddToQueue(events.ItemOwnership{
+			UserId: user.UserId,
+			Item:   requiredItem,
+			Gained: false,
+		})
+	}
+
+	user.SendText(fmt.Sprintf(`You step through the fast travel network and arrive at <ansi fg="room-title">%s</ansi>.`+term.CRLFStr, destRoom.Title))
+	rooms.MoveToRoom(user.UserId, destRoomId)
+
+	return true, nil
+}

--- a/modules/fasttravel/files/data-overlays/config.yaml
+++ b/modules/fasttravel/files/data-overlays/config.yaml
@@ -1,0 +1,15 @@
+################################################################################
+# If modified, these settings will be copied into your config overrides
+# folder under `Modules.fasttravel`:
+#
+# Modules:
+#   fasttravel:
+#     GoldCost: 0
+#     RequiredItemId: 0
+################################################################################
+# - GoldCost -
+#   Gold required each time a player uses fast travel. Set to 0 to disable.
+GoldCost: 0
+# - RequiredItemId -
+#   Item ID that is consumed each time a player uses fast travel. Set to 0 to disable.
+RequiredItemId: 0

--- a/modules/fasttravel/files/data-overlays/keywords.yaml
+++ b/modules/fasttravel/files/data-overlays/keywords.yaml
@@ -1,0 +1,6 @@
+help:
+  command:
+    travel:
+      - fasttravel
+command-aliases:
+  'fasttravel': ['ft']

--- a/modules/fasttravel/files/datafiles/html/admin/fasttravel-config.html
+++ b/modules/fasttravel/files/datafiles/html/admin/fasttravel-config.html
@@ -1,0 +1,238 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .btn { padding: 0.4rem 1rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+    .btn-primary { background: var(--color-primary); color: var(--color-surface-white); }
+    .btn-primary:hover { background: var(--color-primary-hover); }
+    .btn-primary:disabled { background: var(--color-text-secondary); cursor: default; }
+
+    #status-bar { display: none; padding: 0.6rem 1rem; border-radius: 4px; font-size: 0.875rem; margin-bottom: 1rem; }
+    #status-bar.success { background: var(--color-success-bg); color: var(--color-success-text); display: block; }
+    #status-bar.error   { background: var(--color-error-bg); color: var(--color-error-text); display: block; }
+
+    .config-table-wrap { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+    col.col-key   { width: 38%; }
+    col.col-value { width: 62%; }
+    thead th { background: var(--color-border-faint); text-align: left; padding: 0.6rem 0.9rem; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-text-muted); border-bottom: 1px solid var(--color-border); }
+    tbody tr { border-bottom: 1px solid var(--color-border-light); }
+    tbody tr:last-child { border-bottom: none; }
+    tbody tr:hover { background: var(--color-surface-alt); }
+    td { padding: 0.55rem 0.9rem; font-size: 0.875rem; vertical-align: middle; overflow: hidden; }
+    td.key-cell { font-family: monospace; font-size: 0.82rem; color: var(--color-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    td.value-cell { max-width: 0; overflow: hidden; }
+
+    .value-display { cursor: pointer; display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .value-display:hover { text-decoration: underline dotted var(--color-text-faint); }
+    .edit-form { display: none; align-items: center; gap: 0.4rem; width: 100%; }
+    .edit-form.active { display: flex; }
+    .edit-form input[type="text"] { flex: 1; padding: 0.3rem 0.5rem; border: 1px solid var(--color-text-placeholder); border-radius: 3px; font-size: 0.875rem; font-family: inherit; }
+    .btn-save { padding: 0.25rem 0.6rem; font-size: 0.8rem; border-radius: 3px; border: none; cursor: pointer; background: var(--color-btn-save-bg); color: var(--color-surface-white); }
+    .btn-save:hover { background: var(--color-btn-new-hover); }
+    .btn-cancel { padding: 0.25rem 0.6rem; font-size: 0.8rem; border-radius: 3px; border: none; cursor: pointer; background: var(--color-border-medium); color: var(--color-text-strong); }
+    .btn-cancel:hover { background: var(--color-btn-cancel-hover); }
+
+    #pending-panel { display: none; background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1rem; margin-bottom: 1.25rem; }
+    #pending-panel h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+    #pending-list { display: flex; flex-direction: column; gap: 0.4rem; margin-bottom: 0.75rem; }
+    .pending-item { display: flex; align-items: baseline; gap: 0.5rem; font-size: 0.875rem; background: var(--color-surface-alt); border: 1px solid var(--color-border-light); border-radius: 4px; padding: 0.35rem 0.65rem; }
+    .pending-key { font-family: monospace; font-size: 0.82rem; color: var(--color-primary); flex: 1; }
+    .pending-arrow { color: var(--color-text-faint); }
+    .pending-val { color: var(--color-success-text); font-weight: 600; }
+    .pending-remove { background: none; border: none; cursor: pointer; color: var(--color-text-faint); font-size: 1rem; line-height: 1; padding: 0 0.2rem; }
+    .pending-remove:hover { color: var(--color-danger); }
+    .pending-actions { display: flex; gap: 0.5rem; }
+    .btn-discard { background: var(--color-border-light); color: var(--color-text-strong); }
+    .btn-discard:hover { background: var(--color-border); }
+
+    .no-keys { padding: 2rem; text-align: center; color: var(--color-text-faint); font-size: 0.9rem; }
+    tr.desc-row td { padding: 0.1rem 0.9rem 0.5rem; font-size: 0.78rem; color: var(--color-text-faint); font-style: italic; border-bottom: 1px solid var(--color-border-light); }
+</style>
+<h1>fasttravel - Module Config</h1>
+<p class="subtitle">Configuration keys for the <strong>fasttravel</strong> module. Click any value to edit it inline. Changes are staged until you apply them.</p>
+
+<div id="status-bar"></div>
+
+<div id="pending-panel">
+    <h3>Pending Changes</h3>
+    <div id="pending-list"></div>
+    <div class="pending-actions">
+        <button class="btn btn-primary" id="apply-btn" onclick="applyChanges()">Apply Changes</button>
+        <button class="btn btn-discard" onclick="discardAll()">Discard All</button>
+    </div>
+</div>
+
+<div class="config-table-wrap">
+    <table>
+        <colgroup><col class="col-key" /><col class="col-value" /></colgroup>
+        <thead><tr><th>Key</th><th>Value</th></tr></thead>
+        <tbody id="config-body">
+            <tr><td colspan="2" style="padding:1.5rem;text-align:center;color:var(--color-text-faint);">Loading...</td></tr>
+        </tbody>
+    </table>
+</div>
+
+<script>
+(function () {
+    'use strict';
+    const MODULE = 'fasttravel';
+    const PREFIX = 'Modules.' + MODULE + '.';
+    const DESCRIPTIONS = {
+        'GoldCost': 'Gold required each time a player uses fast travel. Set to 0 to disable.',
+        'RequiredItemId': 'Item ID that is consumed each time a player uses fast travel. Set to 0 to disable.',
+    };
+    const pending = {};
+    let configData = {};
+
+    async function init() {
+        const res = await AdminAPI.get('/admin/api/v1/config');
+        if (!res.ok) { showStatus('Failed to load configuration: ' + res.error, false); return; }
+        const all = res.data.data || {};
+        for (const [fullKey, val] of Object.entries(all)) {
+            if (fullKey.startsWith(PREFIX)) {
+                configData[fullKey.slice(PREFIX.length)] = String(val);
+            }
+        }
+        buildTable();
+    }
+
+    function buildTable() {
+        const tbody = document.getElementById('config-body');
+        tbody.innerHTML = '';
+        const keys = Object.keys(configData).sort();
+        if (keys.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="2" class="no-keys">No configuration keys found for this module.</td></tr>';
+            return;
+        }
+        for (const key of keys) {
+            const value = configData[key];
+            const tr = document.createElement('tr');
+            tr.dataset.key = key;
+            tr.innerHTML =
+                '<td class="key-cell" title="' + escAttr(PREFIX + key) + '">' + escHtml(key) + '</td>' +
+                '<td class="value-cell">' +
+                    '<span class="value-display" title="' + escAttr(value) + '" onclick="startEdit(\'' + escAttr(key) + '\')">' + escHtml(value) + '</span>' +
+                    '<span class="edit-form" id="edit-' + cssId(key) + '">' +
+                        '<input type="text" id="input-' + cssId(key) + '" value="' + escAttr(value) + '" onkeydown="editKeydown(event, \'' + escAttr(key) + '\')" />' +
+                        '<button class="btn-save" onclick="stageEdit(\'' + escAttr(key) + '\')">Stage</button>' +
+                        '<button class="btn-cancel" onclick="cancelEdit(\'' + escAttr(key) + '\')">Cancel</button>' +
+                    '</span>' +
+                '</td>';
+            tbody.appendChild(tr);
+            if (DESCRIPTIONS[key]) {
+                const dr = document.createElement('tr');
+                dr.className = 'desc-row';
+                dr.dataset.descFor = key;
+                dr.innerHTML = '<td colspan="2">' + escHtml(DESCRIPTIONS[key]) + '</td>';
+                tbody.appendChild(dr);
+            }
+        }
+    }
+
+    window.startEdit = function (key) {
+        cancelAllEdits();
+        const form = document.getElementById('edit-' + cssId(key));
+        const display = form.previousElementSibling;
+        display.style.display = 'none';
+        form.classList.add('active');
+        const input = document.getElementById('input-' + cssId(key));
+        if (pending[key] !== undefined) input.value = pending[key];
+        input.focus(); input.select();
+    };
+
+    window.cancelEdit = function (key) {
+        const form = document.getElementById('edit-' + cssId(key));
+        if (!form) return;
+        form.classList.remove('active');
+        form.previousElementSibling.style.display = '';
+    };
+
+    window.editKeydown = function (e, key) {
+        if (e.key === 'Enter')  stageEdit(key);
+        if (e.key === 'Escape') cancelEdit(key);
+    };
+
+    window.stageEdit = function (key) {
+        const input = document.getElementById('input-' + cssId(key));
+        const newVal = input.value;
+        cancelEdit(key);
+        if (newVal === configData[key] && pending[key] === undefined) return;
+        if (newVal === configData[key]) { delete pending[key]; }
+        else { pending[key] = newVal; }
+        const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]');
+        if (tr) { tr.querySelector('.value-display').textContent = newVal; tr.style.background = pending[key] !== undefined ? '#fffbe6' : ''; }
+        renderPendingPanel();
+    };
+
+    function cancelAllEdits() {
+        document.querySelectorAll('.edit-form.active').forEach(f => { f.classList.remove('active'); f.previousElementSibling.style.display = ''; });
+    }
+
+    function renderPendingPanel() {
+        const panel = document.getElementById('pending-panel');
+        const list  = document.getElementById('pending-list');
+        const keys  = Object.keys(pending);
+        if (keys.length === 0) { panel.style.display = 'none'; return; }
+        panel.style.display = 'block';
+        list.innerHTML = '';
+        for (const key of keys.sort()) {
+            const item = document.createElement('div');
+            item.className = 'pending-item';
+            item.innerHTML = '<span class="pending-key">' + escHtml(key) + '</span><span class="pending-arrow">&rarr;</span><span class="pending-val">' + escHtml(pending[key]) + '</span><button class="pending-remove" onclick="removePending(\'' + escAttr(key) + '\')">\u00d7</button>';
+            list.appendChild(item);
+        }
+    }
+
+    window.removePending = function (key) {
+        delete pending[key];
+        const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]');
+        if (tr) { tr.querySelector('.value-display').textContent = configData[key]; tr.style.background = ''; }
+        renderPendingPanel();
+    };
+
+    window.discardAll = function () {
+        for (const key of Object.keys(pending)) {
+            const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]');
+            if (tr) { tr.querySelector('.value-display').textContent = configData[key]; tr.style.background = ''; }
+            delete pending[key];
+        }
+        renderPendingPanel();
+    };
+
+    window.applyChanges = async function () {
+        if (Object.keys(pending).length === 0) return;
+        const btn = document.getElementById('apply-btn');
+        btn.disabled = true; btn.textContent = 'Applying...';
+        const payload = {};
+        for (const [key, val] of Object.entries(pending)) { payload[PREFIX + key] = val; }
+        const res = await AdminAPI.patch('/admin/api/v1/config', payload);
+        btn.disabled = false; btn.textContent = 'Apply Changes';
+        if (!res.ok) { showStatus('Error: ' + res.error, false); return; }
+        const result = res.data.data || {};
+        const applied  = (result.applied  || []).map(k => k.startsWith(PREFIX) ? k.slice(PREFIX.length) : k);
+        const rejected = (result.rejected || []).map(k => k.startsWith(PREFIX) ? k.slice(PREFIX.length) : k);
+        for (const key of applied) { configData[key] = pending[key]; delete pending[key]; const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]'); if (tr) tr.style.background = ''; }
+        let msg = '';
+        if (applied.length)  msg += 'Applied: ' + applied.join(', ') + '. ';
+        if (rejected.length) msg += 'Rejected (locked): ' + rejected.join(', ') + '.';
+        showStatus(msg || 'No changes applied.', rejected.length === 0);
+        renderPendingPanel();
+    };
+
+    function showStatus(msg, success) {
+        const bar = document.getElementById('status-bar');
+        bar.textContent = msg; bar.className = success ? 'success' : 'error';
+        clearTimeout(bar._t); bar._t = setTimeout(() => { bar.className = ''; bar.style.display = 'none'; }, 6000);
+    }
+    function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+    function escAttr(s) { return String(s).replace(/'/g, "\\'").replace(/"/g, '&quot;'); }
+    function cssId(key) { return key.replace(/[^a-zA-Z0-9_-]/g, '_'); }
+
+    init();
+})();
+</script>
+
+{{template "footer" .}}

--- a/modules/fasttravel/files/datafiles/templates/help/fasttravel.template
+++ b/modules/fasttravel/files/datafiles/templates/help/fasttravel.template
@@ -1,0 +1,13 @@
+<ansi fg="yellow-bold">Fast Travel</ansi>
+
+Fast travel stations are special locations scattered across the world.
+When you visit a fast travel station, it becomes permanently unlocked for you.
+From any fast travel station, you can instantly travel to any other station
+you have previously visited.
+
+<ansi fg="white-bold">Usage:</ansi>
+  <ansi fg="command">fasttravel</ansi>               - List available destinations
+  <ansi fg="command">fasttravel</ansi> <ansi fg="cyan"><destination></ansi>  - Travel to a destination (partial name match)
+  <ansi fg="command">ft</ansi>                       - Alias for fasttravel
+
+Travel may require gold or a specific item per use, depending on server configuration.


### PR DESCRIPTION
# Description 

Adds a new fasttravel module that allows players to instantly travel between discovered fast travel stations. Rooms tagged with fast travel become stations; visiting a station unlocks it permanently for that player, making it available as a destination from any other station they visit. Travel can optionally require a gold cost or a consumable item per use, configured by the server operator.

## Changes

- Added `modules/fasttravel/fasttravel.go` - core module implementing the fasttravel command, per-user unlocked station persistence, and a room look alert for fast travel stations 
- Added `modules/fasttravel/files/data-overlays/keywords.yaml` - registers `ft` as a command alias for `fasttravel` and adds it to the `travel` help category
- Added `modules/fasttravel/files/datafiles/templates/help/fasttravel.template` - in-game help text for the command
- Added `modules/fasttravel/files/data-overlays/config.yaml` - declares `GoldCost` and `RequiredItemId` config keys, both defaulting to  `0` (disabled)
- Updated `modules/all-modules.go` - added `fasttravel` module import to wire it into the server