### PR TITLE
Election Module

### DIFF
--- a/_datafiles/html/admin/rooms-api.html
+++ b/_datafiles/html/admin/rooms-api.html
@@ -255,4 +255,61 @@
 
 </div>
 
+<div class="api-group-title">Room Instance</div>
+<div class="api-list">
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-get">GET</span>
+            <span class="api-path">/admin/api/v1/rooms/{roomId}/instance</span>
+            <span class="api-desc">Get raw instance YAML</span>
+        </summary>
+        <div class="api-body">
+            <p>Returns the raw YAML content of the instance file for the room. The <code>instance</code> field is an empty string when no instance file exists &mdash; this is normal for most rooms and is not an error.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/rooms/1/instance</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success (file exists)</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"instance":"gold: 42\nstash:\n  - itemid: 5\n"}}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success (no instance file)</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"instance":""}}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-patch">PUT</span>
+            <span class="api-path">/admin/api/v1/rooms/{roomId}/instance</span>
+            <span class="api-desc">Replace or delete instance file</span>
+        </summary>
+        <div class="api-body">
+            <p>Writes the supplied YAML string to the room's instance file under <code>rooms.instances/</code>. Send an empty <code>instance</code> string to delete the instance file.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> PUT <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
+     <span class="flag">-d</span> <span class="str">'{{`{"instance":"gold: 100\n"}`}}'</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/rooms/1/instance</span></div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-delete">DELETE</span>
+            <span class="api-path">/admin/api/v1/rooms/{roomId}/instance</span>
+            <span class="api-desc">Delete instance file</span>
+        </summary>
+        <div class="api-body">
+            <p>Removes the instance file for the room. Returns success even if no instance file existed.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> DELETE \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/rooms/1/instance</span></div>
+        </div>
+    </details>
+
+</div>
+
 {{template "footer" .}}

--- a/_datafiles/html/admin/rooms.html
+++ b/_datafiles/html/admin/rooms.html
@@ -316,6 +316,16 @@
     }
     .script-area textarea:focus { outline: 2px solid var(--color-accent-link); outline-offset: 1px; }
     .script-hint { font-size: 0.75rem; color: var(--color-text-faint); margin-top: 0.3rem; }
+
+    /* instance editor modal */
+    .instance-modal-overlay { display:none; position:fixed; inset:0; background:var(--color-overlay); z-index:600; align-items:center; justify-content:center; }
+    .instance-modal-overlay.open { display:flex; }
+    .instance-modal { background:var(--color-surface-white); border-radius:8px; padding:1.25rem; width:min(780px,95vw); max-height:85vh; display:flex; flex-direction:column; gap:0.75rem; }
+    .instance-modal-header { display:flex; align-items:center; justify-content:space-between; }
+    .instance-modal-body { flex:1; overflow:auto; display:flex; flex-direction:column; gap:0.5rem; }
+    .instance-modal textarea { width:100%; min-height:380px; font-family:monospace; font-size:0.82rem; padding:0.6rem 0.75rem; border:1px solid var(--color-border-medium); border-radius:4px; resize:vertical; box-sizing:border-box; line-height:1.55; }
+    .instance-modal-footer { display:flex; gap:0.6rem; align-items:center; }
+    .instance-empty-hint { font-size:0.8rem; color:var(--color-text-faint); font-style:italic; }
 </style>
 
 <h1>Rooms</h1>
@@ -548,6 +558,7 @@
             <div class="action-bar">
                 <button class="btn btn-primary" id="save-btn" onclick="saveRoom()">Save Room</button>
                 <button class="btn btn-secondary" onclick="cancelEdit()">Cancel</button>
+                <button class="btn btn-secondary" id="instance-btn" onclick="openInstanceEditor()">Instance&hellip;</button>
                 <button class="btn btn-danger" id="delete-btn" onclick="deleteRoom()" style="margin-left:auto;">Delete Room</button>
                 <span class="id-display" id="room-id-display"></span>
             </div>
@@ -564,6 +575,26 @@
         </div>
         <input type="search" id="buff-modal-search" placeholder="Search buffs..." style="padding:0.35rem 0.6rem; border:1px solid var(--color-border-medium); border-radius:4px; font-size:0.85rem;" oninput="filterBuffModal()" />
         <div id="buff-modal-list" style="overflow-y:auto; flex:1; border:1px solid var(--color-border-light); border-radius:4px;"></div>
+    </div>
+</div>
+
+<!-- Instance editor modal -->
+<div id="instance-modal" class="instance-modal-overlay" onclick="handleInstanceOverlayClick(event)">
+    <div class="instance-modal">
+        <div class="instance-modal-header">
+            <strong style="font-size:0.95rem;">Room Instance Data &mdash; #<span id="instance-room-id-label"></span></strong>
+            <button onclick="closeInstanceEditor()" style="background:none;border:none;cursor:pointer;font-size:1.2rem;color:var(--color-text-subtle);">&times;</button>
+        </div>
+        <div class="instance-modal-body">
+            <div id="instance-empty-hint" class="instance-empty-hint" style="display:none;">No instance file exists for this room. Any content you enter will create one.</div>
+            <textarea id="instance-textarea" spellcheck="false" placeholder="# YAML instance overrides&#10;# Leave blank to delete the instance file."></textarea>
+        </div>
+        <div id="instance-status" class="status-bar" style="margin-bottom:0;"></div>
+        <div class="instance-modal-footer">
+            <button class="btn btn-primary" id="instance-save-btn" onclick="saveInstance()">Save Instance</button>
+            <button class="btn btn-secondary" onclick="closeInstanceEditor()">Cancel</button>
+            <button class="btn btn-danger" id="instance-delete-btn" onclick="deleteInstance()" style="margin-left:auto;">Delete Instance</button>
+        </div>
     </div>
 </div>
 
@@ -1336,6 +1367,66 @@
         const card = buffPickerTarget.closest('.exit-card');
         if (card) updateExitHeader(card.querySelector('.exit-name'));
     }
+
+    // -------------------------------------------------------------------------
+    // Instance editor modal
+    // -------------------------------------------------------------------------
+    window.openInstanceEditor = async function () {
+        if (!currentRoomId) return;
+        document.getElementById('instance-room-id-label').textContent = currentRoomId;
+        const bar = document.getElementById('instance-status');
+        bar.className = 'status-bar';
+        bar.textContent = '';
+        document.getElementById('instance-textarea').value = '';
+        document.getElementById('instance-empty-hint').style.display = 'none';
+        document.getElementById('instance-modal').classList.add('open');
+
+        const res = await AdminAPI.get('/admin/api/v1/rooms/' + currentRoomId + '/instance', true);
+        if (!res.ok) {
+            bar.className = 'status-bar error';
+            bar.textContent = 'Failed to load instance: ' + res.error;
+            return;
+        }
+        const content = (res.data && res.data.data && res.data.data.instance) ? res.data.data.instance : '';
+        document.getElementById('instance-textarea').value = content;
+        document.getElementById('instance-empty-hint').style.display = content === '' ? 'block' : 'none';
+    };
+
+    window.closeInstanceEditor = function () {
+        document.getElementById('instance-modal').classList.remove('open');
+    };
+
+    window.handleInstanceOverlayClick = function (e) {
+        if (e.target === document.getElementById('instance-modal')) closeInstanceEditor();
+    };
+
+    window.saveInstance = async function () {
+        const btn = document.getElementById('instance-save-btn');
+        btn.disabled = true; btn.textContent = 'Saving...';
+        const content = document.getElementById('instance-textarea').value;
+        const res = await AdminAPI.put('/admin/api/v1/rooms/' + currentRoomId + '/instance', { instance: content });
+        btn.disabled = false; btn.textContent = 'Save Instance';
+        const bar = document.getElementById('instance-status');
+        if (!res.ok) {
+            bar.className = 'status-bar error'; bar.textContent = 'Save failed: ' + res.error;
+        } else {
+            closeInstanceEditor();
+        }
+    };
+
+    window.deleteInstance = async function () {
+        if (!confirm('Delete the instance file for room #' + currentRoomId + '? This cannot be undone.')) return;
+        const btn = document.getElementById('instance-delete-btn');
+        btn.disabled = true;
+        const res = await AdminAPI.delete('/admin/api/v1/rooms/' + currentRoomId + '/instance');
+        btn.disabled = false;
+        const bar = document.getElementById('instance-status');
+        if (!res.ok) {
+            bar.className = 'status-bar error'; bar.textContent = 'Delete failed: ' + res.error;
+        } else {
+            closeInstanceEditor();
+        }
+    };
 
     // -------------------------------------------------------------------------
     // Spawn Info

--- a/_datafiles/world/default/rooms/frostfang/1.yaml
+++ b/_datafiles/world/default/rooms/frostfang/1.yaml
@@ -41,6 +41,8 @@ idlemessages:
   here.
 - A <ansi fg="mobname">guard</ansi> brushes off some of the snow that has accumulated
   on the <ansi fg="itemname">sign</ansi>.
+tags:
+- election poll
 mapx: 0
 mapy: 0
 mapz: 0

--- a/_datafiles/world/default/rooms/frostfang/433.yaml
+++ b/_datafiles/world/default/rooms/frostfang/433.yaml
@@ -19,6 +19,8 @@ items:
 spawninfo:
 - itemid: 5
   respawnrate: 1 real day
+tags:
+- coffer
 mapx: -1
 mapy: -1
 mapz: 0

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -696,7 +696,7 @@ func (c *Character) getFormattedName(viewingUserId int, uType string, renderFlag
 		f.PetName = c.Pet.DisplayName()
 	}
 
