### PR TITLE
Data and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin/
 private-notes.txt
 _datafiles/**/users/*
+_datafiles/**/telemetry/*
 _datafiles/**/plugin-data/*
 **/config-overrides.yaml
 _datafiles/config.yaml.bak.*

--- a/_datafiles/html/admin/telemetry-api.html
+++ b/_datafiles/html/admin/telemetry-api.html
@@ -1,0 +1,129 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 2rem; font-size: 0.9rem; }
+    .api-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .api-entry { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; }
+    .api-entry summary { display: flex; align-items: baseline; gap: 0.75rem; padding: 0.65rem 1rem; cursor: pointer; user-select: none; list-style: none; }
+    .api-entry summary::-webkit-details-marker { display: none; }
+    .api-entry summary::before { content: "\25B6"; font-size: 0.65rem; color: var(--color-text-faint); transition: transform 0.15s; flex-shrink: 0; }
+    .api-entry[open] summary::before { transform: rotate(90deg); }
+    .api-entry summary:hover { background: var(--color-surface-alt); }
+    .method { font-family: monospace; font-size: 0.8rem; font-weight: 700; padding: 0.15rem 0.45rem; border-radius: 3px; flex-shrink: 0; }
+    .method-get    { background: var(--color-success-bg); color: var(--color-success-text); }
+    .method-delete { background: var(--color-error-bg); color: var(--color-error-text); }
+    .api-path { font-family: monospace; font-size: 0.9rem; color: var(--color-primary); }
+    .api-desc { font-size: 0.85rem; color: var(--color-text-muted); margin-left: auto; text-align: right; }
+    .api-body { padding: 0.75rem 1rem 1rem; border-top: 1px solid var(--color-border-light); background: var(--color-surface-alt); }
+    .api-body p { font-size: 0.85rem; color: var(--color-text-tertiary); margin-bottom: 0.5rem; }
+    .curl-block { background: var(--color-code-bg); color: var(--color-code-text); font-family: monospace; font-size: 0.82rem; padding: 0.85rem 1rem; border-radius: 5px; white-space: pre; overflow-x: auto; line-height: 1.6; margin-bottom: 0.5rem; }
+    .curl-block .kw   { color: var(--color-api-kw); }
+    .curl-block .str  { color: var(--color-api-str); }
+    .curl-block .flag { color: var(--color-api-flag); }
+    .response-examples { margin-top: 1rem; display: flex; flex-direction: column; gap: 0.4rem; }
+    .resp-entry { border: 1px solid var(--color-border); border-radius: 4px; overflow: hidden; }
+    .resp-entry summary { display: flex; align-items: baseline; gap: 0.6rem; padding: 0.45rem 0.75rem; cursor: pointer; user-select: none; list-style: none; background: var(--color-page-bg); font-size: 0.82rem; }
+    .resp-entry summary::-webkit-details-marker { display: none; }
+    .resp-entry summary::before { content: "\25B6"; font-size: 0.6rem; color: var(--color-text-faint); transition: transform 0.15s; flex-shrink: 0; }
+    .resp-entry[open] summary::before { transform: rotate(90deg); }
+    .resp-entry summary:hover { background: var(--color-api-summary-hover); }
+    .resp-body { padding: 0.6rem 0.75rem 0.75rem; border-top: 1px solid var(--color-border-light); background: var(--color-surface-alt); }
+    .resp-body p { font-size: 0.82rem; color: var(--color-text-tertiary); margin-bottom: 0.4rem; }
+    .status-ok  { background: var(--color-success-bg); color: var(--color-success-text); }
+    .status-err { background: var(--color-error-bg); color: var(--color-error-text); }
+    .resp-label { font-size: 0.8rem; color: var(--color-text-tertiary); }
+    code { background: var(--color-border-faint); padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.85em; }
+    .params-table { width: 100%; border-collapse: collapse; font-size: 0.83rem; margin: 0.6rem 0 0.25rem; }
+    .params-table th { text-align: left; padding: 0.3rem 0.6rem; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-text-muted); border-bottom: 1px solid var(--color-border); }
+    .params-table td { padding: 0.35rem 0.6rem; border-bottom: 1px solid var(--color-border-faint); vertical-align: top; }
+    .params-table tr:last-child td { border-bottom: none; }
+    .param-name { font-family: monospace; color: var(--color-primary); }
+    .param-opt  { font-size: 0.72rem; color: var(--color-text-faint); }
+</style>
+
+<h1>Telemetry API Reference</h1>
+<p class="subtitle">REST endpoints for querying and clearing aggregated game event counters.</p>
+
+<div class="api-list">
+
+    <details class="api-entry" open>
+        <summary>
+            <span class="method method-get">GET</span>
+            <span class="api-path">/admin/api/v1/telemetry</span>
+            <span class="api-desc">Query telemetry records</span>
+        </summary>
+        <div class="api-body">
+            <p>Returns an array of <code>Record</code> objects matching the supplied filters. All parameters are optional; omitting a parameter matches any value for that field. Results are sorted by <code>count</code> descending by default.</p>
+            <table class="params-table">
+                <thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
+                <tbody>
+                    <tr><td class="param-name">category</td><td>string <span class="param-opt">optional</span></td><td>One of <code>item_drop</code>, <code>item_pickup</code>, <code>mob_kill</code>, <code>player_death</code>, <code>item_purchase</code></td></tr>
+                    <tr><td class="param-name">itemId</td><td>int <span class="param-opt">optional</span></td><td>Filter by item spec ID</td></tr>
+                    <tr><td class="param-name">mobId</td><td>int <span class="param-opt">optional</span></td><td>Filter by mob spec ID</td></tr>
+                    <tr><td class="param-name">roomId</td><td>int <span class="param-opt">optional</span></td><td>Filter by room ID</td></tr>
+                    <tr><td class="param-name">zone</td><td>string <span class="param-opt">optional</span></td><td>Exact zone name match</td></tr>
+                    <tr><td class="param-name">date</td><td>string <span class="param-opt">optional</span></td><td>Exact date <code>YYYYMMDD</code>. Shorthand for <code>dateFrom</code> + <code>dateTo</code> set to the same value.</td></tr>
+                    <tr><td class="param-name">dateFrom</td><td>string <span class="param-opt">optional</span></td><td>Start of date range <code>YYYYMMDD</code>, inclusive</td></tr>
+                    <tr><td class="param-name">dateTo</td><td>string <span class="param-opt">optional</span></td><td>End of date range <code>YYYYMMDD</code>, inclusive</td></tr>
+                    <tr><td class="param-name">sort</td><td>string <span class="param-opt">optional</span></td><td><code>asc</code> or <code>desc</code> (default <code>desc</code>). Sorts by <code>count</code>.</td></tr>
+                </tbody>
+            </table>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">"http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/telemetry?category=item_drop&amp;sort=desc"</span></div>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">"http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/telemetry?category=mob_kill&amp;zone=frostfang&amp;dateFrom=20260101&amp;dateTo=20261231"</span></div>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">"http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/telemetry?category=item_drop&amp;itemId=42"</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":[
+  {"date":"20260510","category":"item_drop","itemid":42,"mobid":7,"roomid":100,"zone":"frostfang","count":14},
+  {"date":"20260510","category":"item_drop","itemid":42,"mobid":12,"roomid":105,"zone":"frostfang","count":3}
+]}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-delete">DELETE</span>
+            <span class="api-path">/admin/api/v1/telemetry</span>
+            <span class="api-desc">Clear matching telemetry records</span>
+        </summary>
+        <div class="api-body">
+            <p>Removes all records matching the supplied filters and saves the result to disk. Omit all parameters to clear every record. Accepts the same filter parameters as <code>GET</code> except <code>sort</code>.</p>
+            <table class="params-table">
+                <thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
+                <tbody>
+                    <tr><td class="param-name">category</td><td>string <span class="param-opt">optional</span></td><td>Restrict deletion to one category</td></tr>
+                    <tr><td class="param-name">zone</td><td>string <span class="param-opt">optional</span></td><td>Restrict deletion to one zone</td></tr>
+                    <tr><td class="param-name">date</td><td>string <span class="param-opt">optional</span></td><td>Delete records for a single day <code>YYYYMMDD</code></td></tr>
+                    <tr><td class="param-name">dateFrom</td><td>string <span class="param-opt">optional</span></td><td>Start of date range to delete, inclusive</td></tr>
+                    <tr><td class="param-name">dateTo</td><td>string <span class="param-opt">optional</span></td><td>End of date range to delete, inclusive</td></tr>
+                </tbody>
+            </table>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> DELETE \
+     <span class="str">"http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/telemetry?category=item_drop&amp;date=20260101"</span></div>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="flag">-X</span> DELETE \
+     <span class="str">"http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/telemetry?dateFrom=20260101&amp;dateTo=20260131"</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">500</span> <span class="resp-label">Save Error</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"telemetry.Save write: ..."}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+</div>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/telemetry.html
+++ b/_datafiles/html/admin/telemetry.html
@@ -1,0 +1,322 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    /* toolbar */
+    .toolbar { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.25rem; flex-wrap: wrap; }
+    .btn { padding: 0.4rem 1rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+    .btn-primary { background: var(--color-primary); color: var(--color-surface-white); }
+    .btn-primary:hover { background: var(--color-primary-hover); }
+    .btn-danger  { background: var(--color-danger); color: var(--color-surface-white); }
+    .btn-danger:hover { opacity: 0.85; }
+
+    /* filters */
+    .filters { display: flex; gap: 0.6rem; flex-wrap: wrap; align-items: flex-end; margin-bottom: 1.25rem; }
+    .filter-group { display: flex; flex-direction: column; gap: 0.2rem; }
+    .filter-group label { font-size: 0.72rem; font-weight: 600; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.03em; }
+    .filter-group input, .filter-group select {
+        padding: 0.35rem 0.55rem; border: 1px solid var(--color-border-medium); border-radius: 4px;
+        font-size: 0.85rem; font-family: inherit; background: var(--color-surface-white);
+        min-width: 120px;
+    }
+    .filter-group input:focus, .filter-group select:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; border-color: transparent; }
+
+    /* status */
+    .status-bar { display: none; padding: 0.5rem 0.85rem; border-radius: 4px; font-size: 0.85rem; margin-bottom: 1rem; }
+    .status-bar.success { background: var(--color-success-bg); color: var(--color-success-text); display: block; }
+    .status-bar.error   { background: var(--color-error-bg); color: var(--color-error-text); display: block; }
+
+    /* summary */
+    .summary { font-size: 0.82rem; color: var(--color-text-muted); margin-bottom: 0.75rem; }
+
+    /* table */
+    .tbl-wrap { overflow-x: auto; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    th {
+        background: var(--color-border-faint); padding: 0.45rem 0.9rem; text-align: left;
+        font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em;
+        font-weight: 600; color: var(--color-text-muted); border-bottom: 1px solid var(--color-border);
+        cursor: pointer; white-space: nowrap; user-select: none;
+    }
+    th:hover { background: var(--color-row-hover); }
+    td { padding: 0.5rem 0.9rem; border-bottom: 1px solid var(--color-border-faint); vertical-align: middle; }
+    tr:last-child td { border-bottom: none; }
+    tr:hover td { background: var(--color-row-hover); }
+    .num { font-family: monospace; font-weight: 600; color: var(--color-primary); }
+    .cat { font-size: 0.78rem; padding: 0.15rem 0.45rem; border-radius: 3px; background: var(--color-chip-bg); color: var(--color-chip-text); font-weight: 600; }
+    .id-prefix { color: var(--color-text-faint); font-size: 0.8em; }
+    .empty { text-align: center; padding: 3rem; color: var(--color-text-faint); font-size: 0.9rem; }
+    a.admin-link { color: var(--color-accent-link); text-decoration: none; }
+    a.admin-link:hover { text-decoration: underline; }
+</style>
+
+<h1>Telemetry</h1>
+<p class="subtitle">Aggregated game event counters. Each row represents a unique combination of date, category, and dimension fields.</p>
+
+<div id="status" class="status-bar"></div>
+
+<div class="filters">
+    <div class="filter-group">
+        <label>Category</label>
+        <select id="f-category">
+            <option value="">All</option>
+            <option value="item_drop">item_drop</option>
+            <option value="item_pickup">item_pickup</option>
+            <option value="mob_kill">mob_kill</option>
+            <option value="player_death">player_death</option>
+            <option value="item_purchase">item_purchase</option>
+        </select>
+    </div>
+    <div class="filter-group">
+        <label>Item ID</label>
+        <input type="number" id="f-itemId" placeholder="any" min="0">
+    </div>
+    <div class="filter-group">
+        <label>Mob ID</label>
+        <input type="number" id="f-mobId" placeholder="any" min="0">
+    </div>
+    <div class="filter-group">
+        <label>Room ID</label>
+        <input type="number" id="f-roomId" placeholder="any" min="0">
+    </div>
+    <div class="filter-group">
+        <label>Zone</label>
+        <input type="text" id="f-zone" placeholder="any">
+    </div>
+    <div class="filter-group">
+        <label>Date From (YYYYMMDD)</label>
+        <input type="text" id="f-dateFrom" placeholder="e.g. 20260101" maxlength="8">
+    </div>
+    <div class="filter-group">
+        <label>Date To (YYYYMMDD)</label>
+        <input type="text" id="f-dateTo" placeholder="e.g. 20261231" maxlength="8">
+    </div>
+    <div class="filter-group">
+        <label>Sort</label>
+        <select id="f-sort">
+            <option value="desc">Count desc</option>
+            <option value="asc">Count asc</option>
+        </select>
+    </div>
+    <div class="filter-group" style="justify-content: flex-end;">
+        <label>&nbsp;</label>
+        <button class="btn btn-primary" onclick="loadData()">Query</button>
+    </div>
+</div>
+
+<div class="toolbar">
+    <button class="btn btn-danger" onclick="clearData()">Clear Matching Records</button>
+    <span style="font-size:0.8rem;color:var(--color-text-muted)">Clears records matching the current filters above.</span>
+</div>
+
+<div id="summary" class="summary"></div>
+
+<div class="tbl-wrap">
+    <table id="data-table">
+        <thead>
+            <tr>
+                <th onclick="sortBy('date')">Date</th>
+                <th onclick="sortBy('category')">Category</th>
+                <th onclick="sortBy('itemid')">Item</th>
+                <th onclick="sortBy('mobid')">Mob</th>
+                <th onclick="sortBy('roomid')">Room</th>
+                <th onclick="sortBy('zone')">Zone</th>
+                <th onclick="sortBy('count')">Count</th>
+            </tr>
+        </thead>
+        <tbody id="data-body">
+            <tr><td colspan="7" class="empty">Use the filters above and click Query to load data.</td></tr>
+        </tbody>
+    </table>
+</div>
+
+<script>
+let currentData = [];
+let sortKey = 'count';
+let sortAsc = false;
+
+// Lookup maps populated once on page load: id -> name
+const itemNames = {};
+const mobNames  = {};
+const roomTitles = {};
+
+async function initLookups() {
+    try {
+        const [itemsRes, mobsRes] = await Promise.all([
+            fetch('/admin/api/v1/items'),
+            fetch('/admin/api/v1/mobs'),
+        ]);
+        const itemsJson = await itemsRes.json();
+        const mobsJson  = await mobsRes.json();
+
+        if (itemsJson.success && Array.isArray(itemsJson.data)) {
+            for (const item of itemsJson.data) {
+                itemNames[item.ItemId] = item.Name || String(item.ItemId);
+            }
+        }
+        if (mobsJson.success && Array.isArray(mobsJson.data)) {
+            for (const mob of mobsJson.data) {
+                mobNames[mob.MobId] = mob.Character?.Name || String(mob.MobId);
+            }
+        }
+    } catch(e) {
+        // lookups are best-effort; raw IDs will show as fallback
+    }
+}
+
+function fmtDate(d) {
+    if (!d || d.length !== 8) return d || '';
+    return d.slice(0,4) + '-' + d.slice(4,6) + '-' + d.slice(6,8);
+}
+
+function esc(s) {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function itemCell(id) {
+    if (!id) return '';
+    const name = itemNames[id];
+    const label = name ? `<span class="id-prefix">#${id}</span> ${esc(name)}` : `#${id}`;
+    return `<a class="admin-link" href="/admin/items#${id}">${label}</a>`;
+}
+
+function mobCell(id) {
+    if (!id) return '';
+    const name = mobNames[id];
+    const label = name ? `<span class="id-prefix">#${id}</span> ${esc(name)}` : `#${id}`;
+    return `<a class="admin-link" href="/admin/mobs#${id}">${label}</a>`;
+}
+
+function roomCell(id) {
+    if (!id) return '';
+    const title = roomTitles[id];
+    const label = title ? `<span class="id-prefix">#${id}</span> ${esc(title)}` : `#${id}`;
+    return `<a class="admin-link" href="/admin/rooms#${id}">${label}</a>`;
+}
+
+function zoneCell(zone) {
+    if (!zone) return '';
+    return `<a class="admin-link" href="/admin/rooms?zone=${encodeURIComponent(zone)}">${esc(zone)}</a>`;
+}
+
+function buildParams() {
+    const p = new URLSearchParams();
+    const cat      = document.getElementById('f-category').value;
+    const itemId   = document.getElementById('f-itemId').value;
+    const mobId    = document.getElementById('f-mobId').value;
+    const roomId   = document.getElementById('f-roomId').value;
+    const zone     = document.getElementById('f-zone').value;
+    const dateFrom = document.getElementById('f-dateFrom').value;
+    const dateTo   = document.getElementById('f-dateTo').value;
+    const sort     = document.getElementById('f-sort').value;
+
+    if (cat)      p.set('category', cat);
+    if (itemId)   p.set('itemId', itemId);
+    if (mobId)    p.set('mobId', mobId);
+    if (roomId)   p.set('roomId', roomId);
+    if (zone)     p.set('zone', zone);
+    if (dateFrom) p.set('dateFrom', dateFrom);
+    if (dateTo)   p.set('dateTo', dateTo);
+    p.set('sort', sort);
+    return p;
+}
+
+function showStatus(msg, isError) {
+    const el = document.getElementById('status');
+    el.textContent = msg;
+    el.className = 'status-bar ' + (isError ? 'error' : 'success');
+    setTimeout(() => { el.className = 'status-bar'; }, 4000);
+}
+
+async function loadData() {
+    // Lazily fetch room titles for any room IDs that appear in results
+    const params = buildParams();
+    try {
+        const resp = await fetch('/admin/api/v1/telemetry?' + params.toString());
+        const json = await resp.json();
+        if (!json.success) { showStatus('Error: ' + json.error, true); return; }
+        currentData = json.data || [];
+        sortKey = 'count';
+        sortAsc = document.getElementById('f-sort').value === 'asc';
+
+        // Fetch room titles for any unseen room IDs
+        const unseenRooms = [...new Set(currentData.map(r => r.roomid).filter(id => id && !(id in roomTitles)))];
+        await Promise.all(unseenRooms.map(async id => {
+            try {
+                const res = await fetch('/admin/api/v1/rooms/' + id);
+                const j = await res.json();
+                if (j.success && j.data) roomTitles[id] = j.data.Title || String(id);
+                else roomTitles[id] = String(id);
+            } catch { roomTitles[id] = String(id); }
+        }));
+
+        renderTable();
+    } catch(e) {
+        showStatus('Request failed: ' + e, true);
+    }
+}
+
+function renderTable() {
+    const tbody   = document.getElementById('data-body');
+    const summary = document.getElementById('summary');
+
+    if (!currentData || currentData.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="7" class="empty">No records found.</td></tr>';
+        summary.textContent = '';
+        return;
+    }
+
+    const total = currentData.reduce((s, r) => s + (r.count || 0), 0);
+    summary.textContent = currentData.length + ' records, ' + total.toLocaleString() + ' total count';
+
+    tbody.innerHTML = currentData.map(r => `<tr>
+        <td>${fmtDate(r.date)}</td>
+        <td><span class="cat">${esc(r.category || '')}</span></td>
+        <td>${itemCell(r.itemid)}</td>
+        <td>${mobCell(r.mobid)}</td>
+        <td>${roomCell(r.roomid)}</td>
+        <td>${zoneCell(r.zone)}</td>
+        <td class="num">${(r.count || 0).toLocaleString()}</td>
+    </tr>`).join('');
+}
+
+function sortBy(key) {
+    if (sortKey === key) { sortAsc = !sortAsc; }
+    else { sortKey = key; sortAsc = false; }
+
+    currentData.sort((a, b) => {
+        const av = a[key] ?? '', bv = b[key] ?? '';
+        if (typeof av === 'number' && typeof bv === 'number') return sortAsc ? av - bv : bv - av;
+        return sortAsc ? String(av).localeCompare(String(bv)) : String(bv).localeCompare(String(av));
+    });
+    renderTable();
+}
+
+async function clearData() {
+    if (!confirm('Clear telemetry records matching the current filters? This cannot be undone.')) return;
+
+    const params = buildParams();
+    const clearParams = new URLSearchParams();
+    for (const [k, v] of params.entries()) {
+        if (k !== 'sort') clearParams.set(k, v);
+    }
+
+    try {
+        const resp = await fetch('/admin/api/v1/telemetry?' + clearParams.toString(), { method: 'DELETE' });
+        const json = await resp.json();
+        if (!json.success) { showStatus('Error: ' + json.error, true); return; }
+        showStatus('Records cleared.', false);
+        await loadData();
+    } catch(e) {
+        showStatus('Request failed: ' + e, true);
+    }
+}
+
+// Pre-load item and mob name lookups immediately so they're ready when the
+// user runs their first query.
+initLookups();
+</script>
+
+{{template "footer" .}}

--- a/_datafiles/world/default/templates/admincommands/help/command.rankings.template
+++ b/_datafiles/world/default/templates/admincommands/help/command.rankings.template
@@ -1,0 +1,19 @@
+The <ansi fg="command">rankings</ansi> command displays balance rankings for pets, weapons, and armor.
+
+<ansi fg="command">rankings pets [combat/utility/overall]</ansi>
+  Show pet rankings. Default sort: <ansi fg="yellow">overall</ansi>
+  <ansi fg="command">combat</ansi>   - Ranked by weighted combat DPS across all levels
+  <ansi fg="command">utility</ansi>  - Ranked by stat mods, buffs, and carry capacity
+  <ansi fg="command">overall</ansi>  - Combined combat and utility score
+
+<ansi fg="command">rankings weapons [dps/dps-adj/max]</ansi>
+  Show weapon rankings. Default sort: <ansi fg="yellow">dps</ansi>
+  <ansi fg="command">dps</ansi>      - Raw expected DPS against an equal-stat opponent
+  <ansi fg="command">dps-adj</ansi>  - DPS penalized for two-handed and wait-round cost
+  <ansi fg="command">max</ansi>      - Theoretical maximum single-hit damage
+
+<ansi fg="command">rankings armor [def/def-adj/score]</ansi>
+  Show armor rankings. Default sort: <ansi fg="yellow">def</ansi>
+  <ansi fg="command">def</ansi>      - Raw DamageReduction value
+  <ansi fg="command">def-adj</ansi>  - DamageReduction adjusted for slot multiplier (shields x1.5)
+  <ansi fg="command">score</ansi>    - Unified eHP-equivalent score (defense + stats + buffs)

--- a/_datafiles/world/empty/templates/admincommands/help/command.rankings.template
+++ b/_datafiles/world/empty/templates/admincommands/help/command.rankings.template
@@ -1,0 +1,19 @@
+The <ansi fg="command">rankings</ansi> command displays balance rankings for pets, weapons, and armor.
+
+<ansi fg="command">rankings pets [combat/utility/overall]</ansi>
+  Show pet rankings. Default sort: <ansi fg="yellow">overall</ansi>
+  <ansi fg="command">combat</ansi>   - Ranked by weighted combat DPS across all levels
+  <ansi fg="command">utility</ansi>  - Ranked by stat mods, buffs, and carry capacity
+  <ansi fg="command">overall</ansi>  - Combined combat and utility score
+
+<ansi fg="command">rankings weapons [dps/dps-adj/max]</ansi>
+  Show weapon rankings. Default sort: <ansi fg="yellow">dps</ansi>
+  <ansi fg="command">dps</ansi>      - Raw expected DPS against an equal-stat opponent
+  <ansi fg="command">dps-adj</ansi>  - DPS penalized for two-handed and wait-round cost
+  <ansi fg="command">max</ansi>      - Theoretical maximum single-hit damage
+
+<ansi fg="command">rankings armor [def/def-adj/score]</ansi>
+  Show armor rankings. Default sort: <ansi fg="yellow">def</ansi>
+  <ansi fg="command">def</ansi>      - Raw DamageReduction value
+  <ansi fg="command">def-adj</ansi>  - DamageReduction adjusted for slot multiplier (shields x1.5)
+  <ansi fg="command">score</ansi>    - Unified eHP-equivalent score (defense + stats + buffs)

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -45,55 +45,56 @@ const (
 )
 
 type Character struct {
-	Name             string                         // The name of the character
-	Description      string                         // A description of the character.
-	Adjectives       []string                       `yaml:"adjectives,omitempty"` // Decorative text for the name of the character (e.g. "sleeping", "dead", "wounded")
-	RoomId           int                            // The room id the character is in.
-	RoomIdOnReset    int                            // The room they are sent to if their RoomId isn't found.
-	Zone             string                         // The zone the character is in. The folder the room can be located in too.
-	RaceId           int                            // Character race
-	FormRaceId       int                            `yaml:"formraceid,omitempty"` // Temporary race override (0 = not transformed)
-	Stats            stats.Statistics               // Character stats
-	Level            int                            // The level of the character
-	Experience       int                            // The experience of the character
-	TrainingPoints   int                            // The number of training points the character has
-	StatPoints       int                            // The number of skill points the character has
-	Health           int                            // The health of the character
-	Mana             int                            // The mana of the character
-	ActionPoints     int                            // The resevoir of action points the character has to spend on movement etc.
-	Alignment        int8                           // The alignment of the character
-	Gold             int                            // The gold the character is holding
-	Bank             int                            // The gold the character has in the bank
-	Shop             Shop                           `yaml:"shop,omitempty"`          // Definition of shop services/items this character stocks (or just has at the moment)
-	SpellBook        map[string]int                 `yaml:"spellbook,omitempty"`     // The spells the character has learned
-	Charmed          *CharmInfo                     `yaml:"-"`                       // If they are charmed, this is the info
-	CharmedMobs      []int                          `yaml:"-"`                       // If they have charmed anyone, this is the list of mob instance ids
-	Items            []items.Item                   `yaml:"items,omitempty"`         // The items the character is holding
-	Buffs            buffs.Buffs                    `yaml:"buffs,omitempty"`         // The buffs the character has active
-	Equipment        Worn                           `yaml:"equipment,omitempty"`     // The equipment the character is wearing
-	TNLScale         float32                        `yaml:"-"`                       // The experience scale of the character. Don't write to yaml since is dynamically calculated.
-	HealthMax        stats.StatInfo                 `yaml:"-"`                       // The maximum health of the character. Don't write to yaml since is dynamically calculated.
-	ManaMax          stats.StatInfo                 `yaml:"-"`                       // The maximum mana of the character. Don't write to yaml since is dynamically calculated.
-	ActionPointsMax  stats.StatInfo                 `yaml:"-"`                       // The maximum actions of character. Don't write to yaml since is dynamically calculated.
-	Aggro            *Aggro                         `yaml:"-"`                       // Dont' store this. If they leave they break their aggro
-	Skills           map[string]int                 `yaml:"skills,omitempty"`        // The skills the character has, and what level they are at
-	Cooldowns        Cooldowns                      `yaml:"cooldowns,omitempty"`     // How many rounds until it is cooled down
-	Settings         map[string]string              `yaml:"settings,omitempty"`      // custom setting tracking, used for anything.
-	QuestProgress    map[int]string                 `yaml:"questprogress,omitempty"` // quest progress tracking
-	KeyRing          map[string]string              `yaml:"keyring,omitempty"`       // key is the lock id, value is the sequence
-	KD               KDStats                        `yaml:"kd,omitempty"`            // Kill/Death stats
-	MiscData         map[string]any                 `yaml:"miscdata,omitempty"`      // Any random other data that needs to be stored
-	ExtraLives       int                            `yaml:"extralives,omitempty"`    // How many lives remain. If enabled, players can perma-die if they die at zero
-	MobMastery       MobMasteries                   `yaml:"mobmastery,omitempty"`    // Tracks particular masteries around a given mob
-	Pet              pets.Pet                       `yaml:"pet,omitempty"`           // Do they have a pet?
-	Created          time.Time                      `yaml:"created"`                 // When this character was created
-	Timers           map[string]gametime.RoundTimer `yaml:"timers,omitempty"`        // any special timers added to this character
-	ZonesVisited     map[string]RoomBitset          `yaml:"zonesvisited,omitempty"`  // permanent record of every room visited, keyed by zone name
-	roomHistory      []int                          // A stack FILO of the last X rooms the character has been in
-	PlayerDamage     map[int]int                    `yaml:"-"` // key = who, value = how much
-	LastPlayerDamage uint64                         `yaml:"-"` // last round a player damaged this character
-	permaBuffIds     []int                          // Buff Id's that are always present for this character
-	userId           int                            // User ID of the character if any
+	Name                string                         // The name of the character
+	Description         string                         // A description of the character.
+	Adjectives          []string                       `yaml:"adjectives,omitempty"` // Decorative text for the name of the character (e.g. "sleeping", "dead", "wounded")
+	RoomId              int                            // The room id the character is in.
+	RoomIdOnReset       int                            // The room they are sent to if their RoomId isn't found.
+	Zone                string                         // The zone the character is in. The folder the room can be located in too.
+	RaceId              int                            // Character race
+	FormRaceId          int                            `yaml:"formraceid,omitempty"` // Temporary race override (0 = not transformed)
+	Stats               stats.Statistics               // Character stats
+	Level               int                            // The level of the character
+	Experience          int                            // The experience of the character
+	TrainingPoints      int                            // The number of training points the character has
+	StatPoints          int                            // The number of skill points the character has
+	Health              int                            // The health of the character
+	Mana                int                            // The mana of the character
+	ActionPoints        int                            // The resevoir of action points the character has to spend on movement etc.
+	Alignment           int8                           // The alignment of the character
+	Gold                int                            // The gold the character is holding
+	Bank                int                            // The gold the character has in the bank
+	Shop                Shop                           `yaml:"shop,omitempty"`          // Definition of shop services/items this character stocks (or just has at the moment)
+	SpellBook           map[string]int                 `yaml:"spellbook,omitempty"`     // The spells the character has learned
+	Charmed             *CharmInfo                     `yaml:"-"`                       // If they are charmed, this is the info
+	CharmedMobs         []int                          `yaml:"-"`                       // If they have charmed anyone, this is the list of mob instance ids
+	Items               []items.Item                   `yaml:"items,omitempty"`         // The items the character is holding
+	Buffs               buffs.Buffs                    `yaml:"buffs,omitempty"`         // The buffs the character has active
+	Equipment           Worn                           `yaml:"equipment,omitempty"`     // The equipment the character is wearing
+	TNLScale            float32                        `yaml:"-"`                       // The experience scale of the character. Don't write to yaml since is dynamically calculated.
+	HealthMax           stats.StatInfo                 `yaml:"-"`                       // The maximum health of the character. Don't write to yaml since is dynamically calculated.
+	ManaMax             stats.StatInfo                 `yaml:"-"`                       // The maximum mana of the character. Don't write to yaml since is dynamically calculated.
+	ActionPointsMax     stats.StatInfo                 `yaml:"-"`                       // The maximum actions of character. Don't write to yaml since is dynamically calculated.
+	Aggro               *Aggro                         `yaml:"-"`                       // Dont' store this. If they leave they break their aggro
+	Skills              map[string]int                 `yaml:"skills,omitempty"`        // The skills the character has, and what level they are at
+	Cooldowns           Cooldowns                      `yaml:"cooldowns,omitempty"`     // How many rounds until it is cooled down
+	Settings            map[string]string              `yaml:"settings,omitempty"`      // custom setting tracking, used for anything.
+	QuestProgress       map[int]string                 `yaml:"questprogress,omitempty"` // quest progress tracking
+	KeyRing             map[string]string              `yaml:"keyring,omitempty"`       // key is the lock id, value is the sequence
+	KD                  KDStats                        `yaml:"kd,omitempty"`            // Kill/Death stats
+	MiscData            map[string]any                 `yaml:"miscdata,omitempty"`      // Any random other data that needs to be stored
+	ExtraLives          int                            `yaml:"extralives,omitempty"`    // How many lives remain. If enabled, players can perma-die if they die at zero
+	MobMastery          MobMasteries                   `yaml:"mobmastery,omitempty"`    // Tracks particular masteries around a given mob
+	Pet                 pets.Pet                       `yaml:"pet,omitempty"`           // Do they have a pet?
+	Created             time.Time                      `yaml:"created"`                 // When this character was created
+	Timers              map[string]gametime.RoundTimer `yaml:"timers,omitempty"`        // any special timers added to this character
+	ZonesVisited        map[string]RoomBitset          `yaml:"zonesvisited,omitempty"`  // permanent record of every room visited, keyed by zone name
+	roomHistory         []int                          // A stack FILO of the last X rooms the character has been in
+	PlayerDamage        map[int]int                    `yaml:"-"` // key = who, value = how much
+	LastPlayerDamage    uint64                         `yaml:"-"` // last round a player damaged this character
+	KillerMobInstanceId int                            `yaml:"-"` // transient: mob instance that delivered the killing blow
+	permaBuffIds        []int                          // Buff Id's that are always present for this character
+	userId              int                            // User ID of the character if any
 }
 
 func New() *Character {

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -286,6 +286,7 @@ type PlayerDeath struct {
 	CharacterName string
 	Permanent     bool
 	KilledByUsers []int
+	KillerMobId   int // mob spec ID of the killing mob; 0 if killed by a player or unknown
 }
 
 func (l PlayerDeath) Type() string { return `PlayerDeath` }
@@ -436,6 +437,16 @@ type Purchase struct {
 }
 
 func (p Purchase) Type() string { return `Purchase` }
+
+// Fired for each item that actually drops from a mob on death.
+type MobItemDrop struct {
+	MobId  int
+	RoomId int
+	Zone   string
+	ItemId int
+}
+
+func (m MobItemDrop) Type() string { return `MobItemDrop` }
 
 // If a potentially fire-starting event occured in this room
 type FireBlaze struct {

--- a/internal/hooks/NewRound_DoCombat.go
+++ b/internal/hooks/NewRound_DoCombat.go
@@ -1110,6 +1110,9 @@ func handleAffected(affectedPlayerIds []int, affectedMobInstanceIds []int) {
 
 			if user.Character.Health <= -10 {
 
+				if user.Character.Aggro != nil && user.Character.Aggro.MobInstanceId > 0 {
+					user.Character.KillerMobInstanceId = user.Character.Aggro.MobInstanceId
+				}
 				user.Command(`suicide`) // suicide drops all money/items and transports to land of the dead.
 
 			} else if user.Character.Health < 1 {

--- a/internal/hooks/NewTurn_AutoSave.go
+++ b/internal/hooks/NewTurn_AutoSave.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/GoMud/internal/plugins"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/telemetry"
 	"github.com/GoMudEngine/GoMud/internal/term"
 	"github.com/GoMudEngine/GoMud/internal/users"
 	"github.com/GoMudEngine/GoMud/internal/util"
@@ -63,6 +64,11 @@ func AutoSave(e events.Event) events.ListenerReturn {
 		events.AddToQueue(events.Broadcast{Text: `Saving other...`})
 		// Save plugin states if applicable
 		plugins.Save()
+
+		// Save telemetry data
+		if err := telemetry.Save(); err != nil {
+			mudlog.Error("telemetry.Save", "error", err)
+		}
 
 		events.AddToQueue(events.Broadcast{
 			Text:            `Done.` + term.CRLFStr,

--- a/internal/mobcommands/suicide.go
+++ b/internal/mobcommands/suicide.go
@@ -300,6 +300,12 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		for _, item := range mob.Character.Items {
 			msg := fmt.Sprintf(`<ansi fg="item">%s</ansi> drops to the ground.`, item.DisplayName())
 			room.SendText(msg)
+			events.AddToQueue(events.MobItemDrop{
+				MobId:  int(mob.MobId),
+				RoomId: room.RoomId,
+				Zone:   mob.Character.Zone,
+				ItemId: item.ItemId,
+			})
 			room.AddItem(item, false)
 		}
 
@@ -317,6 +323,12 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 			msg := fmt.Sprintf(`<ansi fg="item">%s</ansi> drops to the ground.`, item.DisplayName())
 			room.SendText(msg)
+			events.AddToQueue(events.MobItemDrop{
+				MobId:  int(mob.MobId),
+				RoomId: room.RoomId,
+				Zone:   mob.Character.Zone,
+				ItemId: item.ItemId,
+			})
 			room.AddItem(item, false)
 		}
 

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -1,0 +1,503 @@
+package plugins
+
+import (
+	"embed"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testFS embeds the fixture tree used by all tests in this file.
+// The tree contains:
+//
+//	testdata/datafiles/html/public/index.html  -> short key: html/public/index.html
+//	testdata/datafiles/items/test-sword.yaml   -> short key: items/test-sword.yaml
+//	testdata/data-overlays/config.yaml         -> short key: data-overlays/config.yaml
+//
+//go:embed testdata
+var testFS embed.FS
+
+// newTestPlugin returns a Plugin with testFS attached, constructed directly
+// to avoid touching the package-level registry.
+func newTestPlugin(t *testing.T) *Plugin {
+	t.Helper()
+	p := &Plugin{name: "testplugin", version: "1.0"}
+	require.NoError(t, p.AttachFileSystem(testFS))
+	return p
+}
+
+// withRegistryPlugin temporarily installs a single test plugin into the
+// package-level registry and restores the original state on cleanup.
+// This is required because ReadFile, Open, Stat, and GetExportedFunction
+// all iterate the package-level `registry` global rather than the receiver.
+func withRegistryPlugin(t *testing.T) *Plugin {
+	t.Helper()
+	origRegistry := registry
+	origOpen := registrationOpen
+	t.Cleanup(func() {
+		registry = origRegistry
+		registrationOpen = origOpen
+	})
+	registry = pluginRegistry{}
+	registrationOpen = false // bypass New(); construct directly
+	p := newTestPlugin(t)
+	registry = pluginRegistry{p}
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// AttachFileSystem
+// ---------------------------------------------------------------------------
+
+func TestAttachFileSystem_PopulatesFilePaths(t *testing.T) {
+	p := newTestPlugin(t)
+
+	known := p.files.KnownPaths()
+	sort.Strings(known)
+
+	// datafiles/ prefix is stripped; data-overlays/ prefix is preserved.
+	assert.Contains(t, known, "html/public/index.html")
+	assert.Contains(t, known, "items/test-sword.yaml")
+	assert.Contains(t, known, "data-overlays/config.yaml")
+}
+
+func TestAttachFileSystem_DoesNotRegisterDirectories(t *testing.T) {
+	p := newTestPlugin(t)
+
+	for _, k := range p.files.KnownPaths() {
+		assert.False(t, strings.HasSuffix(k, "/"), "directory registered as file path: %q", k)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PluginFiles.ReadFile
+// ---------------------------------------------------------------------------
+
+func TestPluginFiles_ReadFile_Found(t *testing.T) {
+	p := newTestPlugin(t)
+
+	b, err := p.files.ReadFile("html/public/index.html")
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "hello")
+}
+
+func TestPluginFiles_ReadFile_DataOverlay(t *testing.T) {
+	p := newTestPlugin(t)
+
+	b, err := p.files.ReadFile("data-overlays/config.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "somekey")
+}
+
+func TestPluginFiles_ReadFile_NotFound(t *testing.T) {
+	p := newTestPlugin(t)
+
+	_, err := p.files.ReadFile("nonexistent/file.txt")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+// ReadFile must normalise backslash paths (Windows-style) to forward slashes
+// so that the lookup against the embed.FS key succeeds on all platforms.
+func TestPluginFiles_ReadFile_BackslashPath(t *testing.T) {
+	p := newTestPlugin(t)
+
+	// filepath.Join uses the OS separator, which is backslash on Windows.
+	nativePath := filepath.Join("html", "public", "index.html")
+
+	b, err := p.files.ReadFile(nativePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "hello")
+}
+
+// Double-slash paths must also be tolerated.
+func TestPluginFiles_ReadFile_DoubleSlash(t *testing.T) {
+	p := newTestPlugin(t)
+
+	b, err := p.files.ReadFile("html//public//index.html")
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "hello")
+}
+
+// ---------------------------------------------------------------------------
+// PluginFiles.Open
+// ---------------------------------------------------------------------------
+
+func TestPluginFiles_Open_Found(t *testing.T) {
+	p := newTestPlugin(t)
+
+	f, err := p.files.Open("items/test-sword.yaml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := f.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, "test-sword.yaml", info.Name())
+	assert.False(t, info.IsDir())
+}
+
+func TestPluginFiles_Open_NotFound(t *testing.T) {
+	p := newTestPlugin(t)
+
+	_, err := p.files.Open("no/such/file.txt")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+func TestPluginFiles_Open_BackslashPath(t *testing.T) {
+	p := newTestPlugin(t)
+
+	nativePath := filepath.Join("items", "test-sword.yaml")
+	f, err := p.files.Open(nativePath)
+	require.NoError(t, err)
+	f.Close()
+}
+
+// ---------------------------------------------------------------------------
+// PluginFiles.Stat
+// ---------------------------------------------------------------------------
+
+func TestPluginFiles_Stat_Found(t *testing.T) {
+	p := newTestPlugin(t)
+
+	info, err := p.files.Stat("items/test-sword.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "test-sword.yaml", info.Name())
+	assert.Greater(t, info.Size(), int64(0))
+}
+
+func TestPluginFiles_Stat_NotFound(t *testing.T) {
+	p := newTestPlugin(t)
+
+	_, err := p.files.Stat("ghost/file.txt")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+func TestPluginFiles_Stat_BackslashPath(t *testing.T) {
+	p := newTestPlugin(t)
+
+	nativePath := filepath.Join("items", "test-sword.yaml")
+	info, err := p.files.Stat(nativePath)
+	require.NoError(t, err)
+	assert.Equal(t, "test-sword.yaml", info.Name())
+}
+
+// ---------------------------------------------------------------------------
+// pluginRegistry.ReadFile / Open / Stat
+// NOTE: these methods range over the package-level `registry` global, not the
+// receiver, so tests must install the plugin into that global.
+// ---------------------------------------------------------------------------
+
+func TestRegistry_ReadFile_Found(t *testing.T) {
+	withRegistryPlugin(t)
+
+	b, err := registry.ReadFile("html/public/index.html")
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "hello")
+}
+
+func TestRegistry_ReadFile_NotFound(t *testing.T) {
+	withRegistryPlugin(t)
+
+	_, err := registry.ReadFile("missing.txt")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+func TestRegistry_Open_Found(t *testing.T) {
+	withRegistryPlugin(t)
+
+	f, err := registry.Open("items/test-sword.yaml")
+	require.NoError(t, err)
+	f.Close()
+}
+
+func TestRegistry_Open_NotFound(t *testing.T) {
+	withRegistryPlugin(t)
+
+	_, err := registry.Open("missing.txt")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+func TestRegistry_Stat_Found(t *testing.T) {
+	withRegistryPlugin(t)
+
+	info, err := registry.Stat("items/test-sword.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "test-sword.yaml", info.Name())
+}
+
+func TestRegistry_Stat_NotFound(t *testing.T) {
+	withRegistryPlugin(t)
+
+	_, err := registry.Stat("missing.txt")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+// ---------------------------------------------------------------------------
+// pluginRegistry.AllFileSubSystems
+// AllFileSubSystems uses the receiver, so isolated registries work fine here.
+// ---------------------------------------------------------------------------
+
+func TestRegistry_AllFileSubSystems_IteratesAll(t *testing.T) {
+	p1 := newTestPlugin(t)
+	p2 := newTestPlugin(t)
+	reg := pluginRegistry{p1, p2}
+
+	var visited int
+	reg.AllFileSubSystems(func(f fs.ReadFileFS) bool {
+		visited++
+		return true
+	})
+	assert.Equal(t, 2, visited)
+}
+
+func TestRegistry_AllFileSubSystems_EarlyStop(t *testing.T) {
+	p1 := newTestPlugin(t)
+	p2 := newTestPlugin(t)
+	p3 := newTestPlugin(t)
+	reg := pluginRegistry{p1, p2, p3}
+
+	var visited int
+	reg.AllFileSubSystems(func(f fs.ReadFileFS) bool {
+		visited++
+		return visited < 2 // stop after second
+	})
+	assert.Equal(t, 2, visited)
+}
+
+// ---------------------------------------------------------------------------
+// pluginRegistry first-wins semantics
+// ---------------------------------------------------------------------------
+
+// When two plugins both expose the same short path, the first registry entry
+// wins (ReadFile returns the first match and does not error).
+func TestRegistry_ReadFile_FirstPluginWins(t *testing.T) {
+	origRegistry := registry
+	origOpen := registrationOpen
+	t.Cleanup(func() {
+		registry = origRegistry
+		registrationOpen = origOpen
+	})
+	p1 := newTestPlugin(t)
+	p2 := newTestPlugin(t)
+	registry = pluginRegistry{p1, p2}
+
+	b, err := registry.ReadFile("html/public/index.html")
+	require.NoError(t, err)
+	assert.NotEmpty(t, b)
+}
+
+// ---------------------------------------------------------------------------
+// WriteBytes / ReadBytes round-trip
+// ---------------------------------------------------------------------------
+
+func TestPlugin_WriteBytesReadBytes_RoundTrip(t *testing.T) {
+	p := &Plugin{name: "roundtrip", version: "0.1"}
+	p.files.filePaths = map[string]string{}
+
+	origWriteFolder := writeFolderPath
+	writeFolderPath = t.TempDir()
+	t.Cleanup(func() { writeFolderPath = origWriteFolder })
+
+	payload := []byte("hello plugin data")
+	require.NoError(t, p.WriteBytes("mydata", payload))
+
+	got, err := p.ReadBytes("mydata")
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
+func TestPlugin_ReadBytes_NotExist(t *testing.T) {
+	p := &Plugin{name: "readmissing", version: "0.1"}
+
+	origWriteFolder := writeFolderPath
+	writeFolderPath = t.TempDir()
+	t.Cleanup(func() { writeFolderPath = origWriteFolder })
+
+	_, err := p.ReadBytes("nope")
+	assert.True(t, errors.Is(err, fs.ErrNotExist) || os.IsNotExist(err))
+}
+
+// Identifiers with special characters must be sanitised into a valid file name
+// and still round-trip correctly.
+func TestPlugin_WriteBytes_IdentifierSanitised(t *testing.T) {
+	p := &Plugin{name: "sanitise", version: "1.0"}
+
+	origWriteFolder := writeFolderPath
+	writeFolderPath = t.TempDir()
+	t.Cleanup(func() { writeFolderPath = origWriteFolder })
+
+	require.NoError(t, p.WriteBytes("my data/key:value", []byte("ok")))
+
+	got, err := p.ReadBytes("my data/key:value")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ok"), got)
+}
+
+// ---------------------------------------------------------------------------
+// WriteStruct / ReadIntoStruct round-trip
+// ---------------------------------------------------------------------------
+
+type testStructPayload struct {
+	Name  string `yaml:"name"`
+	Value int    `yaml:"value"`
+}
+
+func TestPlugin_WriteStructReadIntoStruct_RoundTrip(t *testing.T) {
+	p := &Plugin{name: "structtest", version: "2.0"}
+
+	origWriteFolder := writeFolderPath
+	writeFolderPath = t.TempDir()
+	t.Cleanup(func() { writeFolderPath = origWriteFolder })
+
+	in := testStructPayload{Name: "sword", Value: 42}
+	require.NoError(t, p.WriteStruct("weapon", in))
+
+	var out testStructPayload
+	require.NoError(t, p.ReadIntoStruct("weapon", &out))
+	assert.Equal(t, in, out)
+}
+
+// ---------------------------------------------------------------------------
+// New / name sanitisation
+// ---------------------------------------------------------------------------
+
+func TestNew_NameSanitisation(t *testing.T) {
+	origRegistry := registry
+	origOpen := registrationOpen
+	t.Cleanup(func() {
+		registry = origRegistry
+		registrationOpen = origOpen
+	})
+
+	registry = pluginRegistry{}
+	registrationOpen = true
+
+	p := New("my-plugin name!", "1.0")
+	require.NotNil(t, p)
+	assert.Equal(t, "my_plugin_name_", p.name)
+}
+
+func TestNew_RegistrationClosed(t *testing.T) {
+	origRegistry := registry
+	origOpen := registrationOpen
+	t.Cleanup(func() {
+		registry = origRegistry
+		registrationOpen = origOpen
+	})
+
+	registrationOpen = false
+	p := New("shouldfail", "1.0")
+	assert.Nil(t, p)
+}
+
+// ---------------------------------------------------------------------------
+// ReserveTags / GetRegisteredRoomTags
+// ---------------------------------------------------------------------------
+
+func TestReserveTags_GetRegisteredRoomTags(t *testing.T) {
+	origRegistry := registry
+	origOpen := registrationOpen
+	t.Cleanup(func() {
+		registry = origRegistry
+		registrationOpen = origOpen
+	})
+
+	registry = pluginRegistry{}
+	registrationOpen = true
+
+	p := New("tagtest", "1.0")
+	require.NotNil(t, p)
+	p.ReserveTags("shop", "quest-giver")
+
+	tags := GetRegisteredRoomTags()
+	require.Contains(t, tags, "tagtest")
+	assert.ElementsMatch(t, []string{"shop", "quest-giver"}, tags["tagtest"])
+}
+
+func TestGetRegisteredRoomTags_EmptyWhenNoTags(t *testing.T) {
+	origRegistry := registry
+	origOpen := registrationOpen
+	t.Cleanup(func() {
+		registry = origRegistry
+		registrationOpen = origOpen
+	})
+
+	registry = pluginRegistry{}
+	registrationOpen = true
+
+	New("notags", "1.0")
+
+	tags := GetRegisteredRoomTags()
+	assert.NotContains(t, tags, "notags")
+}
+
+// ---------------------------------------------------------------------------
+// ExportFunction
+// ---------------------------------------------------------------------------
+
+func TestExportFunction_PanicsOnNonFunction(t *testing.T) {
+	p := &Plugin{name: "exptest", version: "1.0"}
+	assert.Panics(t, func() {
+		p.ExportFunction("notafunc", "a string")
+	})
+}
+
+func TestExportFunction_RegistersFunction(t *testing.T) {
+	p := &Plugin{name: "exptest2", version: "1.0"}
+	fn := func() string { return "ok" }
+	p.ExportFunction("myFunc", fn)
+	require.NotNil(t, p.exportedFunctions)
+	assert.NotNil(t, p.exportedFunctions["myFunc"])
+}
+
+// ---------------------------------------------------------------------------
+// pluginRegistry.GetExportedFunction
+// ---------------------------------------------------------------------------
+
+// GetExportedFunction also ranges over the package-level registry global.
+func TestRegistry_GetExportedFunction_Found(t *testing.T) {
+	origRegistry := registry
+	origOpen := registrationOpen
+	t.Cleanup(func() {
+		registry = origRegistry
+		registrationOpen = origOpen
+	})
+	p := &Plugin{name: "expfind", version: "1.0"}
+	fn := func() int { return 7 }
+	p.ExportFunction("compute", fn)
+	registry = pluginRegistry{p}
+
+	got, ok := registry.GetExportedFunction("compute")
+	assert.True(t, ok)
+	assert.NotNil(t, got)
+}
+
+func TestRegistry_GetExportedFunction_NotFound(t *testing.T) {
+	origRegistry := registry
+	origOpen := registrationOpen
+	t.Cleanup(func() {
+		registry = origRegistry
+		registrationOpen = origOpen
+	})
+	registry = pluginRegistry{&Plugin{name: "empty", version: "1.0"}}
+	_, ok := registry.GetExportedFunction("ghost")
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// Requires dependency tracking
+// ---------------------------------------------------------------------------
+
+func TestRequires_NameSanitisation(t *testing.T) {
+	p := &Plugin{name: "deptest", version: "1.0"}
+	p.Requires("some-dep name!", "2.0")
+	require.Len(t, p.dependencies, 1)
+	assert.Equal(t, "some_dep_name_", p.dependencies[0].name)
+	assert.Equal(t, "2.0", p.dependencies[0].version)
+}

--- a/internal/plugins/testdata/data-overlays/config.yaml
+++ b/internal/plugins/testdata/data-overlays/config.yaml
@@ -1,0 +1,1 @@
+somekey: somevalue

--- a/internal/plugins/testdata/datafiles/html/public/index.html
+++ b/internal/plugins/testdata/datafiles/html/public/index.html
@@ -1,0 +1,1 @@
+<html><body>hello</body></html>

--- a/internal/plugins/testdata/datafiles/items/test-sword.yaml
+++ b/internal/plugins/testdata/datafiles/items/test-sword.yaml
@@ -1,0 +1,2 @@
+name: test-sword
+damage: 1d6

--- a/internal/telemetry/USAGE.md
+++ b/internal/telemetry/USAGE.md
@@ -1,0 +1,125 @@
+# telemetry — usage examples
+
+## Querying in Go code
+
+The `Query()` builder is the primary interface. All filter methods are chainable
+and return the same `*QueryBuilder`. Call `Results()` or `Total()` to execute.
+
+### All drops of a specific item, sorted by count descending
+
+```go
+drops := telemetry.Query().
+    Category(telemetry.CatItemDrop).
+    ItemId(42).
+    SortDesc().
+    Results()
+
+for _, r := range drops {
+    // r.MobId  — which mob dropped it (0 = floor/player drop)
+    // r.Zone   — which zone
+    // r.RoomId — which room
+    // r.Date   — "YYYYMMDD"
+    // r.Count  — how many times
+    fmt.Printf("mob %d in %s: %d drops\n", r.MobId, r.Zone, r.Count)
+}
+```
+
+### All items dropped by a specific mob
+
+```go
+drops := telemetry.Query().
+    Category(telemetry.CatItemDrop).
+    MobId(7).
+    SortDesc().
+    Results()
+```
+
+### Total mob kills in a zone this month
+
+```go
+// Build a YYYYMM prefix and use DateFrom/DateTo
+now := time.Now()
+firstOfMonth := fmt.Sprintf("%d%02d01", now.Year(), now.Month())
+lastOfMonth  := fmt.Sprintf("%d%02d31", now.Year(), now.Month())
+
+total := telemetry.Query().
+    Category(telemetry.CatMobKill).
+    Zone("frostfang").
+    DateFrom(firstOfMonth).
+    DateTo(lastOfMonth).
+    Total()
+
+fmt.Printf("frostfang mob kills this month: %d\n", total)
+```
+
+### Most-purchased items overall
+
+```go
+purchases := telemetry.Query().
+    Category(telemetry.CatItemPurchase).
+    SortDesc().
+    Results()
+
+// purchases[0] is the most-purchased item across all dates
+```
+
+### Player deaths by mob, filtered to a single day
+
+```go
+today := time.Now().Format("20060102")
+
+deaths := telemetry.Query().
+    Category(telemetry.CatPlayerDeath).
+    Date(today).
+    SortDesc().
+    Results()
+```
+
+### Check whether a specific mob has ever dropped a specific item
+
+```go
+count := telemetry.Query().
+    Category(telemetry.CatItemDrop).
+    ItemId(42).
+    MobId(7).
+    Total()
+
+if count > 0 {
+    fmt.Printf("mob 7 has dropped item 42 %d times\n", count)
+}
+```
+
+---
+
+## API endpoint
+
+`GET /admin/api/v1/telemetry`
+
+All parameters are optional. Omit a parameter to match any value.
+
+| Parameter  | Type   | Description                              |
+|------------|--------|------------------------------------------|
+| `category` | string | `item_drop`, `item_pickup`, `mob_kill`, `player_death`, `item_purchase` |
+| `itemId`   | int    | Filter by item spec ID                   |
+| `mobId`    | int    | Filter by mob spec ID                    |
+| `roomId`   | int    | Filter by room ID                        |
+| `zone`     | string | Filter by zone name (exact match)        |
+| `date`     | string | Exact date `YYYYMMDD`                    |
+| `dateFrom` | string | Start of date range `YYYYMMDD` inclusive |
+| `dateTo`   | string | End of date range `YYYYMMDD` inclusive   |
+| `sort`     | string | `asc` or `desc` (default `desc`)         |
+
+`DELETE /admin/api/v1/telemetry`
+
+Clears records matching the supplied filters and saves to disk. Accepts the
+same filter parameters as GET except `sort`. Omit all parameters to clear
+everything.
+
+---
+
+## Date range notes
+
+`DateFrom` and `DateTo` use simple string comparison on `YYYYMMDD` format,
+which sorts lexicographically the same as chronologically. Both bounds are
+inclusive. Use `Date(d)` as a shorthand when you want exactly one day
+(`DateFrom(d).DateTo(d)`).

--- a/internal/telemetry/hooks.go
+++ b/internal/telemetry/hooks.go
@@ -1,0 +1,93 @@
+package telemetry
+
+import (
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+// RegisterListeners wires all telemetry event listeners. Called once at startup.
+func RegisterListeners() {
+	events.RegisterListener(events.MobItemDrop{}, onMobItemDrop)
+	events.RegisterListener(events.ItemOwnership{}, onItemOwnership)
+	events.RegisterListener(events.MobDeath{}, onMobDeath)
+	events.RegisterListener(events.PlayerDeath{}, onPlayerDeath)
+	events.RegisterListener(events.Purchase{}, onPurchase)
+}
+
+func onMobItemDrop(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.MobItemDrop)
+	if !ok {
+		return events.Continue
+	}
+	Track(CatItemDrop, evt.Zone, evt.ItemId, evt.MobId, evt.RoomId)
+	return events.Continue
+}
+
+func onItemOwnership(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.ItemOwnership)
+	if !ok {
+		return events.Continue
+	}
+	if !evt.Gained {
+		return events.Continue
+	}
+	if evt.UserId == 0 {
+		return events.Continue
+	}
+
+	zone := ""
+	roomId := 0
+	if user := users.GetByUserId(evt.UserId); user != nil {
+		roomId = user.Character.RoomId
+		if r := rooms.LoadRoom(roomId); r != nil {
+			zone = r.Zone
+		}
+	}
+
+	Track(CatItemPickup, zone, evt.Item.ItemId, 0, roomId)
+	return events.Continue
+}
+
+func onMobDeath(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.MobDeath)
+	if !ok {
+		return events.Continue
+	}
+
+	zone := ""
+	if r := rooms.LoadRoom(evt.RoomId); r != nil {
+		zone = r.Zone
+	}
+
+	Track(CatMobKill, zone, 0, evt.MobId, evt.RoomId)
+	return events.Continue
+}
+
+func onPlayerDeath(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerDeath)
+	if !ok {
+		return events.Continue
+	}
+
+	zone := ""
+	if r := rooms.LoadRoom(evt.RoomId); r != nil {
+		zone = r.Zone
+	}
+
+	Track(CatPlayerDeath, zone, 0, evt.KillerMobId, evt.RoomId)
+	return events.Continue
+}
+
+func onPurchase(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.Purchase)
+	if !ok {
+		return events.Continue
+	}
+	if evt.ItemId == 0 {
+		return events.Continue
+	}
+
+	Track(CatItemPurchase, "", evt.ItemId, evt.SellerMobId, 0)
+	return events.Continue
+}

--- a/internal/telemetry/memory.go
+++ b/internal/telemetry/memory.go
@@ -1,0 +1,14 @@
+package telemetry
+
+import "github.com/GoMudEngine/GoMud/internal/util"
+
+func GetMemoryUsage() map[string]util.MemoryResult {
+	ret := map[string]util.MemoryResult{}
+	ret["records"] = util.MemoryResult{Memory: util.MemoryUsage(records), Count: len(records)}
+	ret["index"] = util.MemoryResult{Memory: util.MemoryUsage(index), Count: len(index)}
+	return ret
+}
+
+func init() {
+	util.AddMemoryReporter(`Telemetry`, GetMemoryUsage)
+}

--- a/internal/telemetry/query.go
+++ b/internal/telemetry/query.go
@@ -1,0 +1,71 @@
+package telemetry
+
+import "sort"
+
+// QueryBuilder builds a filtered, optionally sorted query over telemetry records.
+// All filter methods return the same pointer for chaining.
+type QueryBuilder struct {
+	category string
+	zone     string
+	dateFrom string // >= YYYYMMDD
+	dateTo   string // <= YYYYMMDD
+	itemId   int
+	mobId    int
+	roomId   int
+	descSort bool
+	hasSort  bool
+}
+
+func (q *QueryBuilder) Category(c string) *QueryBuilder { q.category = c; return q }
+func (q *QueryBuilder) Zone(z string) *QueryBuilder     { q.zone = z; return q }
+func (q *QueryBuilder) ItemId(id int) *QueryBuilder     { q.itemId = id; return q }
+func (q *QueryBuilder) MobId(id int) *QueryBuilder      { q.mobId = id; return q }
+func (q *QueryBuilder) RoomId(id int) *QueryBuilder     { q.roomId = id; return q }
+
+// Date filters to an exact YYYYMMDD date.
+func (q *QueryBuilder) Date(d string) *QueryBuilder { q.dateFrom = d; q.dateTo = d; return q }
+
+// DateFrom filters to records on or after d (YYYYMMDD).
+func (q *QueryBuilder) DateFrom(d string) *QueryBuilder { q.dateFrom = d; return q }
+
+// DateTo filters to records on or before d (YYYYMMDD).
+func (q *QueryBuilder) DateTo(d string) *QueryBuilder { q.dateTo = d; return q }
+
+// SortAsc sorts results by Count ascending.
+func (q *QueryBuilder) SortAsc() *QueryBuilder { q.descSort = false; q.hasSort = true; return q }
+
+// SortDesc sorts results by Count descending.
+func (q *QueryBuilder) SortDesc() *QueryBuilder { q.descSort = true; q.hasSort = true; return q }
+
+// Results returns a copy of all records matching the configured filters.
+func (q *QueryBuilder) Results() []Record {
+	out := make([]Record, 0)
+	for _, r := range records {
+		if !matchesFilter(r, q.category, q.zone, q.dateFrom, q.dateTo, q.itemId, q.mobId, q.roomId) {
+			continue
+		}
+		out = append(out, r)
+	}
+
+	if q.hasSort {
+		sort.Slice(out, func(i, j int) bool {
+			if q.descSort {
+				return out[i].Count > out[j].Count
+			}
+			return out[i].Count < out[j].Count
+		})
+	}
+
+	return out
+}
+
+// Total returns the sum of Count across all matching records.
+func (q *QueryBuilder) Total() int {
+	total := 0
+	for _, r := range records {
+		if matchesFilter(r, q.category, q.zone, q.dateFrom, q.dateTo, q.itemId, q.mobId, q.roomId) {
+			total += r.Count
+		}
+	}
+	return total
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,237 @@
+package telemetry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/util"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	CatItemDrop     = "item_drop"
+	CatItemPickup   = "item_pickup"
+	CatMobKill      = "mob_kill"
+	CatPlayerDeath  = "player_death"
+	CatItemPurchase = "item_purchase"
+)
+
+// Record holds a single aggregated counter for a unique combination of
+// (Date, Category, ItemId, MobId, RoomId, Zone).
+type Record struct {
+	Date     string `yaml:"date"             json:"date"`
+	Category string `yaml:"category"         json:"category"`
+	ItemId   int    `yaml:"itemid,omitempty" json:"itemid,omitempty"`
+	MobId    int    `yaml:"mobid,omitempty"  json:"mobid,omitempty"`
+	RoomId   int    `yaml:"roomid,omitempty" json:"roomid,omitempty"`
+	Zone     string `yaml:"zone,omitempty"   json:"zone,omitempty"`
+	Count    int    `yaml:"count"            json:"count"`
+}
+
+var (
+	records []Record
+	index   = map[string]int{}  // recordKey -> slice index
+	dirty   = map[string]bool{} // date -> needs save
+	dataDir string              // directory that holds per-date YAML files
+)
+
+// Load reads all YYYYMMDD.yaml files from <dataFilesPath>/telemetry/ and
+// rebuilds the in-memory index. Safe to call when the directory does not
+// exist yet.
+func Load(dataFilesPath string) {
+	dataDir = util.FilePath(dataFilesPath, `/`, `telemetry`)
+
+	mudlog.Info("telemetry.Load", "dir", dataDir)
+
+	records = []Record{}
+	index = map[string]int{}
+	dirty = map[string]bool{}
+
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			mudlog.Info("telemetry.Load", "status", "directory does not exist yet, will be created on first save")
+		} else {
+			mudlog.Error("telemetry.Load", "dir", dataDir, "error", err)
+		}
+		return
+	}
+
+	fileCount := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+
+		data, err := util.ReadFile(filepath.Join(dataDir, e.Name()))
+		if err != nil {
+			mudlog.Error("telemetry.Load", "file", e.Name(), "error", err)
+			continue
+		}
+
+		var loaded []Record
+		if err := yaml.Unmarshal(data, &loaded); err != nil {
+			mudlog.Error("telemetry.Load", "file", e.Name(), "error", err)
+			continue
+		}
+
+		for _, r := range loaded {
+			records = append(records, r)
+			index[recordKey(r.Date, r.Category, r.Zone, r.ItemId, r.MobId, r.RoomId)] = len(records) - 1
+		}
+		fileCount++
+	}
+
+	mudlog.Info("telemetry.Load", "files", fileCount, "records", len(records))
+}
+
+// Save writes one YAML file per dirty date to the telemetry directory.
+// Dates whose records were all cleared have their file deleted.
+// Clean dates are not touched.
+func Save() error {
+	if dataDir == "" {
+		mudlog.Warn("telemetry.Save", "status", "skipped - dataDir not set (Load was never called)")
+		return nil
+	}
+
+	if len(dirty) == 0 {
+		mudlog.Info("telemetry.Save", "status", "skipped - no dirty dates")
+		return nil
+	}
+
+	mudlog.Info("telemetry.Save", "dir", dataDir, "dirty_dates", len(dirty))
+
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		mudlog.Error("telemetry.Save", "action", "mkdir", "dir", dataDir, "error", err)
+		return fmt.Errorf("telemetry.Save mkdir: %w", err)
+	}
+
+	// Group records by date for efficient lookup during save.
+	byDate := make(map[string][]Record, len(dirty))
+	for _, r := range records {
+		if dirty[r.Date] {
+			byDate[r.Date] = append(byDate[r.Date], r)
+		}
+	}
+
+	for date := range dirty {
+		path := filepath.Join(dataDir, date+".yaml")
+		recs := byDate[date]
+
+		if len(recs) == 0 {
+			mudlog.Info("telemetry.Save", "action", "delete", "file", path)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				mudlog.Error("telemetry.Save", "action", "delete", "file", path, "error", err)
+			}
+			continue
+		}
+
+		data, err := yaml.Marshal(recs)
+		if err != nil {
+			mudlog.Error("telemetry.Save", "action", "marshal", "date", date, "error", err)
+			return fmt.Errorf("telemetry.Save marshal %s: %w", date, err)
+		}
+
+		if err := util.WriteFile(path, data, 0644); err != nil {
+			mudlog.Error("telemetry.Save", "action", "write", "file", path, "error", err)
+			return fmt.Errorf("telemetry.Save write %s: %w", date, err)
+		}
+
+		mudlog.Info("telemetry.Save", "action", "wrote", "file", path, "records", len(recs))
+	}
+
+	dirty = map[string]bool{}
+	return nil
+}
+
+// Track increments the counter for the given combination. Zero values for
+// numeric fields mean "not applicable" for that field.
+func Track(category, zone string, itemId, mobId, roomId int) {
+	date := time.Now().Format("20060102")
+	key := recordKey(date, category, zone, itemId, mobId, roomId)
+
+	if i, ok := index[key]; ok {
+		records[i].Count++
+		dirty[date] = true
+		return
+	}
+
+	records = append(records, Record{
+		Date:     date,
+		Category: category,
+		ItemId:   itemId,
+		MobId:    mobId,
+		RoomId:   roomId,
+		Zone:     zone,
+		Count:    1,
+	})
+	index[key] = len(records) - 1
+	dirty[date] = true
+}
+
+// Clear removes all in-memory records matching the given filters and marks
+// the affected dates dirty so Save() will update or remove their files.
+// Pass empty/zero values to match any value for that field.
+func Clear(category, zone, date, dateTo string, itemId, mobId, roomId int) {
+	kept := make([]Record, 0, len(records))
+	for _, r := range records {
+		if matchesFilter(r, category, zone, date, dateTo, itemId, mobId, roomId) {
+			dirty[r.Date] = true
+			continue
+		}
+		kept = append(kept, r)
+	}
+	records = kept
+	rebuildIndex()
+}
+
+// Query returns a new QueryBuilder over the current records.
+func Query() *QueryBuilder {
+	return &QueryBuilder{}
+}
+
+// Len returns the total number of records currently in memory.
+func Len() int {
+	return len(records)
+}
+
+func rebuildIndex() {
+	index = make(map[string]int, len(records))
+	for i, r := range records {
+		index[recordKey(r.Date, r.Category, r.Zone, r.ItemId, r.MobId, r.RoomId)] = i
+	}
+}
+
+func recordKey(date, category, zone string, itemId, mobId, roomId int) string {
+	return fmt.Sprintf("%s|%s|%s|%d|%d|%d", date, category, zone, itemId, mobId, roomId)
+}
+
+// matchesFilter returns true when r matches all non-zero/non-empty filter values.
+func matchesFilter(r Record, category, zone, date, dateTo string, itemId, mobId, roomId int) bool {
+	if category != "" && r.Category != category {
+		return false
+	}
+	if zone != "" && r.Zone != zone {
+		return false
+	}
+	if date != "" && r.Date < date {
+		return false
+	}
+	if dateTo != "" && r.Date > dateTo {
+		return false
+	}
+	if itemId != 0 && r.ItemId != itemId {
+		return false
+	}
+	if mobId != 0 && r.MobId != mobId {
+		return false
+	}
+	if roomId != 0 && r.RoomId != roomId {
+		return false
+	}
+	return true
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,281 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	mudlog.SetupLogger(nil, "", "", false)
+	os.Exit(m.Run())
+}
+
+func resetState() {
+	records = []Record{}
+	index = map[string]int{}
+	dirty = map[string]bool{}
+	dataDir = ""
+}
+
+func TestTrack_NewRecord(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "frostfang", 0, 7, 100)
+
+	require.Len(t, records, 1)
+	assert.Equal(t, CatMobKill, records[0].Category)
+	assert.Equal(t, "frostfang", records[0].Zone)
+	assert.Equal(t, 7, records[0].MobId)
+	assert.Equal(t, 100, records[0].RoomId)
+	assert.Equal(t, 1, records[0].Count)
+}
+
+func TestTrack_Increment(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "frostfang", 0, 7, 100)
+	Track(CatMobKill, "frostfang", 0, 7, 100)
+	Track(CatMobKill, "frostfang", 0, 7, 100)
+
+	require.Len(t, records, 1)
+	assert.Equal(t, 3, records[0].Count)
+}
+
+func TestTrack_DifferentDimensions(t *testing.T) {
+	resetState()
+
+	Track(CatItemDrop, "zone1", 42, 7, 100)
+	Track(CatItemDrop, "zone1", 42, 8, 100)
+	Track(CatItemDrop, "zone2", 42, 7, 200)
+
+	assert.Len(t, records, 3)
+}
+
+func TestTrack_MarksDirty(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "z", 0, 1, 10)
+
+	assert.Len(t, dirty, 1)
+	for date := range dirty {
+		assert.Len(t, date, 8) // YYYYMMDD
+	}
+}
+
+func TestQuery_FilterByCategory(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "zone1", 0, 1, 10)
+	Track(CatItemDrop, "zone1", 5, 1, 10)
+	Track(CatMobKill, "zone1", 0, 2, 11)
+
+	results := Query().Category(CatMobKill).Results()
+	assert.Len(t, results, 2)
+	for _, r := range results {
+		assert.Equal(t, CatMobKill, r.Category)
+	}
+}
+
+func TestQuery_FilterByItemId(t *testing.T) {
+	resetState()
+
+	Track(CatItemDrop, "zone1", 42, 7, 100)
+	Track(CatItemDrop, "zone1", 43, 7, 100)
+	Track(CatItemDrop, "zone1", 42, 8, 101)
+
+	results := Query().Category(CatItemDrop).ItemId(42).Results()
+	assert.Len(t, results, 2)
+	for _, r := range results {
+		assert.Equal(t, 42, r.ItemId)
+	}
+}
+
+func TestQuery_FilterByMobId(t *testing.T) {
+	resetState()
+
+	Track(CatItemDrop, "zone1", 42, 7, 100)
+	Track(CatItemDrop, "zone1", 43, 7, 100)
+	Track(CatItemDrop, "zone1", 42, 8, 101)
+
+	results := Query().Category(CatItemDrop).MobId(7).Results()
+	assert.Len(t, results, 2)
+	for _, r := range results {
+		assert.Equal(t, 7, r.MobId)
+	}
+}
+
+func TestQuery_FilterByZone(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "frostfang", 0, 1, 10)
+	Track(CatMobKill, "frostfang", 0, 2, 11)
+	Track(CatMobKill, "dungeon", 0, 3, 20)
+
+	results := Query().Zone("frostfang").Results()
+	assert.Len(t, results, 2)
+}
+
+func TestQuery_FilterByDateRange(t *testing.T) {
+	resetState()
+
+	records = []Record{
+		{Date: "20260101", Category: CatMobKill, MobId: 1, Count: 5},
+		{Date: "20260201", Category: CatMobKill, MobId: 2, Count: 3},
+		{Date: "20260301", Category: CatMobKill, MobId: 3, Count: 7},
+	}
+	rebuildIndex()
+
+	results := Query().DateFrom("20260201").DateTo("20260301").Results()
+	assert.Len(t, results, 2)
+}
+
+func TestQuery_FilterByExactDate(t *testing.T) {
+	resetState()
+
+	records = []Record{
+		{Date: "20260101", Category: CatMobKill, MobId: 1, Count: 5},
+		{Date: "20260201", Category: CatMobKill, MobId: 2, Count: 3},
+	}
+	rebuildIndex()
+
+	results := Query().Date("20260101").Results()
+	require.Len(t, results, 1)
+	assert.Equal(t, 1, results[0].MobId)
+}
+
+func TestQuery_SortDesc(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "z", 0, 1, 10)
+	Track(CatMobKill, "z", 0, 1, 10)
+	Track(CatMobKill, "z", 0, 2, 11)
+
+	results := Query().Category(CatMobKill).SortDesc().Results()
+	require.Len(t, results, 2)
+	assert.True(t, results[0].Count >= results[1].Count)
+}
+
+func TestQuery_SortAsc(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "z", 0, 1, 10)
+	Track(CatMobKill, "z", 0, 1, 10)
+	Track(CatMobKill, "z", 0, 2, 11)
+
+	results := Query().Category(CatMobKill).SortAsc().Results()
+	require.Len(t, results, 2)
+	assert.True(t, results[0].Count <= results[1].Count)
+}
+
+func TestQuery_Total(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "z", 0, 1, 10)
+	Track(CatMobKill, "z", 0, 1, 10)
+	Track(CatMobKill, "z", 0, 2, 11)
+
+	total := Query().Category(CatMobKill).Total()
+	assert.Equal(t, 3, total)
+}
+
+func TestClear(t *testing.T) {
+	resetState()
+
+	Track(CatMobKill, "frostfang", 0, 1, 10)
+	Track(CatItemDrop, "frostfang", 5, 1, 10)
+	Track(CatMobKill, "dungeon", 0, 2, 20)
+
+	Clear(CatMobKill, "frostfang", "", "", 0, 0, 0)
+
+	results := Query().Category(CatMobKill).Results()
+	assert.Len(t, results, 1)
+	assert.Equal(t, "dungeon", results[0].Zone)
+
+	allResults := Query().Results()
+	assert.Len(t, allResults, 2)
+}
+
+func TestSaveLoad_RoundTrip(t *testing.T) {
+	resetState()
+
+	base := t.TempDir()
+	dataDir = filepath.Join(base, "telemetry")
+
+	// Inject two records with known dates so we can assert per-file layout.
+	records = []Record{
+		{Date: "20260101", Category: CatMobKill, MobId: 7, Zone: "zone1", Count: 2},
+		{Date: "20260102", Category: CatItemDrop, ItemId: 42, Zone: "zone2", Count: 1},
+	}
+	rebuildIndex()
+	dirty["20260101"] = true
+	dirty["20260102"] = true
+
+	require.NoError(t, Save())
+
+	// Verify two separate files were written.
+	assert.FileExists(t, filepath.Join(dataDir, "20260101.yaml"))
+	assert.FileExists(t, filepath.Join(dataDir, "20260102.yaml"))
+
+	// Reload from directory.
+	resetState()
+	Load(base)
+
+	results := Query().Results()
+	require.Len(t, results, 2)
+
+	kills := Query().Category(CatMobKill).Results()
+	require.Len(t, kills, 1)
+	assert.Equal(t, 2, kills[0].Count)
+
+	drops := Query().Category(CatItemDrop).Results()
+	require.Len(t, drops, 1)
+	assert.Equal(t, 42, drops[0].ItemId)
+}
+
+func TestSave_DeletesFileWhenDateCleared(t *testing.T) {
+	resetState()
+
+	base := t.TempDir()
+	dataDir = filepath.Join(base, "telemetry")
+
+	records = []Record{
+		{Date: "20260101", Category: CatMobKill, MobId: 1, Count: 3},
+		{Date: "20260102", Category: CatMobKill, MobId: 2, Count: 1},
+	}
+	rebuildIndex()
+	dirty["20260101"] = true
+	dirty["20260102"] = true
+	require.NoError(t, Save())
+
+	// Clear only the first date.
+	Clear("", "", "20260101", "20260101", 0, 0, 0)
+	require.NoError(t, Save())
+
+	assert.NoFileExists(t, filepath.Join(dataDir, "20260101.yaml"))
+	assert.FileExists(t, filepath.Join(dataDir, "20260102.yaml"))
+}
+
+func TestLoad_EmptyDirectory(t *testing.T) {
+	resetState()
+
+	base := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(base, "telemetry"), 0755))
+	Load(base)
+
+	assert.Empty(t, records)
+	assert.Empty(t, index)
+}
+
+func TestLoad_MissingDirectory(t *testing.T) {
+	resetState()
+
+	Load(t.TempDir()) // telemetry subdir does not exist
+
+	assert.Empty(t, records)
+	assert.Empty(t, index)
+}

--- a/internal/usercommands/admin.rankings.go
+++ b/internal/usercommands/admin.rankings.go
@@ -1,0 +1,291 @@
+package usercommands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/combat"
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/templates"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+// colorNum wraps a numeric string in green (positive), red (negative), or
+// yellow (zero) ANSI tags.
+func colorNum(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	if s[0] == '-' {
+		return `<ansi fg="red">` + s + `</ansi>`
+	}
+	if s == "0" || s == "0.0" || s == "0.00" || s == "0.000" {
+		return `<ansi fg="yellow">` + s + `</ansi>`
+	}
+	return `<ansi fg="green">` + s + `</ansi>`
+}
+
+/*
+* Role Permissions:
+* rankings 				(All)
+ */
+func Rankings(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+
+	args := strings.Fields(rest)
+
+	if len(args) == 0 {
+		infoOutput, _ := templates.Process("admincommands/help/command.rankings", nil, user.UserId)
+		user.SendText(infoOutput)
+		return true, nil
+	}
+
+	subCmd := strings.ToLower(args[0])
+
+	switch subCmd {
+	case "pets":
+		return rankings_Pets(args[1:], user)
+	case "weapons":
+		return rankings_Weapons(args[1:], user)
+	case "armor":
+		return rankings_Armor(args[1:], user)
+	default:
+		infoOutput, _ := templates.Process("admincommands/help/command.rankings", nil, user.UserId)
+		user.SendText(infoOutput)
+		return true, nil
+	}
+}
+
+func rankings_Pets(args []string, user *users.UserRecord) (bool, error) {
+
+	mode := "overall"
+	if len(args) > 0 {
+		switch strings.ToLower(args[0]) {
+		case "combat", "utility", "overall":
+			mode = strings.ToLower(args[0])
+		default:
+			user.SendText(fmt.Sprintf(`Unknown sort mode "<ansi fg="red">%s</ansi>". Valid options: <ansi fg="command">combat</ansi>, <ansi fg="command">utility</ansi>, <ansi fg="command">overall</ansi>`, args[0]))
+			return true, nil
+		}
+	}
+
+	byCombat, byUtility, byOverall := combat.RankPets()
+
+	var ranked []combat.PetRank
+	var scoreLabel string
+	var titleSuffix string
+
+	switch mode {
+	case "combat":
+		ranked = byCombat
+		scoreLabel = "Combat"
+		titleSuffix = "Combat Score"
+	case "utility":
+		ranked = byUtility
+		scoreLabel = "Utility"
+		titleSuffix = "Utility Score"
+	default:
+		ranked = byOverall
+		scoreLabel = "Overall"
+		titleSuffix = "Overall Score"
+	}
+
+	headers := []string{"Rank", "Type", "PeakDPS", "PeakStats", "PeakCap", "Buffs", "BuffVal", scoreLabel}
+	rows := make([][]string, 0, len(ranked))
+	formatting := make([][]string, 0, len(ranked))
+
+	for i, r := range ranked {
+		var score string
+		switch mode {
+		case "combat":
+			score = colorNum(fmt.Sprintf("%.3f", r.CombatScore))
+		case "utility":
+			score = colorNum(fmt.Sprintf("%.3f", r.UtilityScore))
+		default:
+			score = colorNum(fmt.Sprintf("%.3f", r.OverallScore))
+		}
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", i+1),
+			r.Type,
+			colorNum(fmt.Sprintf("%.2f", r.PeakDPS)),
+			colorNum(fmt.Sprintf("%d", r.PeakStatTotal)),
+			colorNum(fmt.Sprintf("%d", r.PeakCapacity)),
+			colorNum(fmt.Sprintf("%d", r.PeakBuffCount)),
+			colorNum(fmt.Sprintf("%d", r.PeakBuffValue)),
+			score,
+		})
+		formatting = append(formatting, []string{
+			`<ansi fg="yellow">%s</ansi>`,
+			`<ansi fg="petname">%s</ansi>`,
+			`%s`, `%s`, `%s`, `%s`, `%s`, `%s`,
+		})
+	}
+
+	tblData := templates.GetTable(fmt.Sprintf("Pet Rankings by %s", titleSuffix), headers, rows, formatting...)
+	tplTxt, _ := templates.Process("tables/generic", tblData, user.UserId)
+	user.SendText(tplTxt)
+
+	return true, nil
+}
+
+func rankings_Weapons(args []string, user *users.UserRecord) (bool, error) {
+
+	mode := "dps"
+	if len(args) > 0 {
+		switch strings.ToLower(args[0]) {
+		case "dps", "dps-adj", "max":
+			mode = strings.ToLower(args[0])
+		default:
+			user.SendText(fmt.Sprintf(`Unknown sort mode "<ansi fg="red">%s</ansi>". Valid options: <ansi fg="command">dps</ansi>, <ansi fg="command">dps-adj</ansi>, <ansi fg="command">max</ansi>`, args[0]))
+			return true, nil
+		}
+	}
+
+	byDPS, byAdjDPS, byMaxDmg := combat.RankWeapons()
+
+	var ranked []combat.WeaponRank
+	var scoreLabel string
+	var titleSuffix string
+
+	switch mode {
+	case "dps-adj":
+		ranked = byAdjDPS
+		scoreLabel = "AdjDPS"
+		titleSuffix = "Adjusted DPS"
+	case "max":
+		ranked = byMaxDmg
+		scoreLabel = "MaxDmg"
+		titleSuffix = "Max Damage"
+	default:
+		ranked = byDPS
+		scoreLabel = "DPS"
+		titleSuffix = "DPS"
+	}
+
+	headers := []string{"Rank", "Name", "Dice", "Subtype", "Hands", "Wait", scoreLabel}
+	rows := make([][]string, 0, len(ranked))
+	formatting := make([][]string, 0, len(ranked))
+
+	for i, r := range ranked {
+		var score string
+		switch mode {
+		case "dps-adj":
+			score = colorNum(fmt.Sprintf("%.3f", r.AdjDPS))
+		case "max":
+			score = fmt.Sprintf(`<ansi fg="green">%d</ansi> <ansi fg="yellow">(avg %.2f)</ansi>`, r.MaxDmg, r.AvgDmg)
+		default:
+			score = colorNum(fmt.Sprintf("%.3f", r.DPS))
+		}
+
+		waitStr := fmt.Sprintf("%d", r.WaitRounds)
+		if r.WaitRounds > 0 {
+			waitStr = `<ansi fg="red">` + waitStr + `</ansi>`
+		} else {
+			waitStr = `<ansi fg="yellow">` + waitStr + `</ansi>`
+		}
+
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", i+1),
+			r.Name,
+			r.DiceRoll,
+			string(r.Subtype),
+			fmt.Sprintf("%d", r.Hands),
+			waitStr,
+			score,
+		})
+		formatting = append(formatting, []string{
+			`<ansi fg="yellow">%s</ansi>`,
+			`<ansi fg="itemname">%s</ansi>`,
+			`<ansi fg="cyan">%s</ansi>`,
+			`<ansi fg="white">%s</ansi>`,
+			`<ansi fg="white">%s</ansi>`,
+			`%s`,
+			`%s`,
+		})
+	}
+
+	tblData := templates.GetTable(fmt.Sprintf("Weapon Rankings by %s", titleSuffix), headers, rows, formatting...)
+	tplTxt, _ := templates.Process("tables/generic", tblData, user.UserId)
+	user.SendText(tplTxt)
+
+	return true, nil
+}
+
+func rankings_Armor(args []string, user *users.UserRecord) (bool, error) {
+
+	mode := "def"
+	if len(args) > 0 {
+		switch strings.ToLower(args[0]) {
+		case "def", "def-adj", "score":
+			mode = strings.ToLower(args[0])
+		default:
+			user.SendText(fmt.Sprintf(`Unknown sort mode "<ansi fg="red">%s</ansi>". Valid options: <ansi fg="command">def</ansi>, <ansi fg="command">def-adj</ansi>, <ansi fg="command">score</ansi>`, args[0]))
+			return true, nil
+		}
+	}
+
+	byDefense, byAdjDefense, byScore := combat.RankArmor()
+
+	var ranked []combat.ArmorRank
+	var scoreLabel string
+	var titleSuffix string
+
+	switch mode {
+	case "def-adj":
+		ranked = byAdjDefense
+		scoreLabel = "AdjDef"
+		titleSuffix = "Adjusted Defense"
+	case "score":
+		ranked = byScore
+		scoreLabel = "Score"
+		titleSuffix = "Score"
+	default:
+		ranked = byDefense
+		scoreLabel = "Defense"
+		titleSuffix = "Defense"
+	}
+
+	headers := []string{"Rank", "Name", "Slot", "Cursed", "Buffs", "Stats", scoreLabel}
+	rows := make([][]string, 0, len(ranked))
+	formatting := make([][]string, 0, len(ranked))
+
+	for i, r := range ranked {
+		var cursed string
+		if r.Cursed {
+			cursed = `<ansi fg="red">yes</ansi>`
+		}
+
+		var score string
+		switch mode {
+		case "def-adj":
+			score = colorNum(fmt.Sprintf("%.1f", r.AdjDefense))
+		case "score":
+			score = colorNum(fmt.Sprintf("%.2f", r.Score))
+		default:
+			score = colorNum(fmt.Sprintf("%d", r.Defense))
+		}
+
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", i+1),
+			r.Name,
+			r.Slot,
+			cursed,
+			colorNum(fmt.Sprintf("%d", r.BuffCount)),
+			colorNum(fmt.Sprintf("%d", r.StatBonus)),
+			score,
+		})
+		formatting = append(formatting, []string{
+			`<ansi fg="yellow">%s</ansi>`,
+			`<ansi fg="itemname">%s</ansi>`,
+			`<ansi fg="white">%s</ansi>`,
+			`%s`,
+			`%s`, `%s`, `%s`,
+		})
+	}
+
+	tblData := templates.GetTable(fmt.Sprintf("Armor Rankings by %s", titleSuffix), headers, rows, formatting...)
+	tplTxt, _ := templates.Process("tables/generic", tblData, user.UserId)
+	user.SendText(tplTxt)
+
+	return true, nil
+}

--- a/internal/usercommands/admin.telemetry.go
+++ b/internal/usercommands/admin.telemetry.go
@@ -1,0 +1,174 @@
+package usercommands
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/telemetry"
+	"github.com/GoMudEngine/GoMud/internal/templates"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+/*
+* Role Permissions:
+* telemetry			(Admin only)
+ */
+func Telemetry(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+
+	args := util.SplitButRespectQuotes(strings.ToLower(rest))
+
+	if len(args) == 0 || args[0] == "help" {
+		user.SendText(`<ansi fg="white-bold">Telemetry Commands:</ansi>`)
+		user.SendText(`  <ansi fg="command">telemetry list item_drops</ansi>  [itemId=N] [mobId=N] [zone=X] [date=YYYYMMDD] [dateFrom=YYYYMMDD] [dateTo=YYYYMMDD] [asc|desc]`)
+		user.SendText(`  <ansi fg="command">telemetry list item_pickups</ansi> [itemId=N] [zone=X] [date=YYYYMMDD] [asc|desc]`)
+		user.SendText(`  <ansi fg="command">telemetry list mob_kills</ansi>    [mobId=N] [zone=X] [date=YYYYMMDD] [asc|desc]`)
+		user.SendText(`  <ansi fg="command">telemetry list player_deaths</ansi>[mobId=N] [zone=X] [date=YYYYMMDD] [asc|desc]`)
+		user.SendText(`  <ansi fg="command">telemetry list item_purchases</ansi>[itemId=N] [mobId=N] [date=YYYYMMDD] [asc|desc]`)
+		user.SendText(`  <ansi fg="command">telemetry clear</ansi> [category] [date=YYYYMMDD]`)
+		user.SendText(`  <ansi fg="command">telemetry save</ansi>`)
+		return true, nil
+	}
+
+	switch args[0] {
+
+	case "save":
+		if err := telemetry.Save(); err != nil {
+			user.SendText(fmt.Sprintf(`<ansi fg="red">Error saving telemetry: %s</ansi>`, err.Error()))
+		} else {
+			user.SendText(`Telemetry data saved.`)
+		}
+		return true, nil
+
+	case "clear":
+		category := ""
+		date := ""
+		if len(args) >= 2 {
+			category = normCategory(args[1])
+		}
+		for _, arg := range args[2:] {
+			if strings.HasPrefix(arg, "date=") {
+				date = strings.TrimPrefix(arg, "date=")
+			}
+		}
+		telemetry.Clear(category, "", date, "", 0, 0, 0)
+		user.SendText(`Telemetry records cleared.`)
+		return true, nil
+
+	case "list":
+		if len(args) < 2 {
+			user.SendText(`Usage: telemetry list <category> [filters...]`)
+			return true, nil
+		}
+
+		category := normCategory(args[1])
+		if category == "" {
+			user.SendText(fmt.Sprintf(`Unknown category: %s`, args[1]))
+			return true, nil
+		}
+
+		qb := telemetry.Query().Category(category)
+		descSort := true
+
+		for _, arg := range args[2:] {
+			switch {
+			case arg == "asc":
+				descSort = false
+			case arg == "desc":
+				descSort = true
+			case strings.HasPrefix(arg, "itemid="):
+				if v, err := strconv.Atoi(strings.TrimPrefix(arg, "itemid=")); err == nil {
+					qb = qb.ItemId(v)
+				}
+			case strings.HasPrefix(arg, "mobid="):
+				if v, err := strconv.Atoi(strings.TrimPrefix(arg, "mobid=")); err == nil {
+					qb = qb.MobId(v)
+				}
+			case strings.HasPrefix(arg, "roomid="):
+				if v, err := strconv.Atoi(strings.TrimPrefix(arg, "roomid=")); err == nil {
+					qb = qb.RoomId(v)
+				}
+			case strings.HasPrefix(arg, "zone="):
+				qb = qb.Zone(strings.TrimPrefix(arg, "zone="))
+			case strings.HasPrefix(arg, "date="):
+				qb = qb.Date(strings.TrimPrefix(arg, "date="))
+			case strings.HasPrefix(arg, "datefrom="):
+				qb = qb.DateFrom(strings.TrimPrefix(arg, "datefrom="))
+			case strings.HasPrefix(arg, "dateto="):
+				qb = qb.DateTo(strings.TrimPrefix(arg, "dateto="))
+			}
+		}
+
+		if descSort {
+			qb = qb.SortDesc()
+		} else {
+			qb = qb.SortAsc()
+		}
+
+		results := qb.Results()
+		if len(results) == 0 {
+			user.SendText(`No telemetry records found.`)
+			return true, nil
+		}
+
+		headers := []string{`Date`, `Category`, `ItemId`, `MobId`, `RoomId`, `Zone`, `Count`}
+		formatting := []string{
+			`<ansi fg="cyan">%s</ansi>`,
+			`<ansi fg="white">%s</ansi>`,
+			`<ansi fg="itemname">%s</ansi>`,
+			`<ansi fg="mobname">%s</ansi>`,
+			`%s`,
+			`<ansi fg="room-title">%s</ansi>`,
+			`<ansi fg="yellow-bold">%s</ansi>`,
+		}
+
+		rows := make([][]string, 0, len(results))
+		for _, r := range results {
+			rows = append(rows, []string{
+				r.Date,
+				r.Category,
+				intOrEmpty(r.ItemId),
+				intOrEmpty(r.MobId),
+				intOrEmpty(r.RoomId),
+				r.Zone,
+				strconv.Itoa(r.Count),
+			})
+		}
+
+		title := fmt.Sprintf(`Telemetry: %s (%d records)`, category, len(results))
+		tblData := templates.GetTable(title, headers, rows, formatting)
+		tplTxt, _ := templates.Process("tables/generic", tblData, user.UserId)
+		user.SendText(tplTxt)
+
+		return true, nil
+	}
+
+	user.SendText(fmt.Sprintf(`Unknown telemetry command: %s`, args[0]))
+	return true, nil
+}
+
+func normCategory(s string) string {
+	switch s {
+	case "item_drops", "item_drop":
+		return telemetry.CatItemDrop
+	case "item_pickups", "item_pickup":
+		return telemetry.CatItemPickup
+	case "mob_kills", "mob_kill":
+		return telemetry.CatMobKill
+	case "player_deaths", "player_death":
+		return telemetry.CatPlayerDeath
+	case "item_purchases", "item_purchase":
+		return telemetry.CatItemPurchase
+	}
+	return ""
+}
+
+func intOrEmpty(v int) string {
+	if v == 0 {
+		return ""
+	}
+	return strconv.Itoa(v)
+}