-	return f
+	return OnGetFormattedName.Fire(f)
 }
 
 func (c *Character) PruneCooldowns() {

--- a/internal/characters/formattedname.go
+++ b/internal/characters/formattedname.go
@@ -5,7 +5,13 @@ import (
 	"sort"
 
 	"github.com/GoMudEngine/GoMud/internal/colorpatterns"
+	"github.com/GoMudEngine/GoMud/internal/util"
 )
+
+// OnGetFormattedName is fired at the end of getFormattedName with the
+// fully-populated FormattedName. Modules may register handlers to modify the
+// name before it is returned to the caller (e.g. to append a title).
+var OnGetFormattedName util.Hook[FormattedName]
 
 type adjectiveStyle struct {
 	LongForm     string
@@ -34,6 +40,7 @@ type FormattedName struct {
 	Name               string
 	Type               string // mob/user
 	Suffix             string // What ansi alias suffix to use (if any)
+	Title              string // Optional title appended after name (e.g. "Mayor of Frostfang")
 	Adjectives         []string
 	UseShortAdjectives bool   // Whether to failover to short adjectives
 	QuestAlert         bool   // Whether this mob is relevant to a current quest
@@ -48,6 +55,10 @@ func (f FormattedName) String() string {
 	}
 
 	output := fmt.Sprintf(`<ansi fg="%s">%s</ansi>`, ansiAlias, f.Name)
+
+	if f.Title != `` {
+		output += `, ` + f.Title
+	}
 
 	adjectives := f.Adjectives
 

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -422,6 +422,15 @@ type CLIRequest struct {
 
 func (c CLIRequest) Type() string { return `CLIRequest` }
 
+// Fired when a player successfully purchases something from a shop.
+type Purchase struct {
+	UserId int
+	Zone   string
+	Cost   int
+}
+
+func (p Purchase) Type() string { return `Purchase` }
+
 // If a potentially fire-starting event occured in this room
 type FireBlaze struct {
 	RoomId int

--- a/internal/rooms/admin.go
+++ b/internal/rooms/admin.go
@@ -293,6 +293,56 @@ func SaveZoneConfigForAdmin(name string, cfg *ZoneConfig) error {
 	return nil
 }
 
+// GetRoomInstanceRaw returns the raw YAML bytes of the instance file for
+// roomId. Returns nil, nil when the file does not exist.
+func GetRoomInstanceRaw(roomId int) ([]byte, error) {
+	filePath, ok := roomManager.roomIdToFileCache[roomId]
+	if !ok {
+		return nil, fmt.Errorf("room %d not found", roomId)
+	}
+	instancePath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/rooms.instances/`, filePath)
+	data, err := os.ReadFile(instancePath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return data, err
+}
+
+// SaveRoomInstanceRaw writes raw YAML bytes to the instance file for roomId.
+// The room template must exist. Passing empty or nil content deletes the file.
+func SaveRoomInstanceRaw(roomId int, content []byte) error {
+	if LoadRoomTemplate(roomId) == nil {
+		return fmt.Errorf("room %d not found", roomId)
+	}
+	if len(content) == 0 {
+		return DeleteRoomInstance(roomId)
+	}
+	filePath, ok := roomManager.roomIdToFileCache[roomId]
+	if !ok {
+		return fmt.Errorf("room %d not found", roomId)
+	}
+	instancePath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/rooms.instances/`, filePath)
+	dir := strings.TrimSuffix(instancePath, fmt.Sprintf("%d.yaml", roomId))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("creating instance directory: %w", err)
+	}
+	return os.WriteFile(instancePath, content, 0644)
+}
+
+// DeleteRoomInstance removes the instance file for roomId. Returns nil when
+// the file does not exist.
+func DeleteRoomInstance(roomId int) error {
+	filePath, ok := roomManager.roomIdToFileCache[roomId]
+	if !ok {
+		return fmt.Errorf("room %d not found", roomId)
+	}
+	instancePath := util.FilePath(configs.GetFilePathsConfig().DataFiles.String(), `/rooms.instances/`, filePath)
+	if err := os.Remove(instancePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing instance file: %w", err)
+	}
+	return nil
+}
+
 // SaveRoomScript writes (or overwrites) the JavaScript file for a room. If
 // content is empty the script file is deleted instead.
 func SaveRoomScript(roomId int, content string) error {

--- a/internal/usercommands/buy.go
+++ b/internal/usercommands/buy.go
@@ -312,6 +312,13 @@ func tryPurchase(request string, user *users.UserRecord, room *rooms.Room, shopM
 	})
 
 	user.Character.Gold -= price
+	if price > 0 {
+		events.AddToQueue(events.Purchase{
+			UserId: user.UserId,
+			Zone:   room.Zone,
+			Cost:   price,
+		})
+	}
 	if shopMob != nil {
 		shopMob.Character.Gold += 1 // only gains 1 gold with each sale
 	} else if shopUser != nil {

--- a/internal/web/api_routes.go
+++ b/internal/web/api_routes.go
@@ -232,6 +232,15 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /admin/api/v1/rooms/{roomId}/script", RunWithMUDLocked(
 		doBasicAuth(apiV1PutRoomScript),
 	))
+	mux.HandleFunc("GET /admin/api/v1/rooms/{roomId}/instance", RunWithMUDLocked(
+		doBasicAuth(apiV1GetRoomInstance),
+	))
+	mux.HandleFunc("PUT /admin/api/v1/rooms/{roomId}/instance", RunWithMUDLocked(
+		doBasicAuth(apiV1PutRoomInstance),
+	))
+	mux.HandleFunc("DELETE /admin/api/v1/rooms/{roomId}/instance", RunWithMUDLocked(
+		doBasicAuth(apiV1DeleteRoomInstance),
+	))
 	mux.HandleFunc("GET /admin/api/v1/rooms/{roomId}", RunWithMUDLocked(
 		doBasicAuth(apiV1GetRoom),
 	))

--- a/internal/web/api_v1_rooms.go
+++ b/internal/web/api_v1_rooms.go
@@ -299,3 +299,78 @@ func apiV1PutRoomScript(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
 }
+
+// GET /admin/api/v1/rooms/{roomId}/instance
+func apiV1GetRoomInstance(w http.ResponseWriter, r *http.Request) {
+	roomId, err := strconv.Atoi(r.PathValue("roomId"))
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "roomId must be an integer")
+		return
+	}
+
+	if rooms.GetRoomForAdmin(roomId) == nil {
+		writeAPIError(w, http.StatusNotFound, "room not found: "+strconv.Itoa(roomId))
+		return
+	}
+
+	data, err := rooms.GetRoomInstanceRaw(roomId)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[map[string]string]{
+		Success: true,
+		Data:    map[string]string{"instance": string(data)},
+	})
+}
+
+// PUT /admin/api/v1/rooms/{roomId}/instance
+func apiV1PutRoomInstance(w http.ResponseWriter, r *http.Request) {
+	roomId, err := strconv.Atoi(r.PathValue("roomId"))
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "roomId must be an integer")
+		return
+	}
+
+	if rooms.GetRoomForAdmin(roomId) == nil {
+		writeAPIError(w, http.StatusNotFound, "room not found: "+strconv.Itoa(roomId))
+		return
+	}
+
+	var body struct {
+		Instance string `json:"instance"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+
+	if err := rooms.SaveRoomInstanceRaw(roomId, []byte(body.Instance)); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}
+
+// DELETE /admin/api/v1/rooms/{roomId}/instance
+func apiV1DeleteRoomInstance(w http.ResponseWriter, r *http.Request) {
+	roomId, err := strconv.Atoi(r.PathValue("roomId"))
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "roomId must be an integer")
+		return
+	}
+
+	if rooms.GetRoomForAdmin(roomId) == nil {
+		writeAPIError(w, http.StatusNotFound, "room not found: "+strconv.Itoa(roomId))
+		return
+	}
+
+	if err := rooms.DeleteRoomInstance(roomId); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}

--- a/modules/all-modules.go
+++ b/modules/all-modules.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/GoMudEngine/GoMud/modules/auctions"
 	_ "github.com/GoMudEngine/GoMud/modules/cleanup"
 	_ "github.com/GoMudEngine/GoMud/modules/clibridge"
+	_ "github.com/GoMudEngine/GoMud/modules/elections"
 	_ "github.com/GoMudEngine/GoMud/modules/fasttravel"
 	_ "github.com/GoMudEngine/GoMud/modules/follow"
 	_ "github.com/GoMudEngine/GoMud/modules/gambling"

--- a/modules/alt-characters/alt_characters.go
+++ b/modules/alt-characters/alt_characters.go
@@ -46,6 +46,7 @@ func init() {
 	}
 
 	m.plug.Web.AdminPage("Config", "alt-characters-config", "html/admin/alt-characters-config.html", true, "Modules", "Alt Characters", nil)
+	m.plug.Web.AdminPage("About", "alt-characters-about", "html/admin/alt-characters-about.html", true, "Modules", "Alt Characters", nil)
 	m.plug.AddUserCommand(`character`, m.characterCommand, true, false)
 
 	m.plug.ReserveTags(characterTag)

--- a/modules/alt-characters/files/datafiles/html/admin/alt-characters-about.html
+++ b/modules/alt-characters/files/datafiles/html/admin/alt-characters-about.html
@@ -1,0 +1,41 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Alt Characters</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Alt Characters module lets a single account maintain multiple player characters. Once a character reaches level 5, the player can visit a <em>character room</em> and use the <code>character</code> command to create, view, switch to, delete, or hire out alternate characters stored under the same account.</p>
+    <p>Switching characters saves the current character to the alt roster and loads the selected one in its place. Hiring spawns the alt as a charmed mob that fights alongside the active character for a gold fee based on level and gear value.</p>
+    <p>The maximum number of alts is controlled by the <code>MaxAltCharacters</code> config key. Setting it to 0 disables the system entirely.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <table class="tag-table">
+        <thead><tr><th>Tag</th><th>Effect</th></tr></thead>
+        <tbody>
+            <tr>
+                <td class="tag-name">character</td>
+                <td>Marks the room as a Character Management room. The <code>character</code> command only functions in rooms with this tag. When a player looks at the room, an alert is shown prompting them to type <code>character</code> to interact.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+{{template "footer" .}}

--- a/modules/auctions/auctions.go
+++ b/modules/auctions/auctions.go
@@ -58,7 +58,8 @@ func init() {
 		panic(err)
 	}
 
-	a.plug.Web.AdminPage("Config", "auctions-config", "html/admin/auctions-config.html", true, "Modules", "Auctions", nil) //
+	a.plug.Web.AdminPage("Config", "auctions-config", "html/admin/auctions-config.html", true, "Modules", "Auctions", nil)
+	a.plug.Web.AdminPage("About", "auctions-about", "html/admin/auctions-about.html", true, "Modules", "Auctions", nil) //
 	// Register any user/mob commands
 	//
 	a.plug.AddUserCommand(`auction`, a.auctionCommand, true, false)

--- a/modules/auctions/files/datafiles/html/admin/auctions-about.html
+++ b/modules/auctions/files/datafiles/html/admin/auctions-about.html
@@ -1,0 +1,34 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Auctions</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Auctions module provides a global player-driven auction system. Any player can put an item from their backpack up for auction with a minimum starting bid. All online players are notified when an auction starts, when a new bid is placed, and when the auction ends.</p>
+    <p>Only one auction may be active at a time. When the auction timer expires the item is delivered to the highest bidder (or returned to the seller if there were no bids), and gold is deposited into the seller's bank account. If the winner is offline the item is delivered via mudmail.</p>
+    <p>Key config values: <code>DurationSeconds</code> controls how long each auction lasts; <code>UpdateSeconds</code> controls reminder broadcast frequency; <code>Anonymous</code> hides buyer and seller names.</p>
+    <p>Players can disable auction broadcasts for themselves via the <code>set auction off</code> user preference.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/cleanup/cleanup.go
+++ b/modules/cleanup/cleanup.go
@@ -49,6 +49,7 @@ func init() {
 	}
 
 	c.plug.Web.AdminPage("Config", "cleanup-config", "html/admin/cleanup-config.html", true, "Modules", "Cleanup", nil)
+	c.plug.Web.AdminPage("About", "cleanup-about", "html/admin/cleanup-about.html", true, "Modules", "Cleanup", nil)
 	//
 	// Register any user/mob commands
 	//

--- a/modules/cleanup/files/datafiles/html/admin/cleanup-about.html
+++ b/modules/cleanup/files/datafiles/html/admin/cleanup-about.html
@@ -1,0 +1,33 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Cleanup</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Cleanup module adds two commands for removing unwanted content from the world: <code>trash</code> and <code>bury</code>.</p>
+    <p><strong>trash &lt;item&gt;</strong> permanently destroys an item from the player's backpack. If the <code>ExperienceValue</code> config key is set to a positive number, the player receives experience equal to the greater of that value or one-tenth of the item's gold value as a reward for cleaning up.</p>
+    <p><strong>bury &lt;corpse&gt;</strong> removes a corpse from the current room. Both commands are also available as mob commands, allowing NPCs to clean up after combat automatically.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/clibridge/clibridge.go
+++ b/modules/clibridge/clibridge.go
@@ -37,6 +37,8 @@ func init() {
 		panic(err)
 	}
 
+	m.plug.Web.AdminPage("About", "clibridge-about", "html/admin/clibridge-about.html", true, "Modules", "CLI Bridge", nil)
+
 	m.plug.AddUserCommand(`cli`, m.cliCommand, false, true)
 
 	events.RegisterListener(events.CLIRequest{}, m.onCLIRequest)

--- a/modules/clibridge/files/datafiles/html/admin/clibridge-about.html
+++ b/modules/clibridge/files/datafiles/html/admin/clibridge-about.html
@@ -1,0 +1,34 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">CLI Bridge</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The CLI Bridge module gives players direct access to whitelisted command-line tools running on the server, rendered inside the MUD terminal via a pseudo-terminal (PTY). This is useful for in-game file editors, viewers, or other interactive tools that an operator wants to expose.</p>
+    <p>Players use the <code>cli &lt;tool&gt; [args...]</code> command to launch a session. The tool must be listed in the <code>AllowedTools</code> config key, and any file-path arguments must fall within the <code>AllowedPaths</code> list. Tab-completion is provided for both tool names and file paths within the data directory.</p>
+    <p>CLI sessions are only supported over raw TCP (telnet/SSH) connections. WebSocket clients receive an error message. The session ends when the tool exits, returning the player to normal game input.</p>
+    <p>Setting <code>Enabled</code> to <code>false</code> disables the command entirely without unloading the module.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/elections/elections.go
+++ b/modules/elections/elections.go
@@ -1,0 +1,629 @@
+package elections
+
+import (
+	"embed"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/characters"
+	"github.com/GoMudEngine/GoMud/internal/colorpatterns"
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/gametime"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/term"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+var (
+	//go:embed files/*
+	files embed.FS
+)
+
+const (
+	pollTag   = "election poll"
+	cofferTag = "coffer"
+	maxCoffer = 100000000
+)
+
+func init() {
+	m := &ElectionsModule{
+		plug: plugins.New(`elections`, `1.0`),
+	}
+
+	if err := m.plug.AttachFileSystem(files); err != nil {
+		panic(err)
+	}
+
+	m.plug.ReserveTags(pollTag, cofferTag)
+
+	m.plug.Web.AdminPage("Config", "elections-config", "html/admin/elections-config.html", true, "Modules", "Elections", nil)
+	m.plug.Web.AdminPage("About", "elections-about", "html/admin/elections-about.html", true, "Modules", "Elections", nil)
+
+	m.plug.AddUserCommand(`election`, m.electionAdminCommand, true, true)
+	m.plug.AddUserCommand(`coffer`, m.cofferCommand, false, false)
+
+	m.plug.Callbacks.SetOnLoad(m.load)
+	m.plug.Callbacks.SetOnSave(m.save)
+
+	events.RegisterListener(events.Input{}, m.onInput, events.First)
+	events.RegisterListener(events.PlayerSpawn{}, m.onPlayerSpawn)
+	events.RegisterListener(events.NewRound{}, m.onNewRound)
+	events.RegisterListener(events.Purchase{}, m.onPurchase)
+
+	rooms.OnRoomLook.Register(m.onRoomLook)
+	characters.OnGetFormattedName.Register(m.onGetFormattedName)
+}
+
+// ElectionsState is the persisted state for the elections module.
+type ElectionsState struct {
+	ActiveElection *Election         `yaml:"activeelection,omitempty"`
+	Winners        map[string]Winner `yaml:"winners,omitempty"`
+	Coffers        map[string]int    `yaml:"coffers,omitempty"`
+}
+
+// Election represents a running election.
+type Election struct {
+	Title      string      `yaml:"title"`
+	Zone       string      `yaml:"zone"`
+	StartRound uint64      `yaml:"startround"`
+	Nominees   []string    `yaml:"nominees,omitempty"`
+	NomineeIds []int       `yaml:"nomineeids,omitempty"`
+	Votes      map[int]int `yaml:"votes,omitempty"`
+}
+
+// Winner records the outcome of a completed election.
+type Winner struct {
+	CharacterName string `yaml:"charactername"`
+	UserId        int    `yaml:"userid"`
+	Title         string `yaml:"title"`
+}
+
+// ElectionsModule owns all elections state.
+type ElectionsModule struct {
+	plug  *plugins.Plugin
+	state ElectionsState
+}
+
+func (m *ElectionsModule) load() {
+	m.plug.ReadIntoStruct(`elections-state`, &m.state)
+	if m.state.Winners == nil {
+		m.state.Winners = make(map[string]Winner)
+	}
+	if m.state.Coffers == nil {
+		m.state.Coffers = make(map[string]int)
+	}
+	if m.state.ActiveElection != nil && m.state.ActiveElection.Votes == nil {
+		m.state.ActiveElection.Votes = make(map[int]int)
+	}
+}
+
+func (m *ElectionsModule) save() {
+	m.plug.WriteStruct(`elections-state`, m.state)
+}
+
+// electionAlert formats a bordered election update message.
+func electionAlert(lines ...string) string {
+	border := `<ansi fg="yellow-bold">********************</ansi> <ansi fg="white-bold">Election Update</ansi> <ansi fg="yellow-bold">********************</ansi>`
+	close := `<ansi fg="yellow-bold">*********************************************************</ansi>`
+	parts := []string{border}
+	parts = append(parts, lines...)
+	parts = append(parts, close)
+	return strings.Join(parts, "\n")
+}
+
+// broadcastAlert sends an alert to all online players.
+func broadcastAlert(msg string) {
+	for _, uid := range users.GetOnlineUserIds() {
+		if u := users.GetByUserId(uid); u != nil {
+			u.SendText(msg)
+		}
+	}
+}
+
+func (m *ElectionsModule) electionDuration() string {
+	if v, ok := m.plug.Config.Get(`ElectionDuration`).(string); ok && v != `` {
+		return v
+	}
+	return `2 days`
+}
+
+func (m *ElectionsModule) titleColor() string {
+	if v, ok := m.plug.Config.Get(`TitleColor`).(string); ok && v != `` {
+		return v
+	}
+	return `yellow`
+}
+
+// daysRemaining returns a human-readable days-remaining string for an election.
+func (m *ElectionsModule) daysRemaining() string {
+	if m.state.ActiveElection == nil {
+		return `0 days`
+	}
+	gd := gametime.GetDate(m.state.ActiveElection.StartRound)
+	endRound := gd.AddPeriod(m.electionDuration())
+	now := util.GetRoundCount()
+	if endRound <= now {
+		return `0 days`
+	}
+	remaining := endRound - now
+	// Use config rounds-per-day for conversion.
+	roundsPerDay := gd.RoundsPerDay
+	if roundsPerDay < 1 {
+		roundsPerDay = 480
+	}
+	days := (int(remaining) + roundsPerDay - 1) / roundsPerDay
+	if days == 1 {
+		return `1 day`
+	}
+	return fmt.Sprintf(`%d days`, days)
+}
+
+// endElection tallies votes, saves the winner, and broadcasts the result.
+// adminUser may be nil for auto-end.
+func (m *ElectionsModule) endElection(adminUser *users.UserRecord) {
+	el := m.state.ActiveElection
+	if el == nil {
+		return
+	}
+
+	// Tally votes: count votes per nominee userId.
+	voteCounts := make(map[int]int, len(el.NomineeIds))
+	for _, nomineeId := range el.NomineeIds {
+		voteCounts[nomineeId] = 0
+	}
+	for _, nomineeId := range el.Votes {
+		voteCounts[nomineeId]++
+	}
+
+	// Find winner (most votes; ties go to first-nominated).
+	winnerUserId := 0
+	winnerName := ``
+	winnerVotes := -1
+	for i, nomineeId := range el.NomineeIds {
+		count := voteCounts[nomineeId]
+		if count > winnerVotes {
+			winnerVotes = count
+			winnerUserId = nomineeId
+			winnerName = el.Nominees[i]
+		}
+	}
+
+	m.state.ActiveElection = nil
+
+	if winnerUserId == 0 {
+		// No nominees at all.
+		msg := electionAlert(
+			fmt.Sprintf(`The election for <ansi fg="white-bold">%s</ansi> has ended with no candidates.`, el.Title),
+		)
+		broadcastAlert(msg)
+		return
+	}
+
+	zoneKey := strings.ToLower(el.Zone)
+	m.state.Winners[zoneKey] = Winner{
+		CharacterName: winnerName,
+		UserId:        winnerUserId,
+		Title:         el.Title,
+	}
+
+	msg := electionAlert(
+		fmt.Sprintf(`The election has ended for <ansi fg="white-bold">%s</ansi>, and the winner is <ansi fg="username">%s</ansi>!`, el.Title, winnerName),
+		fmt.Sprintf(`Congratulations <ansi fg="username">%s</ansi>, <ansi fg="white-bold">%s</ansi>!`, winnerName, el.Title),
+	)
+	broadcastAlert(msg)
+}
+
+// electionAdminCommand handles the `election` admin command.
+func (m *ElectionsModule) electionAdminCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	args := strings.Fields(rest)
+
+	if len(args) == 0 {
+		user.SendText(`Usage: <ansi fg="command">election start <title></ansi> or <ansi fg="command">election end</ansi>` + term.CRLFStr)
+		return true, nil
+	}
+
+	switch strings.ToLower(args[0]) {
+
+	case `start`:
+		if len(args) < 2 {
+			user.SendText(`Usage: <ansi fg="command">election start <title></ansi>` + term.CRLFStr)
+			return true, nil
+		}
+
+		if m.state.ActiveElection != nil {
+			user.SendText(fmt.Sprintf(`An election for <ansi fg="white-bold">%s</ansi> is already in progress.`+term.CRLFStr, m.state.ActiveElection.Title))
+			return true, nil
+		}
+
+		title := strings.Join(args[1:], ` `)
+		zone := room.Zone
+
+		m.state.ActiveElection = &Election{
+			Title:      title,
+			Zone:       zone,
+			StartRound: util.GetRoundCount(),
+			Votes:      make(map[int]int),
+		}
+
+		daysLeft := m.daysRemaining()
+		msg := electionAlert(
+			fmt.Sprintf(`An election has started for "<ansi fg="white-bold">%s</ansi>."`, title),
+			`Type <ansi fg="command">help elections</ansi> to find out more about it.`,
+			`Cast your vote at the nearest polling location.`,
+			fmt.Sprintf(`The election ends in <ansi fg="white-bold">%s</ansi>!`, daysLeft),
+		)
+		broadcastAlert(msg)
+
+	case `end`:
+		if m.state.ActiveElection == nil {
+			user.SendText(`There is no active election to end.` + term.CRLFStr)
+			return true, nil
+		}
+		m.endElection(user)
+
+	default:
+		user.SendText(`Usage: <ansi fg="command">election start <title></ansi> or <ansi fg="command">election end</ansi>` + term.CRLFStr)
+	}
+
+	return true, nil
+}
+
+// cofferCommand handles the `coffer` user command.
+func (m *ElectionsModule) cofferCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	if !room.HasTag(cofferTag) {
+		user.SendText(`You are not at a coffer location.` + term.CRLFStr)
+		return true, nil
+	}
+
+	zoneKey := strings.ToLower(room.Zone)
+	balance := m.state.Coffers[zoneKey]
+
+	if rest == `` {
+		user.SendText(``)
+		user.SendText(fmt.Sprintf(`The coffer of <ansi fg="white-bold">%s</ansi> holds <ansi fg="gold">%d gold</ansi>.`, room.Zone, balance))
+		user.SendText(`You can <ansi fg="command">coffer deposit</ansi> or <ansi fg="command">coffer withdraw</ansi> from the coffer.` + term.CRLFStr)
+		return true, nil
+	}
+
+	// Only the zone's current title-holder may deposit or withdraw.
+	winner, hasWinner := m.state.Winners[zoneKey]
+	if !hasWinner || winner.UserId != user.UserId {
+		user.SendText(fmt.Sprintf(`Only the elected <ansi fg="white-bold">%s</ansi> may manage this coffer.`+term.CRLFStr, func() string {
+			if hasWinner {
+				return winner.Title
+			}
+			return `leader`
+		}()))
+		return true, nil
+	}
+
+	if rest == `deposit` || rest == `withdraw` {
+		user.SendText(fmt.Sprintf(`%s how much? Include the amount of gold or "all".%s`, rest, term.CRLFStr))
+		return true, nil
+	}
+
+	parts := strings.Fields(strings.ToLower(rest))
+	if len(parts) < 2 || (parts[0] != `deposit` && parts[0] != `withdraw`) {
+		user.SendText(`Try <ansi fg="command">help elections</ansi> for more information about coffers.` + term.CRLFStr)
+		return true, nil
+	}
+
+	action := parts[0]
+	amountStr := parts[1]
+	amount, _ := strconv.Atoi(amountStr)
+
+	if amount < 1 && amountStr != `all` {
+		user.SendText(fmt.Sprintf(`You must specify an amount greater than zero to %s.%s`, action, term.CRLFStr))
+		return true, nil
+	}
+
+	if action == `deposit` {
+		if amountStr == `all` {
+			amount = user.Character.Gold
+		}
+		if amount > user.Character.Gold {
+			amount = user.Character.Gold
+			user.SendText(`You don't have that much gold on hand, but you deposit what you have.`)
+		}
+		newBalance := balance + amount
+		if newBalance > maxCoffer {
+			amount = maxCoffer - balance
+			newBalance = maxCoffer
+			user.SendText(`The coffer is nearly full; only a portion was deposited.`)
+		}
+		user.Character.Gold -= amount
+		m.state.Coffers[zoneKey] = newBalance
+
+		events.AddToQueue(events.EquipmentChange{
+			UserId:     user.UserId,
+			GoldChange: -amount,
+		})
+
+		user.SendText(fmt.Sprintf(`You deposit <ansi fg="gold">%d gold</ansi> into the coffer.`, amount))
+		user.SendText(fmt.Sprintf(`The coffer now holds <ansi fg="gold">%d gold</ansi>.`, newBalance))
+
+	} else if action == `withdraw` {
+		if amountStr == `all` {
+			amount = balance
+		}
+		if amount > balance {
+			amount = balance
+			user.SendText(`The coffer doesn't hold that much, but you withdraw what is there.`)
+		}
+		newBalance := balance - amount
+		user.Character.Gold += amount
+		m.state.Coffers[zoneKey] = newBalance
+
+		events.AddToQueue(events.EquipmentChange{
+			UserId:     user.UserId,
+			GoldChange: amount,
+		})
+
+		user.SendText(fmt.Sprintf(`You withdraw <ansi fg="gold">%d gold</ansi> from the coffer.`, amount))
+		user.SendText(fmt.Sprintf(`The coffer now holds <ansi fg="gold">%d gold</ansi>.`, newBalance))
+	}
+
+	user.SendText(``)
+	return true, nil
+}
+
+// onInput intercepts `nominate` and `vote` commands.
+func (m *ElectionsModule) onInput(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.Input)
+	if !ok || evt.UserId == 0 {
+		return events.Continue
+	}
+
+	inputLower := strings.TrimSpace(strings.ToLower(evt.InputText))
+	cmd, rest, _ := strings.Cut(inputLower, ` `)
+
+	switch cmd {
+	case `nominate`:
+		return m.handleNominate(evt.UserId, strings.TrimSpace(rest))
+	case `vote`:
+		return m.handleVote(evt.UserId, strings.TrimSpace(rest))
+	}
+
+	return events.Continue
+}
+
+func (m *ElectionsModule) handleNominate(userId int, targetName string) events.ListenerReturn {
+	user := users.GetByUserId(userId)
+	if user == nil {
+		return events.Continue
+	}
+
+	if m.state.ActiveElection == nil {
+		return events.Continue
+	}
+
+	room := rooms.LoadRoom(user.Character.RoomId)
+	if room == nil || !room.HasTag(pollTag) {
+		user.SendText(`You must be at a polling location to nominate someone.`)
+		return events.Cancel
+	}
+
+	if targetName == `` {
+		user.SendText(`Nominate who? Try <ansi fg="command">nominate <playername></ansi>.`)
+		return events.Cancel
+	}
+
+	// Find the target player online (exact match, case-insensitive).
+	var targetUser *users.UserRecord
+	for _, uid := range users.GetOnlineUserIds() {
+		u := users.GetByUserId(uid)
+		if u != nil && strings.EqualFold(u.Character.Name, targetName) {
+			targetUser = u
+			break
+		}
+	}
+
+	if targetUser == nil {
+		user.SendText(fmt.Sprintf(`No online player named <ansi fg="username">%s</ansi> was found.`, targetName))
+		return events.Cancel
+	}
+
+	el := m.state.ActiveElection
+
+	// Check for duplicate nomination.
+	for _, nid := range el.NomineeIds {
+		if nid == targetUser.UserId {
+			user.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> is already on the ballot.`, targetUser.Character.Name))
+			return events.Cancel
+		}
+	}
+
+	el.Nominees = append(el.Nominees, targetUser.Character.Name)
+	el.NomineeIds = append(el.NomineeIds, targetUser.UserId)
+
+	msg := electionAlert(
+		fmt.Sprintf(`<ansi fg="username">%s</ansi> was nominated for <ansi fg="white-bold">%s</ansi>!`, targetUser.Character.Name, el.Title),
+	)
+	broadcastAlert(msg)
+
+	return events.Cancel
+}
+
+func (m *ElectionsModule) handleVote(userId int, targetName string) events.ListenerReturn {
+	user := users.GetByUserId(userId)
+	if user == nil {
+		return events.Continue
+	}
+
+	if m.state.ActiveElection == nil {
+		return events.Continue
+	}
+
+	room := rooms.LoadRoom(user.Character.RoomId)
+	if room == nil || !room.HasTag(pollTag) {
+		user.SendText(`You must be at a polling location to vote for someone.`)
+		return events.Cancel
+	}
+
+	el := m.state.ActiveElection
+
+	// `vote` with no argument: list candidates.
+	if targetName == `` {
+		if len(el.Nominees) == 0 {
+			user.SendText(fmt.Sprintf(`No one has been nominated yet for <ansi fg="white-bold">%s</ansi>.`, el.Title))
+			return events.Cancel
+		}
+		user.SendText(``)
+		user.SendText(fmt.Sprintf(`<ansi fg="white-bold">Candidates for %s:</ansi>`, el.Title))
+		for _, name := range el.Nominees {
+			user.SendText(fmt.Sprintf(`  <ansi fg="username">%s</ansi>`, name))
+		}
+		user.SendText(``)
+		user.SendText(`Type <ansi fg="command">vote <name></ansi> to cast your vote.`)
+		return events.Cancel
+	}
+
+	// Check if already voted.
+	if _, alreadyVoted := el.Votes[userId]; alreadyVoted {
+		user.SendText(`You have already cast your vote in this election.`)
+		return events.Cancel
+	}
+
+	// Find nominee by name.
+	nomineeUserId := 0
+	nomineeName := ``
+	for i, name := range el.Nominees {
+		if strings.EqualFold(name, targetName) {
+			nomineeUserId = el.NomineeIds[i]
+			nomineeName = name
+			break
+		}
+	}
+
+	if nomineeUserId == 0 {
+		user.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> is not on the ballot. Type <ansi fg="command">vote</ansi> to see candidates.`, targetName))
+		return events.Cancel
+	}
+
+	el.Votes[userId] = nomineeUserId
+	user.SendText(fmt.Sprintf(`You have cast your vote for <ansi fg="username">%s</ansi>.`, nomineeName))
+
+	return events.Cancel
+}
+
+// onPlayerSpawn sends the election reminder to a newly spawned player.
+func (m *ElectionsModule) onPlayerSpawn(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerSpawn)
+	if !ok {
+		return events.Continue
+	}
+
+	if m.state.ActiveElection == nil {
+		return events.Continue
+	}
+
+	el := m.state.ActiveElection
+	daysLeft := m.daysRemaining()
+
+	u := users.GetByUserId(evt.UserId)
+	if u == nil {
+		return events.Continue
+	}
+
+	msg := electionAlert(
+		fmt.Sprintf(`An election is ongoing for <ansi fg="white-bold">"%s."</ansi>`, el.Title),
+		`Type <ansi fg="command">help elections</ansi> to find out more about it.`,
+		`Cast your vote at the nearest polling location.`,
+		fmt.Sprintf(`The election ends in <ansi fg="white-bold">%s</ansi>!`, daysLeft),
+	)
+	u.SendText(msg)
+
+	return events.Continue
+}
+
+// onNewRound checks whether the election duration has elapsed and auto-ends if so.
+func (m *ElectionsModule) onNewRound(e events.Event) events.ListenerReturn {
+	if m.state.ActiveElection == nil {
+		return events.Continue
+	}
+
+	gd := gametime.GetDate(m.state.ActiveElection.StartRound)
+	endRound := gd.AddPeriod(m.electionDuration())
+
+	if util.GetRoundCount() >= endRound {
+		m.endElection(nil)
+	}
+
+	return events.Continue
+}
+
+// onPurchase applies a 10% coffer tax on any shop purchase.
+func (m *ElectionsModule) onPurchase(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.Purchase)
+	if !ok || evt.Cost <= 0 {
+		return events.Continue
+	}
+
+	zoneKey := strings.ToLower(evt.Zone)
+	tax := evt.Cost / 10
+	if tax < 1 {
+		tax = 1
+	}
+
+	current := m.state.Coffers[zoneKey]
+	current += tax
+	if current > maxCoffer {
+		current = maxCoffer
+	}
+	m.state.Coffers[zoneKey] = current
+
+	return events.Continue
+}
+
+// onRoomLook injects poll/coffer alerts into the room look details.
+func (m *ElectionsModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
+	for _, t := range d.Tags {
+		if strings.EqualFold(t, pollTag) {
+			if m.state.ActiveElection != nil {
+				d.RoomAlerts = append(d.RoomAlerts,
+					`<ansi fg="yellow-bold">This is a polling location!</ansi> <ansi fg="command">vote</ansi> for or <ansi fg="command">nominate</ansi> someone.`,
+				)
+			} else {
+				//d.RoomAlerts = append(d.RoomAlerts,
+				//	`<ansi fg="yellow-bold">This is a polling location.</ansi> No election is currently in progress.`,
+				//)
+			}
+			return d
+		}
+		if strings.EqualFold(t, cofferTag) {
+			zoneKey := strings.ToLower(d.Zone)
+			bal := m.state.Coffers[zoneKey]
+			d.RoomAlerts = append(d.RoomAlerts,
+				fmt.Sprintf(`<ansi fg="yellow-bold">This room holds the zone coffer.</ansi> Balance: <ansi fg="gold">%d gold</ansi>. Type <ansi fg="command">coffer</ansi> to manage it.`, bal),
+			)
+			return d
+		}
+	}
+	return d
+}
+
+// onGetFormattedName appends the player's title (if any) to their formatted name.
+func (m *ElectionsModule) onGetFormattedName(f characters.FormattedName) characters.FormattedName {
+	if f.Type != `username` {
+		return f
+	}
+
+	for _, w := range m.state.Winners {
+		if strings.EqualFold(w.CharacterName, f.Name) {
+			color := m.titleColor()
+			if len(color) > 0 {
+				if num, err := strconv.Atoi(color); err == nil {
+					f.Title = fmt.Sprintf(`<ansi fg="%d">%s</ansi>`, num, w.Title)
+				} else {
+					f.Title = colorpatterns.ApplyColorPattern(w.Title, color)
+				}
+			}
+			return f
+		}
+	}
+
+	return f
+}