--- a/internal/usercommands/suicide.go
+++ b/internal/usercommands/suicide.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/colorpatterns"
 	"github.com/GoMudEngine/GoMud/internal/configs"
 	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/mobs"
 	"github.com/GoMudEngine/GoMud/internal/rooms"
 	"github.com/GoMudEngine/GoMud/internal/templates"
 	"github.com/GoMudEngine/GoMud/internal/term"
@@ -90,6 +91,14 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room, flags events
 
 	allowPenalties := user.Character.Level > int(config.Death.ProtectionLevels)
 
+	killerMobId := 0
+	if user.Character.KillerMobInstanceId > 0 {
+		if killerMob := mobs.GetInstance(user.Character.KillerMobInstanceId); killerMob != nil {
+			killerMobId = int(killerMob.MobId)
+		}
+		user.Character.KillerMobInstanceId = 0
+	}
+
 	events.AddToQueue(events.PlayerDeath{
 		UserId:        user.UserId,
 		RoomId:        user.Character.RoomId,
@@ -97,6 +106,7 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room, flags events
 		CharacterName: user.Character.Name,
 		Permanent:     allowPenalties && bool(config.Death.PermaDeath) && user.Character.ExtraLives == 0,
 		KilledByUsers: killedByUserIds,
+		KillerMobId:   killerMobId,
 	})
 
 	// If permadeath is enabled, do some extra bookkeeping

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -160,7 +160,8 @@ var (
 		`status`:      {Status, true, false},
 
 		`suicide`:    {Suicide, true, false},
-		`syslogs`:    {SysLogs, true, true}, // Admin only
+		`syslogs`:    {SysLogs, true, true},   // Admin only
+		`telemetry`:  {Telemetry, true, true}, // Admin only
 		`tame`:       {Tame, false, false},
 		`teleport`:   {Teleport, true, true}, // Admin only
 		`throw`:      {Throw, false, false},

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -131,6 +131,7 @@ var (
 		`quit`:        {Quit, true, false},
 		`questtoken`:  {QuestToken, false, true}, // Admin only
 		`rank`:        {Rank, false, false},
+		`rankings`:    {Rankings, false, true}, // Admin only
 		`read`:        {Read, false, false},
 		`recover`:     {Recover, false, false},
 		`reload`:      {Reload, true, true}, // Admin only

--- a/internal/web/admin_nav.go
+++ b/internal/web/admin_nav.go
@@ -187,11 +187,11 @@ func buildAdminNav() []WebNavItem {
 					},
 				},
 				{
-					Name:   "GameTime",
-					Target: "/admin/gametime",
+					Name:   "Telemetry",
+					Target: "/admin/telemetry",
 					SubItems: []WebNavSub{
-						{Label: "View / Edit", Target: "/admin/gametime"},
-						{Label: "API Docs", Target: "/admin/gametime-api"},
+						{Label: "View / Query", Target: "/admin/telemetry"},
+						{Label: "API Docs", Target: "/admin/telemetry-api"},
 					},
 				},
 				{
@@ -200,6 +200,14 @@ func buildAdminNav() []WebNavItem {
 					SubItems: []WebNavSub{
 						{Label: "View", Target: "/admin/stats"},
 						{Label: "API Docs", Target: "/admin/stats-api"},
+					},
+				},
+				{
+					Name:   "GameTime",
+					Target: "/admin/gametime",
+					SubItems: []WebNavSub{
+						{Label: "View / Edit", Target: "/admin/gametime"},
+						{Label: "API Docs", Target: "/admin/gametime-api"},
 					},
 				},
 				{

--- a/internal/web/admin_routes.go
+++ b/internal/web/admin_routes.go
@@ -157,6 +157,13 @@ func registerAdminRoutes(mux *http.ServeMux) {
 		doBasicAuth(adminStatsAPI),
 	))
 
+	mux.HandleFunc("GET /admin/telemetry", RunWithMUDLocked(
+		doBasicAuth(adminTelemetry),
+	))
+	mux.HandleFunc("GET /admin/telemetry-api", RunWithMUDLocked(
+		doBasicAuth(adminTelemetryAPI),
+	))
+
 	mux.HandleFunc("GET /admin/spells", RunWithMUDLocked(
 		doBasicAuth(adminSpells),
 	))

--- a/internal/web/admin_telemetry.go
+++ b/internal/web/admin_telemetry.go
@@ -1,0 +1,100 @@
+package web
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/GoMudEngine/GoMud/internal/telemetry"
+)
+
+func adminTelemetry(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "telemetry.html", nil)
+}
+
+func adminTelemetryAPI(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "telemetry-api.html", nil)
+}
+
+// GET /admin/api/v1/telemetry
+// Query params: category, itemId, mobId, roomId, zone, date, dateFrom, dateTo, sort (asc|desc)
+func apiV1GetTelemetry(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	qb := telemetry.Query()
+
+	if v := q.Get("category"); v != "" {
+		qb = qb.Category(v)
+	}
+	if v := q.Get("zone"); v != "" {
+		qb = qb.Zone(v)
+	}
+	if v := q.Get("date"); v != "" {
+		qb = qb.Date(v)
+	}
+	if v := q.Get("dateFrom"); v != "" {
+		qb = qb.DateFrom(v)
+	}
+	if v := q.Get("dateTo"); v != "" {
+		qb = qb.DateTo(v)
+	}
+	if v := q.Get("itemId"); v != "" {
+		if id, err := strconv.Atoi(v); err == nil {
+			qb = qb.ItemId(id)
+		}
+	}
+	if v := q.Get("mobId"); v != "" {
+		if id, err := strconv.Atoi(v); err == nil {
+			qb = qb.MobId(id)
+		}
+	}
+	if v := q.Get("roomId"); v != "" {
+		if id, err := strconv.Atoi(v); err == nil {
+			qb = qb.RoomId(id)
+		}
+	}
+
+	if q.Get("sort") == "asc" {
+		qb = qb.SortAsc()
+	} else {
+		qb = qb.SortDesc()
+	}
+
+	results := qb.Results()
+	if results == nil {
+		results = []telemetry.Record{}
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[[]telemetry.Record]{
+		Success: true,
+		Data:    results,
+	})
+}
+
+// DELETE /admin/api/v1/telemetry
+// Query params: category, zone, date, dateFrom, dateTo (all optional - omit to clear all)
+func apiV1DeleteTelemetry(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	category := q.Get("category")
+	zone := q.Get("zone")
+	date := q.Get("date")
+	dateTo := q.Get("dateTo")
+
+	// A bare "date" param sets both bounds to that single day.
+	// dateFrom/dateTo allow clearing a range.
+	if date != "" && dateTo == "" {
+		dateTo = date
+	}
+	if v := q.Get("dateFrom"); v != "" && date == "" {
+		date = v
+	}
+
+	telemetry.Clear(category, zone, date, dateTo, 0, 0, 0)
+
+	if err := telemetry.Save(); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}

--- a/internal/web/api_routes.go
+++ b/internal/web/api_routes.go
@@ -9,6 +9,14 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/api/v1/scripting/functions", RunWithMUDLocked(
 		doBasicAuth(apiV1GetScriptFunctions),
 	))
+
+	// Telemetry
+	mux.HandleFunc("GET /admin/api/v1/telemetry", RunWithMUDLocked(
+		doBasicAuth(apiV1GetTelemetry),
+	))
+	mux.HandleFunc("DELETE /admin/api/v1/telemetry", RunWithMUDLocked(
+		doBasicAuth(apiV1DeleteTelemetry),
+	))
 	mux.HandleFunc("POST /admin/api/v1/scripting/validate", RunWithMUDLocked(
 		doBasicAuth(apiV1ValidateScript),
 	))

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/scripting"
 	"github.com/GoMudEngine/GoMud/internal/spells"
 	"github.com/GoMudEngine/GoMud/internal/suggestions"
+	"github.com/GoMudEngine/GoMud/internal/telemetry"
 	"github.com/GoMudEngine/GoMud/internal/templates"
 	"github.com/GoMudEngine/GoMud/internal/term"
 	"github.com/GoMudEngine/GoMud/internal/users"
@@ -211,6 +212,9 @@ func main() {
 	})
 
 	hooks.RegisterListeners()