--- a/modules/elections/files/data-overlays/config.yaml
+++ b/modules/elections/files/data-overlays/config.yaml
@@ -1,0 +1,16 @@
+################################################################################
+# If modified, these settings will be copied into your config overrides
+# folder under `Modules.elections`:
+#
+# Modules:
+#   elections:
+#     TitleColor: "yellow"
+#     ElectionDuration: "2 days"
+################################################################################
+# - TitleColor -
+#   The color code or color pattern name to apply to player titles when shown.
+TitleColor: "158"
+# - ElectionDuration -
+#   How long an election runs before it automatically ends.
+#   Uses the game-time period format (e.g. "2 days", "1 week").
+ElectionDuration: "2 days"

--- a/modules/elections/files/data-overlays/keywords.yaml
+++ b/modules/elections/files/data-overlays/keywords.yaml
@@ -1,0 +1,4 @@
+help:
+  command:
+    social:
+      - elections

--- a/modules/elections/files/datafiles/html/admin/elections-about.html
+++ b/modules/elections/files/datafiles/html/admin/elections-about.html
@@ -1,0 +1,47 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Elections</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Elections module provides a server-wide election system. Admins start an election with <code>election start &lt;title&gt;</code> from within a zone; the zone the command is issued in becomes the zone the title is associated with. Only one election may run at a time.</p>
+    <p>Elections proceed in two phases. During the <strong>nomination</strong> phase, players visit a polling location and type <code>nominate &lt;playername&gt;</code> to add someone to the ballot. When a player is nominated, an alert goes out to all online players. During the <strong>voting</strong> phase, players type <code>vote &lt;name&gt;</code> at a polling location to cast their ballot; each player may only vote once. Typing <code>vote</code> with no argument lists current candidates.</p>
+    <p>An election ends when an admin types <code>election end</code>, or automatically after the <code>ElectionDuration</code> config period elapses. The winner receives the election title appended to their name (styled with <code>TitleColor</code>) and exclusive access to the zone coffer.</p>
+    <p>The <strong>coffer</strong> is a zone treasury. Every purchase made anywhere in a zone adds 10% of the cost (minimum 1 gold) to that zone's coffer, up to a cap of 100,000,000 gold. Only the current elected title-holder may deposit or withdraw from the coffer; anyone may view the balance by typing <code>coffer</code> at a coffer room.</p>
+    <p>Players who log in while an election is active receive a reminder broadcast.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <table class="tag-table">
+        <thead><tr><th>Tag</th><th>Effect</th></tr></thead>
+        <tbody>
+            <tr>
+                <td class="tag-name">election poll</td>
+                <td>Marks the room as a polling location. The <code>nominate</code> and <code>vote</code> commands only work in rooms with this tag. When an election is active and a player looks at the room, an alert prompts them to nominate or vote.</td>
+            </tr>
+            <tr>
+                <td class="tag-name">coffer</td>
+                <td>Marks the room as the zone coffer location. The <code>coffer</code> command only functions here. When a player looks at the room, an alert shows the current coffer balance and instructions for managing it.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+{{template "footer" .}}