+
+	telemetry.Load(configs.GetFilePathsConfig().DataFiles.String())
+	telemetry.RegisterListeners()
 
 	// Discord integration
 	if webhookUrl := string(c.Integrations.Discord.WebhookUrl); webhookUrl != "" {


### PR DESCRIPTION
# Description

This PR introduces a telemetry system for tracking aggregated in-game event data, an admin `rankings` in-game command mirroring the existing admin web rankings pages, and test coverage for the `plugins` package.

The telemetry system is core server functionality (not a plugin). It listens to game events, accumulates daily-bucketed counters in memory, persists them as one YAML file per day under `<DataFiles>/telemetry/`, and flushes on the natural autosave cycle.

## Changes

- Added `internal/telemetry` — core telemetry package tracking five event categories: `item_drop`, `item_pickup`, `mob_kill`, `player_death`, and `item_purchase`. Records are keyed by date, category, and relevant dimension fields (item ID, mob ID, room ID, zone). A fluent `QueryBuilder` supports filtering by any combination of those dimensions plus date ranges. Data is persisted as one `YYYYMMDD.yaml` file per day; only dates with changes are written on each autosave. Memory usage is reported in the `util` memory system alongside other subsystems.

- Added admin web UI for telemetry at `/admin/telemetry` and `/admin/telemetry-api` — the query page resolves item, mob, and room IDs to names and links each cell to its respective admin editor page. The API docs page covers the `GET` and `DELETE` endpoints with parameter tables and curl examples.

- Added `telemetry` admin in-game command — admin-only command supporting `list`, `clear`, and `save` subcommands with the same filter dimensions available in the web UI.

- Added two new event types to support telemetry — `MobItemDrop` (fired for each item that actually drops from a mob on death) and `KillerMobId` on `PlayerDeath` (carries the mob spec ID of the killing mob). The kill-side wiring captures aggro state before it is cleared and threads it through to the `suicide` command.

- Added `rankings` admin in-game command — mirrors the existing `/admin` web rankings pages in-game. Supports `rankings pets [combat|utility|overall]`, `rankings weapons [dps|dps-adj|max]`, and `rankings armor [def|def-adj|score]`, each rendering a formatted table with color-coded numeric columns.

- Added `internal/plugins` test suite — covers the full public surface of the plugins package: file system attachment and path normalisation (`ReadFile`, `Open`, `Stat` with backslash and double-slash paths), registry first-wins semantics across multiple plugins, `WriteBytes`/`ReadBytes` and `WriteStruct`/`ReadIntoStruct` persistence round-trips, plugin name sanitisation, registration-closed guard, room tag reservation, exported function registration and lookup, and dependency tracking via `Requires`.