--- a/modules/elections/files/datafiles/html/admin/elections-config.html
+++ b/modules/elections/files/datafiles/html/admin/elections-config.html
@@ -1,0 +1,452 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .btn { padding: 0.4rem 1rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+    .btn-primary { background: var(--color-primary); color: var(--color-surface-white); }
+    .btn-primary:hover { background: var(--color-primary-hover); }
+    .btn-primary:disabled { background: var(--color-text-secondary); cursor: default; }
+
+    #status-bar { display: none; padding: 0.6rem 1rem; border-radius: 4px; font-size: 0.875rem; margin-bottom: 1rem; }
+    #status-bar.success { background: var(--color-success-bg); color: var(--color-success-text); display: block; }
+    #status-bar.error   { background: var(--color-error-bg); color: var(--color-error-text); display: block; }
+
+    .config-table-wrap { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+    col.col-key   { width: 38%; }
+    col.col-value { width: 62%; }
+    thead th { background: var(--color-border-faint); text-align: left; padding: 0.6rem 0.9rem; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-text-muted); border-bottom: 1px solid var(--color-border); }
+    tbody tr { border-bottom: 1px solid var(--color-border-light); }
+    tbody tr:last-child { border-bottom: none; }
+    tbody tr:hover { background: var(--color-surface-alt); }
+    td { padding: 0.55rem 0.9rem; font-size: 0.875rem; vertical-align: middle; overflow: hidden; }
+    td.key-cell { font-family: monospace; font-size: 0.82rem; color: var(--color-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    td.value-cell { max-width: 0; overflow: hidden; }
+
+    .value-display { cursor: pointer; display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .value-display:hover { text-decoration: underline dotted var(--color-text-faint); }
+    .edit-form { display: none; align-items: center; gap: 0.4rem; width: 100%; }
+    .edit-form.active { display: flex; }
+    .edit-form input[type="text"] { flex: 1; padding: 0.3rem 0.5rem; border: 1px solid var(--color-text-placeholder); border-radius: 3px; font-size: 0.875rem; font-family: inherit; }
+    .btn-save { padding: 0.25rem 0.6rem; font-size: 0.8rem; border-radius: 3px; border: none; cursor: pointer; background: var(--color-btn-save-bg); color: var(--color-surface-white); }
+    .btn-save:hover { background: var(--color-btn-new-hover); }
+    .btn-cancel { padding: 0.25rem 0.6rem; font-size: 0.8rem; border-radius: 3px; border: none; cursor: pointer; background: var(--color-border-medium); color: var(--color-text-strong); }
+    .btn-cancel:hover { background: var(--color-btn-cancel-hover); }
+
+    #pending-panel { display: none; background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1rem; margin-bottom: 1.25rem; }
+    #pending-panel h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+    #pending-list { display: flex; flex-direction: column; gap: 0.4rem; margin-bottom: 0.75rem; }
+    .pending-item { display: flex; align-items: baseline; gap: 0.5rem; font-size: 0.875rem; background: var(--color-surface-alt); border: 1px solid var(--color-border-light); border-radius: 4px; padding: 0.35rem 0.65rem; }
+    .pending-key { font-family: monospace; font-size: 0.82rem; color: var(--color-primary); flex: 1; }
+    .pending-arrow { color: var(--color-text-faint); }
+    .pending-val { color: var(--color-success-text); font-weight: 600; }
+    .pending-remove { background: none; border: none; cursor: pointer; color: var(--color-text-faint); font-size: 1rem; line-height: 1; padding: 0 0.2rem; }
+    .pending-remove:hover { color: var(--color-danger); }
+    .pending-actions { display: flex; gap: 0.5rem; }
+    .btn-discard { background: var(--color-border-light); color: var(--color-text-strong); }
+    .btn-discard:hover { background: var(--color-border); }
+
+    .no-keys { padding: 2rem; text-align: center; color: var(--color-text-faint); font-size: 0.9rem; }
+    tr.desc-row td { padding: 0.1rem 0.9rem 0.5rem; font-size: 0.78rem; color: var(--color-text-faint); font-style: italic; border-bottom: 1px solid var(--color-border-light); }
+
+    /* ── TitleColor picker cell ──────────────────────────────────────────── */
+    .color-picker-cell { display: flex; flex-direction: column; gap: 0.4rem; padding: 0.4rem 0; }
+    .color-picker-input-row { display: flex; align-items: center; gap: 0.4rem; }
+    .color-picker-input-row input[type="text"] {
+        flex: 1; padding: 0.3rem 0.5rem; border: 1px solid var(--color-border-medium);
+        border-radius: 3px; font-size: 0.875rem; font-family: monospace;
+    }
+    .btn-search {
+        padding: 0.25rem 0.55rem; font-size: 0.82rem; border-radius: 3px;
+        border: 1px solid var(--color-border-medium); background: var(--color-page-bg);
+        cursor: pointer; white-space: nowrap; flex-shrink: 0;
+    }
+    .btn-search:hover { background: var(--color-hover-tint); border-color: var(--color-hover-tint-border); }
+    .color-picker-stage {
+        padding: 0.25rem 0.6rem; font-size: 0.8rem; border-radius: 3px; border: none;
+        cursor: pointer; background: var(--color-btn-save-bg); color: var(--color-surface-white);
+    }
+    .color-picker-stage:hover { background: var(--color-btn-new-hover); }
+
+    /* 256-color swatch popup — same as color-aliases.html */
+    .cp-swatch-wrap { position: relative; display: inline-block; }
+    .ansi-palette-popup {
+        position: fixed; z-index: 9999; margin-top: 0.35rem;
+        background: var(--color-surface); border: 1px solid var(--color-border);
+        border-radius: 6px; padding: 0.5rem;
+        box-shadow: 0 4px 16px var(--color-shadow);
+        display: flex; flex-wrap: wrap; gap: 2px;
+        width: 404px;
+    }
+    .ansi-palette-cell {
+        width: 18px; height: 18px; border-radius: 2px; cursor: pointer;
+        border: 2px solid transparent; flex-shrink: 0; transition: transform 0.08s;
+    }
+    .ansi-palette-cell:hover { transform: scale(1.4); border-color: rgba(255,255,255,0.6); z-index: 1; position: relative; }
+    .ansi-palette-cell.selected { border-color: var(--color-surface-white); box-shadow: 0 0 0 2px var(--color-focus); }
+</style>
+
+<h1>elections - Module Config</h1>
+<p class="subtitle">Configuration keys for the <strong>elections</strong> module. Click any value to edit it inline. Changes are staged until you apply them.</p>
+
+<div id="status-bar"></div>
+
+<div id="pending-panel">
+    <h3>Pending Changes</h3>
+    <div id="pending-list"></div>
+    <div class="pending-actions">
+        <button class="btn btn-primary" id="apply-btn" onclick="applyChanges()">Apply Changes</button>
+        <button class="btn btn-discard" onclick="discardAll()">Discard All</button>
+    </div>
+</div>
+
+<div class="config-table-wrap">
+    <table>
+        <colgroup><col class="col-key" /><col class="col-value" /></colgroup>
+        <thead><tr><th>Key</th><th>Value</th></tr></thead>
+        <tbody id="config-body">
+            <tr><td colspan="2" style="padding:1.5rem;text-align:center;color:var(--color-text-faint);">Loading...</td></tr>
+        </tbody>
+    </table>
+</div>
+
+<script>
+(function () {
+    'use strict';
+    const MODULE = 'elections';
+    const PREFIX = 'Modules.' + MODULE + '.';
+    const DESCRIPTIONS = {
+        'TitleColor':       'Color code (0\u2013255) or color pattern name applied to player titles. Use the swatch to pick a color, or the Pattern button to browse named patterns.',
+        'ElectionDuration': 'How long an election runs before it automatically ends. Uses game-time period format (e.g. "2 days", "1 week").',
+    };
+    const COLOR_PICKER_KEYS = new Set(['TitleColor']);
+
+    const pending = {};
+    let configData = {};
+
+    // One active swatch popup at a time.
+    let palettePopup = null;
+    let paletteOutsideHandler = null;
+
+    async function init() {
+        const res = await AdminAPI.get('/admin/api/v1/config');
+        if (!res.ok) { showStatus('Failed to load configuration: ' + res.error, false); return; }
+        const all = res.data.data || {};
+        for (const [fullKey, val] of Object.entries(all)) {
+            if (fullKey.startsWith(PREFIX)) {
+                configData[fullKey.slice(PREFIX.length)] = String(val);
+            }
+        }
+        buildTable();
+    }
+
+    // -------------------------------------------------------------------------
+    // Table
+    // -------------------------------------------------------------------------
+    function buildTable() {
+        const tbody = document.getElementById('config-body');
+        tbody.innerHTML = '';
+        const keys = Object.keys(configData).sort();
+        if (keys.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="2" class="no-keys">No configuration keys found for this module.</td></tr>';
+            return;
+        }
+        for (const key of keys) {
+            const value = configData[key];
+            const tr = document.createElement('tr');
+            tr.dataset.key = key;
+
+            if (COLOR_PICKER_KEYS.has(key)) {
+                const td1 = document.createElement('td');
+                td1.className = 'key-cell';
+                td1.title = PREFIX + key;
+                td1.textContent = key;
+
+                const td2 = document.createElement('td');
+                td2.className = 'value-cell';
+                td2.appendChild(buildColorPickerWidget(key, value));
+
+                tr.appendChild(td1);
+                tr.appendChild(td2);
+            } else {
+                tr.innerHTML =
+                    '<td class="key-cell" title="' + escAttr(PREFIX + key) + '">' + escHtml(key) + '</td>' +
+                    '<td class="value-cell">' +
+                        '<span class="value-display" title="' + escAttr(value) + '" onclick="startEdit(\'' + escAttr(key) + '\')">' + escHtml(value) + '</span>' +
+                        '<span class="edit-form" id="edit-' + cssId(key) + '">' +
+                            '<input type="text" id="input-' + cssId(key) + '" value="' + escAttr(value) + '" onkeydown="editKeydown(event, \'' + escAttr(key) + '\')" />' +
+                            '<button class="btn-save" onclick="stageEdit(\'' + escAttr(key) + '\')">Stage</button>' +
+                            '<button class="btn-cancel" onclick="cancelEdit(\'' + escAttr(key) + '\')">Cancel</button>' +
+                        '</span>' +
+                    '</td>';
+            }
+
+            tbody.appendChild(tr);
+
+            if (DESCRIPTIONS[key]) {
+                const dr = document.createElement('tr');
+                dr.className = 'desc-row';
+                dr.dataset.descFor = key;
+                dr.innerHTML = '<td colspan="2">' + escHtml(DESCRIPTIONS[key]) + '</td>';
+                tbody.appendChild(dr);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Color picker widget
+    // -------------------------------------------------------------------------
+    function buildColorPickerWidget(key, value) {
+        const wrap = document.createElement('div');
+        wrap.className = 'color-picker-cell';
+
+        const inputRow = document.createElement('div');
+        inputRow.className = 'color-picker-input-row';
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.id = 'cpinput-' + cssId(key);
+        input.value = pending[key] !== undefined ? pending[key] : value;
+        input.placeholder = 'e.g. 220 or rainbow';
+        input.addEventListener('keydown', e => { if (e.key === 'Enter') stageColorValue(key); });
+        inputRow.appendChild(input);
+
+        // Swatch button + popup anchor
+        const swatchWrap = document.createElement('div');
+        swatchWrap.className = 'cp-swatch-wrap';
+
+        const btnSwatch = document.createElement('button');
+        btnSwatch.type = 'button';
+        btnSwatch.className = 'btn-search';
+        btnSwatch.textContent = '\uD83C\uDFA8 Color';
+        btnSwatch.title = 'Pick from 256-color palette';
+        btnSwatch.addEventListener('click', e => { e.stopPropagation(); togglePalette(key, swatchWrap); });
+        swatchWrap.appendChild(btnSwatch);
+        inputRow.appendChild(swatchWrap);
+
+        // Color pattern picker button
+        const btnPattern = document.createElement('button');
+        btnPattern.type = 'button';
+        btnPattern.className = 'btn-search';
+        btnPattern.textContent = '\uD83D\uDD0D Pattern';
+        btnPattern.title = 'Browse color patterns';
+        btnPattern.addEventListener('click', () => openColorPatternPicker(key));
+        inputRow.appendChild(btnPattern);
+
+        const stageBtn = document.createElement('button');
+        stageBtn.type = 'button';
+        stageBtn.className = 'color-picker-stage';
+        stageBtn.textContent = 'Stage';
+        stageBtn.addEventListener('click', () => stageColorValue(key));
+        inputRow.appendChild(stageBtn);
+
+        wrap.appendChild(inputRow);
+        return wrap;
+    }
+
+    function stageColorValue(key) {
+        const input = document.getElementById('cpinput-' + cssId(key));
+        if (!input) return;
+        const newVal = input.value.trim();
+        const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]');
+        if (newVal === configData[key]) {
+            delete pending[key];
+            if (tr) tr.style.background = '';
+        } else {
+            pending[key] = newVal;
+            if (tr) tr.style.background = '#fffbe6';
+        }
+        renderPendingPanel();
+    }
+
+    // ── 256-color palette popup ──────────────────────────────────────────────
+    function togglePalette(key, anchor) {
+        if (palettePopup) { closePalette(); return; }
+
+        const input = document.getElementById('cpinput-' + cssId(key));
+        const currentCode = input ? parseInt(input.value, 10) : NaN;
+
+        palettePopup = document.createElement('div');
+        palettePopup.className = 'ansi-palette-popup';
+
+        let html = '';
+        for (let i = 0; i < 256; i++) {
+            const sel = i === currentCode ? ' selected' : '';
+            html += '<div class="ansi-palette-cell' + sel + '" data-code="' + i + '" style="background:' + AnsiColors.toHex(i) + '" title="' + i + '"></div>';
+        }
+        palettePopup.innerHTML = html;
+
+        palettePopup.addEventListener('click', function (e) {
+            const cell = e.target.closest('.ansi-palette-cell');
+            if (!cell) return;
+            if (input) { input.value = cell.dataset.code; stageColorValue(key); }
+            closePalette();
+        });
+
+        document.body.appendChild(palettePopup);
+
+        const btn = anchor.querySelector('.btn-search');
+        const rect = btn.getBoundingClientRect();
+        palettePopup.style.top  = (rect.bottom + window.scrollY + 4) + 'px';
+        palettePopup.style.left = rect.left + 'px';
+
+        paletteOutsideHandler = function (e) {
+            if (palettePopup && !palettePopup.contains(e.target) && e.target !== btn) {
+                closePalette();
+            }
+        };
+        setTimeout(() => document.addEventListener('click', paletteOutsideHandler), 0);
+    }
+
+    function closePalette() {
+        if (palettePopup) { palettePopup.remove(); palettePopup = null; }
+        if (paletteOutsideHandler) { document.removeEventListener('click', paletteOutsideHandler); paletteOutsideHandler = null; }
+    }
+
+    // ── Color pattern picker ─────────────────────────────────────────────────
+    function openColorPatternPicker(key) {
+        SelectDialog.open({
+            title: 'Pick a Color Pattern',
+            apiPath: '/admin/api/v1/colorpatterns',
+            transform: data => Object.keys(data).sort().map(k => ({
+                label: k,
+                value: k,
+                html: AnsiColors.swatchHtml(data[k], 12),
+            })),
+            onSelect: value => {
+                const input = document.getElementById('cpinput-' + cssId(key));
+                if (input) { input.value = value; stageColorValue(key); }
+            },
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Plain text editor
+    // -------------------------------------------------------------------------
+    window.startEdit = function (key) {
+        cancelAllEdits();
+        const form = document.getElementById('edit-' + cssId(key));
+        const display = form.previousElementSibling;
+        display.style.display = 'none';
+        form.classList.add('active');
+        const input = document.getElementById('input-' + cssId(key));
+        if (pending[key] !== undefined) input.value = pending[key];
+        input.focus(); input.select();
+    };
+
+    window.cancelEdit = function (key) {
+        const form = document.getElementById('edit-' + cssId(key));
+        if (!form) return;
+        form.classList.remove('active');
+        form.previousElementSibling.style.display = '';
+    };
+
+    window.editKeydown = function (e, key) {
+        if (e.key === 'Enter')  stageEdit(key);
+        if (e.key === 'Escape') cancelEdit(key);
+    };
+
+    window.stageEdit = function (key) {
+        const input = document.getElementById('input-' + cssId(key));
+        const newVal = input.value;
+        cancelEdit(key);
+        if (newVal === configData[key] && pending[key] === undefined) return;
+        if (newVal === configData[key]) { delete pending[key]; }
+        else { pending[key] = newVal; }
+        const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]');
+        if (tr) { tr.querySelector('.value-display').textContent = newVal; tr.style.background = pending[key] !== undefined ? '#fffbe6' : ''; }
+        renderPendingPanel();
+    };
+
+    function cancelAllEdits() {
+        document.querySelectorAll('.edit-form.active').forEach(f => { f.classList.remove('active'); f.previousElementSibling.style.display = ''; });
+    }
+
+    // -------------------------------------------------------------------------
+    // Pending panel
+    // -------------------------------------------------------------------------
+    function renderPendingPanel() {
+        const panel = document.getElementById('pending-panel');
+        const list  = document.getElementById('pending-list');
+        const keys  = Object.keys(pending);
+        if (keys.length === 0) { panel.style.display = 'none'; return; }
+        panel.style.display = 'block';
+        list.innerHTML = '';
+        for (const key of keys.sort()) {
+            const item = document.createElement('div');
+            item.className = 'pending-item';
+            item.innerHTML = '<span class="pending-key">' + escHtml(key) + '</span><span class="pending-arrow">&rarr;</span><span class="pending-val">' + escHtml(pending[key]) + '</span><button class="pending-remove" onclick="removePending(\'' + escAttr(key) + '\')">\u00d7</button>';
+            list.appendChild(item);
+        }
+    }
+
+    window.removePending = function (key) {
+        delete pending[key];
+        const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]');
+        if (tr) tr.style.background = '';
+        if (COLOR_PICKER_KEYS.has(key)) {
+            const input = document.getElementById('cpinput-' + cssId(key));
+            if (input) input.value = configData[key] || '';
+        } else {
+            if (tr) tr.querySelector('.value-display').textContent = configData[key];
+        }
+        renderPendingPanel();
+    };
+
+    window.discardAll = function () {
+        for (const key of Object.keys(pending)) {
+            const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]');
+            if (tr) tr.style.background = '';
+            if (COLOR_PICKER_KEYS.has(key)) {
+                const input = document.getElementById('cpinput-' + cssId(key));
+                if (input) input.value = configData[key] || '';
+            } else {
+                if (tr) tr.querySelector('.value-display').textContent = configData[key];
+            }
+            delete pending[key];
+        }
+        renderPendingPanel();
+    };
+
+    // -------------------------------------------------------------------------
+    // Apply
+    // -------------------------------------------------------------------------
+    window.applyChanges = async function () {
+        if (Object.keys(pending).length === 0) return;
+        const btn = document.getElementById('apply-btn');
+        btn.disabled = true; btn.textContent = 'Applying...';
+        const payload = {};
+        for (const [key, val] of Object.entries(pending)) { payload[PREFIX + key] = val; }
+        const res = await AdminAPI.patch('/admin/api/v1/config', payload);
+        btn.disabled = false; btn.textContent = 'Apply Changes';
+        if (!res.ok) { showStatus('Error: ' + res.error, false); return; }
+        const result = res.data.data || {};
+        const applied  = (result.applied  || []).map(k => k.startsWith(PREFIX) ? k.slice(PREFIX.length) : k);
+        const rejected = (result.rejected || []).map(k => k.startsWith(PREFIX) ? k.slice(PREFIX.length) : k);
+        for (const key of applied) { configData[key] = pending[key]; delete pending[key]; const tr = document.querySelector('tr[data-key="' + escAttr(key) + '"]'); if (tr) tr.style.background = ''; }
+        let msg = '';
+        if (applied.length)  msg += 'Applied: ' + applied.join(', ') + '. ';
+        if (rejected.length) msg += 'Rejected (locked): ' + rejected.join(', ') + '.';
+        showStatus(msg || 'No changes applied.', rejected.length === 0);
+        renderPendingPanel();
+    };
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+    function showStatus(msg, success) {
+        const bar = document.getElementById('status-bar');
+        bar.textContent = msg; bar.className = success ? 'success' : 'error';
+        clearTimeout(bar._t); bar._t = setTimeout(() => { bar.className = ''; bar.style.display = 'none'; }, 6000);
+    }
+    function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+    function escAttr(s) { return String(s).replace(/'/g, "\\'").replace(/"/g, '&quot;'); }
+    function cssId(key) { return key.replace(/[^a-zA-Z0-9_-]/g, '_'); }
+
+    init();
+})();
+</script>
+
+{{template "footer" .}}

--- a/modules/elections/files/datafiles/templates/help/elections.template
+++ b/modules/elections/files/datafiles/templates/help/elections.template
@@ -1,0 +1,51 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">elections</ansi>
+
+  Elections are system-wide events where players can nominate
+  candidates and vote for their preferred leader.
+
+  <ansi fg="yellow">How Elections Work</ansi>
+
+  When an election is announced, a notification is sent to all
+  online players. The election goes through two phases:
+
+    <ansi fg="white-bold">Nomination Phase</ansi>
+      Any player at a polling location can nominate any online
+      player (including themselves) using:
+
+        <ansi fg="command">nominate <playername></ansi>
+
+      A nomination alert is broadcast to everyone when a new
+      candidate is added to the ballot.
+
+    <ansi fg="white-bold">Voting Phase</ansi>
+      Also at a polling location, you can view the candidates
+      and cast your vote:
+
+        <ansi fg="command">vote</ansi>            - Lists all current candidates.
+        <ansi fg="command">vote <playername></ansi> - Casts your vote for that candidate.
+
+      Each player may only vote once per election.
+
+  <ansi fg="yellow">Polling Locations</ansi>
+
+  Rooms tagged with <ansi fg="cyan">election poll</ansi> are polling locations.
+  The <ansi fg="command">nominate</ansi> and <ansi fg="command">vote</ansi> commands only work at these locations.
+
+  <ansi fg="yellow">Titles</ansi>
+
+  The winner of an election receives the election title, which
+  is displayed after their name for all to see.
+  Example: <ansi fg="username">Sammy</ansi>, <ansi fg="yellow">Mayor of Frostfang</ansi>
+
+  <ansi fg="yellow">The Coffer</ansi>
+
+  Each zone may have a coffer room (tagged <ansi fg="cyan">coffer</ansi>). A portion
+  of every purchase made in that zone flows into the coffer.
+  Only the current title-holder for that zone can deposit or
+  withdraw gold from the coffer.
+
+    <ansi fg="command">coffer</ansi>                   - View the coffer balance.
+    <ansi fg="command">coffer deposit <amount></ansi>  - Deposit gold (title-holder only).
+    <ansi fg="command">coffer withdraw <amount></ansi> - Withdraw gold (title-holder only).
+
+<ansi fg="yellow-bold">*****************************************************</ansi>

--- a/modules/fasttravel/fasttravel.go
+++ b/modules/fasttravel/fasttravel.go
@@ -39,6 +39,7 @@ func init() {
 	m.plug.AddUserCommand(`fasttravel`, m.fastTravelCommand, false, false)
 
 	m.plug.Web.AdminPage("Config", "fasttravel-config", "html/admin/fasttravel-config.html", true, "Modules", "Fast Travel", nil)
+	m.plug.Web.AdminPage("About", "fasttravel-about", "html/admin/fasttravel-about.html", true, "Modules", "Fast Travel", nil)
 
 	m.plug.ReserveTags(fastTravelTag)
 

--- a/modules/fasttravel/files/datafiles/html/admin/fasttravel-about.html
+++ b/modules/fasttravel/files/datafiles/html/admin/fasttravel-about.html
@@ -1,0 +1,41 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Fast Travel</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Fast Travel module lets players teleport instantly between discovered fast travel stations. A station is discovered when a player types <code>fasttravel</code> or <code>look fast travel</code> in a room tagged with <code>fast travel</code>.</p>
+    <p>Once at a known station, <code>fasttravel</code> lists all other discovered destinations. <code>fasttravel &lt;destination&gt;</code> teleports the player there immediately. Travel may optionally require gold (<code>GoldCost</code>) or a consumable item (<code>RequiredItemId</code>). Certain item types or subtypes can be configured to block travel via <code>DisallowedItemTypes</code> and <code>DisallowedItemSubtypes</code>.</p>
+    <p>Per-player unlock data is persisted across sessions so players keep their discovered stations after logging out.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <table class="tag-table">
+        <thead><tr><th>Tag</th><th>Effect</th></tr></thead>
+        <tbody>
+            <tr>
+                <td class="tag-name">fast travel</td>
+                <td>Marks the room as a fast travel station. Using the <code>fasttravel</code> command or examining the station here unlocks it for the player. When a player looks at the room, an alert is shown with instructions for using the network.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+{{template "footer" .}}

--- a/modules/follow/files/datafiles/html/admin/follow-about.html
+++ b/modules/follow/files/datafiles/html/admin/follow-about.html
@@ -1,0 +1,34 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Follow</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Follow module lets players and mobs trail another character through the world. When a leader moves through an exit, all followers automatically move through the same exit in their wake.</p>
+    <p>Players use <code>follow &lt;name&gt;</code> to begin following a player or mob, <code>follow stop</code> to stop following, and <code>follow lose</code> to shed all followers. An optional duration argument (e.g. <code>follow guard 30 real minutes</code>) limits how long the follow lasts. The <code>DefaultFollowPeriod</code> config key sets the default duration when none is given.</p>
+    <p>Following is automatically cancelled on party changes, player death, mob death, or if the leader teleports (moves without using a named exit). Mobs that are following suppress their idle AI so they do not wander away.</p>
+    <p>A scripting export <code>GetFollowers</code> is available for scripts that need to inspect who is following a given actor.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/follow/follow.go
+++ b/modules/follow/follow.go
@@ -53,7 +53,8 @@ func init() {
 		panic(err)
 	}
 
-	f.plug.Web.AdminPage("Config", "follow-config", "html/admin/follow-config.html", true, "Modules", "Follow", nil) //
+	f.plug.Web.AdminPage("Config", "follow-config", "html/admin/follow-config.html", true, "Modules", "Follow", nil)
+	f.plug.Web.AdminPage("About", "follow-about", "html/admin/follow-about.html", true, "Modules", "Follow", nil) //
 	// Register any user/mob commands
 	//
 	f.plug.AddUserCommand(`follow`, f.followUserCommand, true, false)

--- a/modules/gambling/files/datafiles/html/admin/gambling-about.html
+++ b/modules/gambling/files/datafiles/html/admin/gambling-about.html
@@ -1,0 +1,50 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Gambling</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Gambling module adds two arcade-style gambling fixtures: a slot machine and a claw machine. Players interact with them using the <code>play slots</code> or <code>play claw machine</code> command while in a room that has the appropriate tag.</p>
+    <p><strong>Slot machine</strong> — players pay a configurable cost per spin and win gold based on matching symbols. A portion of each losing spin accumulates in a jackpot that grows until someone hits the jackpot combination. The jackpot is persisted across restarts.</p>
+    <p><strong>Claw machine</strong> — players pay a cost per attempt and have a configurable chance to win a prize item from the machine's prize pool.</p>
+    <p>Both fixtures can be examined with <code>look slot machine</code> or <code>look claw machine</code> to see a description and current state. The module also registers several prop items (dice, lucky coin, tarot deck, magic 8-ball, empty bottle, deck of cards) with scripted behaviors.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <table class="tag-table">
+        <thead><tr><th>Tag</th><th>Effect</th></tr></thead>
+        <tbody>
+            <tr>
+                <td class="tag-name">slots</td>
+                <td>Marks the room as containing a slot machine. Either <code>slots</code> or <code>slot machine</code> activates the fixture. When a player looks at the room, an alert is shown inviting them to look at or play the slot machine.</td>
+            </tr>
+            <tr>
+                <td class="tag-name">slot machine</td>
+                <td>Alias for the <code>slots</code> tag. Either value activates the same slot machine fixture in the room.</td>
+            </tr>
+            <tr>
+                <td class="tag-name">claw machine</td>
+                <td>Marks the room as containing a claw machine. When a player looks at the room, an alert is shown inviting them to look at or play the claw machine.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+{{template "footer" .}}

--- a/modules/gambling/gambling.go
+++ b/modules/gambling/gambling.go
@@ -33,6 +33,7 @@ func init() {
 	}
 
 	g.plug.Web.AdminPage("Config", "gambling-config", "html/admin/gambling-config.html", true, "Modules", "Gambling", nil)
+	g.plug.Web.AdminPage("About", "gambling-about", "html/admin/gambling-about.html", true, "Modules", "Gambling", nil)
 	for itemId, path := range map[int]string{
 		1040000: `files/datafiles/items/1040000-6_sided_die.js`,
 		1040001: `files/datafiles/items/1040001-lucky_coin.js`,

--- a/modules/gmcp/files/datafiles/html/admin/gmcp-about.html
+++ b/modules/gmcp/files/datafiles/html/admin/gmcp-about.html
@@ -1,0 +1,34 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">GMCP</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The GMCP module implements the Generic MUD Communication Protocol, a telnet sub-negotiation extension that allows the server to send structured JSON data alongside normal text output. This enables feature-rich MUD clients such as Mudlet to display live character stats, room data, map information, and more in dedicated UI panels.</p>
+    <p>On connection the module negotiates GMCP capability with the client. WebSocket connections are treated as always-enabled and receive GMCP payloads via a text prefix format (<code>!!GMCP(...)</code>) instead of telnet IAC sequences.</p>
+    <p>Supported GMCP namespaces include <code>Char</code> (character stats, inventory, skills, vitals), <code>Room</code> (room details and map data), <code>World</code> (server-wide info), <code>Party</code> (party state), <code>Game</code> (server info), <code>Gametime</code> (in-game time), <code>Comm</code> (channel messages), and <code>External.Discord</code> (Discord rich presence integration).</p>
+    <p>Other modules can send GMCP events by calling the exported <code>SendGMCPEvent(userId, namespace, payload)</code> function. The <code>IsMudlet(connectionId)</code> export lets other modules adapt output for Mudlet clients.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/gmcp/gmcp.Mudlet.go
+++ b/modules/gmcp/gmcp.Mudlet.go
@@ -87,6 +87,7 @@ func init() {
 	}
 
 	g.plug.Web.AdminPage("Config", "gmcp-config", "html/admin/gmcp-config.html", true, "Modules", "GMCP", nil)
+	g.plug.Web.AdminPage("About", "gmcp-about", "html/admin/gmcp-about.html", true, "Modules", "GMCP", nil)
 
 	// Register callbacks for load/save
 	g.plug.Callbacks.SetOnLoad(g.load)

--- a/modules/leaderboards/files/datafiles/html/admin/leaderboards-about.html
+++ b/modules/leaderboards/files/datafiles/html/admin/leaderboards-about.html
@@ -1,0 +1,33 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Leaderboards</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Leaderboards module maintains ranked lists of the top players across four categories: Gold (on-hand plus bank), Experience, Kills, and Exploration (total unique rooms visited). Leaderboards are recalculated at most once per real-time minute and consider both online and offline characters, including alt characters if the Alt Characters module is loaded.</p>
+    <p>Players can view the leaderboards in-game with the <code>leaderboard</code> command. A public web page at <code>/leaderboards</code> also displays the current standings for visitors who are not logged in.</p>
+    <p>The size of each leaderboard is individually configurable: <code>GoldLBSize</code>, <code>ExperienceLBSize</code>, <code>KillsLBSize</code>, and <code>ExplorationLBSize</code>. Setting any of these to 0 disables that particular leaderboard.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/leaderboards/leaderboards.go
+++ b/modules/leaderboards/leaderboards.go
@@ -53,7 +53,8 @@ func init() {
 		panic(err)
 	}
 
-	t.plug.Web.AdminPage("Config", "leaderboards-config", "html/admin/leaderboards-config.html", true, "Modules", "Leaderboards", nil) //
+	t.plug.Web.AdminPage("Config", "leaderboards-config", "html/admin/leaderboards-config.html", true, "Modules", "Leaderboards", nil)
+	t.plug.Web.AdminPage("About", "leaderboards-about", "html/admin/leaderboards-about.html", true, "Modules", "Leaderboards", nil) //
 	// Register any user/mob commands
 	//
 	t.plug.AddUserCommand(`leaderboard`, t.leaderboardCommand, true, false)

--- a/modules/mudmail/files/datafiles/html/admin/mudmail-about.html
+++ b/modules/mudmail/files/datafiles/html/admin/mudmail-about.html
@@ -1,0 +1,34 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Mudmail</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Mudmail module provides an in-game mailbox system. Players can send messages to other players, including gold and item attachments. Messages are delivered to the recipient's inbox immediately if they are online, or stored for retrieval when they next log in.</p>
+    <p>Reading a message that contains a gold attachment transfers the gold to the reader's character. Reading a message with an item attachment places the item into the reader's backpack (if space permits). Unread messages with attachments are preserved until the player can receive them.</p>
+    <p>Other modules can deliver mail programmatically via the exported <code>SendMudMail(userId, senderName, message, gold, *item)</code> function. The Auctions module uses this to notify offline winners and sellers.</p>
+    <p>An admin panel provides a view of all stored inboxes, with the ability to inspect and delete individual messages.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/mudmail/mudmail.go
+++ b/modules/mudmail/mudmail.go
@@ -62,6 +62,17 @@ func init() {
 		nil,
 	)
 
+	// Admin page: About.
+	m.plug.Web.AdminPage(
+		"About",
+		"mudmail-about",
+		"html/admin/mudmail-about.html",
+		true,
+		"Modules",
+		"Mudmail",
+		nil,
+	)
+
 	// Admin API endpoints.
 	m.plug.Web.AdminAPIEndpoint("GET", "mudmail", m.apiAdminListMudmail)
 	m.plug.Web.AdminAPIEndpoint("GET", "mudmail-body/{user_id}/{timestamp}", m.apiAdminGetMudmailBody)

--- a/modules/newbieguide/files/datafiles/html/admin/newbieguide-about.html
+++ b/modules/newbieguide/files/datafiles/html/admin/newbieguide-about.html
@@ -1,0 +1,34 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Newbie Guide</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Newbie Guide module automatically spawns a helpful guide NPC to accompany new players as they explore the world. The guide appears whenever a low-level player moves to a new room (subject to a cooldown) and introduces itself, offering to create a portal back to Town Square on request.</p>
+    <p>The guide follows the player as a charmed mob. Once the player reaches the configured <code>MaximumPlayerLevel</code> (default 5), the guide bids them farewell and despawns. The guide mob ID is configurable via <code>GuideMobId</code> (default 38).</p>
+    <p>The guide will not spawn inside the character creation area (rooms 900–999) or respawn within the cooldown window (300 real seconds by default).</p>
+    <p>A <code>PlayerGuideMobId</code> function is exported so other modules can identify and interact with the guide mob.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/newbieguide/newbieguide.go
+++ b/modules/newbieguide/newbieguide.go
@@ -35,6 +35,7 @@ func init() {
 	}
 
 	mod.plug.Web.AdminPage("Config", "newbieguide-config", "html/admin/newbieguide-config.html", true, "Modules", "Newbie Guide", nil)
+	mod.plug.Web.AdminPage("About", "newbieguide-about", "html/admin/newbieguide-about.html", true, "Modules", "Newbie Guide", nil)
 	events.RegisterListener(events.RoomChange{}, mod.spawnGuide)
 	events.RegisterListener(events.LevelUp{}, mod.checkGuide)
 

--- a/modules/storage/files/datafiles/html/admin/storage-about.html
+++ b/modules/storage/files/datafiles/html/admin/storage-about.html
@@ -1,0 +1,42 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Storage</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Storage module gives players a personal item vault separate from their backpack. Players can store and retrieve items at any room tagged with <code>storage</code> using the <code>storage add &lt;item&gt;</code> and <code>storage remove &lt;item&gt;</code> commands. Typing <code>storage</code> alone lists everything currently in storage. Up to 20 items may be stored per player.</p>
+    <p>Storage data is persisted per-player and survives logouts. The module exports <code>GetStorageItems</code>, <code>AddStorageItem</code>, and <code>RemoveStorageItem</code> functions for use by other modules and scripts.</p>
+    <p>An admin panel provides a read-only view of all players' stored items, with the ability to delete individual entries. A documented REST API is also available for external tooling.</p>
+    <p>Tab-completion is provided for both the <code>add</code> and <code>remove</code> subcommands.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <table class="tag-table">
+        <thead><tr><th>Tag</th><th>Effect</th></tr></thead>
+        <tbody>
+            <tr>
+                <td class="tag-name">storage</td>
+                <td>Marks the room as a storage location. The <code>storage</code> command only functions in rooms with this tag. When a player looks at the room, an alert is shown prompting them to use the <code>storage</code> command to manage their vault.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+{{template "footer" .}}

--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -67,6 +67,16 @@ func init() {
 		nil,
 	)
 
+	m.plug.Web.AdminPage(
+		"About",
+		"storage-about",
+		"html/admin/storage-about.html",
+		true,
+		"Modules",
+		"Storage",
+		nil,
+	)
+
 	m.plug.Web.AdminAPIEndpoint("GET", "storage", m.apiAdminGetStorage)
 	m.plug.Web.AdminAPIEndpoint("DELETE", "storage", m.apiAdminDeleteStorageItem)
 

--- a/modules/time/files/datafiles/html/admin/time-about.html
+++ b/modules/time/files/datafiles/html/admin/time-about.html
@@ -1,0 +1,32 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Time</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Time module adds the <code>time</code> command, which displays the current in-game date and time. The output includes the current hour and minute, whether it is day or night, the day of the year, the year number, the current month name from the fantasy calendar, and the zodiac animal for the current year.</p>
+    <p>This module has no configuration keys and no persistent state. It is a lightweight read-only interface to the engine's <code>gametime</code> package.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/time/time.go
+++ b/modules/time/time.go
@@ -45,6 +45,7 @@ func init() {
 	//
 	// Register any user/mob commands
 	//
+	plug.Web.AdminPage("About", "time-about", "html/admin/time-about.html", true, "Modules", "Time", nil)
 	plug.AddUserCommand(`time`, TimeCommand, true, false)
 }
 

--- a/modules/webhelp/files/datafiles/html/admin/webhelp-about.html
+++ b/modules/webhelp/files/datafiles/html/admin/webhelp-about.html
@@ -1,0 +1,33 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Web Help</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Web Help module exposes the game's in-game help system as public web pages. It provides two routes: <code>/help</code> lists all non-admin help topics grouped by category, and <code>/help-details?search=&lt;topic&gt;</code> renders the full content of a specific help topic with ANSI color codes converted to HTML.</p>
+    <p>These pages are publicly accessible without authentication, making the help content browsable outside the game client. Skill topics are automatically grouped under the <em>skills</em> category regardless of their declared category.</p>
+    <p>This module has no configuration keys, no persistent state, and no in-game commands.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/webhelp/webhelp.go
+++ b/modules/webhelp/webhelp.go
@@ -48,6 +48,7 @@ func init() {
 
 	w.plug.Web.WebPage(`Help`, `/help`, `help.html`, true, w.getHelpCategories)
 	w.plug.Web.WebPage(`Help Topic`, `/help-details`, `help-details.html`, false, w.getHelpCommand)
+	w.plug.Web.AdminPage("About", "webhelp-about", "html/admin/webhelp-about.html", true, "Modules", "Web Help", nil)
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/modules/zombiemode/files/datafiles/html/admin/zombiemode-about.html
+++ b/modules/zombiemode/files/datafiles/html/admin/zombiemode-about.html
@@ -1,0 +1,34 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .no-tags { font-size: 0.875rem; color: var(--color-text-faint); font-style: italic; }
+</style>
+
+<h1 class="about-h1">Zombie Mode</h1>
+<p class="about-subtitle">Module overview and room tag reference.</p>
+
+<div class="about-section">
+    <h2>Description</h2>
+    <p>The Zombie Mode module lets players put their character on autopilot. While active, the zombie AI automatically attacks nearby hostile mobs, loots corpses, rests when health is low, and optionally roams or follows a waypoint route. Any real keyboard input (other than a small set of status commands) immediately wakes the player and deactivates zombie mode.</p>
+    <p>Players configure their zombie behavior with the <code>zombie</code> command, setting combat targets, loot preferences, rest thresholds, roam radius, and waypoints. Multiple named profiles can be saved and activated by name. The <code>zombie status</code> sub-command shows the current session's running stats without waking the player.</p>
+    <p>When zombie mode ends (by player input, death, or logout) a session summary is displayed showing mobs killed, gold collected, experience gained, levels gained, rooms travelled, and items looted.</p>
+    <p>Per-player zombie configuration is persisted across logouts. The <code>zombieact</code> admin command can be used to manually trigger one AI tick for testing.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p class="no-tags">This module does not use any room tags.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/zombiemode/files/datafiles/html/admin/zombiemode-config.html
+++ b/modules/zombiemode/files/datafiles/html/admin/zombiemode-config.html
@@ -93,7 +93,7 @@
         if (!res.ok) { showStatus('Failed to load configuration: ' + res.error, false); return; }
         const all = res.data.data || {};
         for (const [fullKey, val] of Object.entries(all)) {
-            if (fullKey.startsWith(PREFIX)) {
+            if (fullKey.startsWith(PREFIX) && typeof val !== 'object') {
                 configData[fullKey.slice(PREFIX.length)] = String(val);
             }
         }

--- a/modules/zombiemode/zombiemode.go
+++ b/modules/zombiemode/zombiemode.go
@@ -29,6 +29,7 @@ func init() {
 	}
 
 	m.plug.Web.AdminPage("Config", "zombiemode-config", "html/admin/zombiemode-config.html", true, "Modules", "Zombie Mode", nil)
+	m.plug.Web.AdminPage("About", "zombiemode-about", "html/admin/zombiemode-about.html", true, "Modules", "Zombie Mode", nil)
 
 	m.plug.AddUserCommand(`zombie`, m.zombieCommand, false, false)
 	m.plug.AddUserCommand(`zombieact`, m.zombieActCommand, true, false)


### PR DESCRIPTION
# Description

Introduces the `elections` module and adds an About page to every module's admin nav section.

- **Elections module** - a new zone-based election system. Admins start an election (`election start <title>`) from within a zone; players then nominate candidates and cast votes at rooms tagged `election poll`. Elections end manually (`election end`) or automatically after the configured `ElectionDuration`. The winner receives a colored title appended to their name and exclusive access to the zone coffer. The coffer accumulates a 10% tax on all purchases made in the zone (capped at 100M gold) and is managed via the `coffer` command at rooms tagged `coffer`. Requires a new `events.Purchase` event fired from `buy.go`, and a new `OnGetFormattedName` hook in `internal/characters` for title injection.
- **Admin About pages** - every module now has an About page registered in its admin nav section. Each page describes what the module does and lists every room tag it uses along with what that tag does to a room. Modules that previously had no admin presence (clibridge, time, webhelp) gain a nav entry through their About page.
- Room instance save data can now be edited or cleared. This is primarily a debugging tool.
- Zombiemode config page wasn't showing all configuration options.
