### PR TITLE
Auto mission module

### DIFF
--- a/_datafiles/html/admin/mapper.html
+++ b/_datafiles/html/admin/mapper.html
@@ -1400,16 +1400,14 @@
     .re-tag-picker-wrap { position: relative; display: inline-block; }
     .re-tag-picker-dropdown {
         display: none;
-        position: absolute;
-        top: 100%;
-        left: 0;
-        z-index: 1100;
+        position: fixed;
+        z-index: 1200;
         background: var(--color-surface-white);
         border: 1px solid var(--color-border);
         border-radius: 6px;
-        min-width: 200px;
-        max-width: 320px;
-        max-height: 240px;
+        min-width: 320px;
+        max-width: 480px;
+        max-height: 280px;
         overflow-y: auto;
         padding: 4px 0;
         box-shadow: 0 4px 16px rgba(0,0,0,0.5);

--- a/_datafiles/html/admin/static/js/mapper/mapper-ui.js
+++ b/_datafiles/html/admin/static/js/mapper/mapper-ui.js
@@ -1464,6 +1464,10 @@ var MapperUI = (function() {
                     var searchEl = document.getElementById('room-editor-tag-search');
                     if (searchEl) searchEl.value = '';
                     _reTagBuildPickerList('');
+                    // Position the fixed dropdown below the button
+                    var rect = newTagPickBtn.getBoundingClientRect();
+                    dd.style.top  = (rect.bottom + 4) + 'px';
+                    dd.style.left = rect.left + 'px';
                     dd.classList.add('open');
                     if (searchEl) setTimeout(function() { searchEl.focus(); }, 30);
                 }

--- a/_datafiles/world/default/rooms/frostfang/829.yaml
+++ b/_datafiles/world/default/rooms/frostfang/829.yaml
@@ -13,6 +13,7 @@ description: Nestled within the fortified city of Frostfang, the training yard n
   breath visible in the cold. Here, under the watchful eye of the Master-at-Arms,
   warriors are forged, their skills honed against the ever-present backdrop of Frostfang's
   icy embrace.
+biome: city
 exits:
   south:
     roomid: 270
@@ -24,6 +25,11 @@ skilltraining:
   brawling:
     min: 1
     max: 4
+tags:
+- missionboard kill_mob
+- missionboard find_item
+- missionboard explore
+- missionboard escort
 mapx: 1
 mapy: -5
 mapz: 0

--- a/modules/all-modules.go
+++ b/modules/all-modules.go
@@ -8,6 +8,7 @@ package modules
 import (
 	_ "github.com/GoMudEngine/GoMud/modules/alt-characters"
 	_ "github.com/GoMudEngine/GoMud/modules/auctions"
+	_ "github.com/GoMudEngine/GoMud/modules/automission"
 	_ "github.com/GoMudEngine/GoMud/modules/cleanup"
 	_ "github.com/GoMudEngine/GoMud/modules/clibridge"
 	_ "github.com/GoMudEngine/GoMud/modules/elections"

--- a/modules/automission/admin_api.go
+++ b/modules/automission/admin_api.go
@@ -1,0 +1,240 @@
+package automission
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/GoMudEngine/GoMud/internal/configs"
+)
+
+// rewardEntry is the JSON shape for one entry in a reward pool.
+type rewardEntry struct {
+	Type   string `json:"Type" yaml:"Type"`
+	Amount int    `json:"Amount" yaml:"Amount"`
+}
+
+// complexConfig holds all the config keys that cannot go through SetVal.
+type complexConfig struct {
+	EscortMobIds []int `yaml:"EscortMobIds"`
+
+	KillMobEasyRewards  []rewardEntry `yaml:"KillMobEasyRewards"`
+	KillMobHardRewards  []rewardEntry `yaml:"KillMobHardRewards"`
+	FindItemEasyRewards []rewardEntry `yaml:"FindItemEasyRewards"`
+	FindItemHardRewards []rewardEntry `yaml:"FindItemHardRewards"`
+	ExploreEasyRewards  []rewardEntry `yaml:"ExploreEasyRewards"`
+	ExploreHardRewards  []rewardEntry `yaml:"ExploreHardRewards"`
+	EscortEasyRewards   []rewardEntry `yaml:"EscortEasyRewards"`
+	EscortHardRewards   []rewardEntry `yaml:"EscortHardRewards"`
+
+	KillMobEasyRewardItems  []int `yaml:"KillMobEasyRewardItems"`
+	KillMobHardRewardItems  []int `yaml:"KillMobHardRewardItems"`
+	FindItemEasyRewardItems []int `yaml:"FindItemEasyRewardItems"`
+	FindItemHardRewardItems []int `yaml:"FindItemHardRewardItems"`
+	ExploreEasyRewardItems  []int `yaml:"ExploreEasyRewardItems"`
+	ExploreHardRewardItems  []int `yaml:"ExploreHardRewardItems"`
+	EscortEasyRewardItems   []int `yaml:"EscortEasyRewardItems"`
+	EscortHardRewardItems   []int `yaml:"EscortHardRewardItems"`
+}
+
+const complexConfigKey = "complex-config"
+
+// loadComplexConfig reads the persisted complex config from plugin storage.
+func (m *AutoMissionModule) loadComplexConfig() complexConfig {
+	var cc complexConfig
+	m.plug.ReadIntoStruct(complexConfigKey, &cc)
+	return cc
+}
+
+// saveComplexConfig persists the complex config to plugin storage.
+func (m *AutoMissionModule) saveComplexConfig(cc complexConfig) error {
+	return m.plug.WriteStruct(complexConfigKey, cc)
+}
+
+// configSlice reads a complex config key, checking plugin storage first,
+// then falling back to the overlay config (for defaults from config.yaml).
+func (m *AutoMissionModule) configSlice(key string) []any {
+	cc := m.loadComplexConfig()
+
+	switch key {
+	case "EscortMobIds":
+		return intsToAny(cc.EscortMobIds)
+	case "KillMobEasyRewards":
+		return rewardsToAny(cc.KillMobEasyRewards)
+	case "KillMobHardRewards":
+		return rewardsToAny(cc.KillMobHardRewards)
+	case "FindItemEasyRewards":
+		return rewardsToAny(cc.FindItemEasyRewards)
+	case "FindItemHardRewards":
+		return rewardsToAny(cc.FindItemHardRewards)
+	case "ExploreEasyRewards":
+		return rewardsToAny(cc.ExploreEasyRewards)
+	case "ExploreHardRewards":
+		return rewardsToAny(cc.ExploreHardRewards)
+	case "EscortEasyRewards":
+		return rewardsToAny(cc.EscortEasyRewards)
+	case "EscortHardRewards":
+		return rewardsToAny(cc.EscortHardRewards)
+	case "KillMobEasyRewardItems":
+		return intsToAny(cc.KillMobEasyRewardItems)
+	case "KillMobHardRewardItems":
+		return intsToAny(cc.KillMobHardRewardItems)
+	case "FindItemEasyRewardItems":
+		return intsToAny(cc.FindItemEasyRewardItems)
+	case "FindItemHardRewardItems":
+		return intsToAny(cc.FindItemHardRewardItems)
+	case "ExploreEasyRewardItems":
+		return intsToAny(cc.ExploreEasyRewardItems)
+	case "ExploreHardRewardItems":
+		return intsToAny(cc.ExploreHardRewardItems)
+	case "EscortEasyRewardItems":
+		return intsToAny(cc.EscortEasyRewardItems)
+	case "EscortHardRewardItems":
+		return intsToAny(cc.EscortHardRewardItems)
+	}
+
+	// Fall back to overlay config for any key not managed here.
+	v := m.plug.Config.Get(key)
+	if v == nil {
+		return nil
+	}
+	if s, ok := v.([]any); ok {
+		return s
+	}
+	return nil
+}
+
+// apiGetConfig handles GET /admin/api/v1/automission-config.
+func (m *AutoMissionModule) apiGetConfig(r *http.Request) (int, bool, any) {
+	cc := m.loadComplexConfig()
+
+	// Merge scalar keys from the overlay config so the response is complete.
+	type fullConfig struct {
+		RestockPeriod   string `json:"RestockPeriod"`
+		MaxMissions     any    `json:"MaxMissions"`
+		EscortTimeLimit string `json:"EscortTimeLimit"`
+		complexConfig
+	}
+
+	fc := fullConfig{
+		RestockPeriod:   m.restockPeriod(),
+		EscortTimeLimit: m.escortTimeLimit(),
+		complexConfig:   cc,
+	}
+
+	if v := m.plug.Config.Get("MaxMissions"); v != nil {
+		fc.MaxMissions = v
+	} else {
+		fc.MaxMissions = 6
+	}
+
+	// Seed reward pools from overlay defaults if plugin storage is empty.
+	if len(cc.KillMobEasyRewards) == 0 {
+		fc.KillMobEasyRewards = overlayRewards(m, "KillMobEasyRewards")
+	}
+	if len(cc.KillMobHardRewards) == 0 {
+		fc.KillMobHardRewards = overlayRewards(m, "KillMobHardRewards")
+	}
+	if len(cc.FindItemEasyRewards) == 0 {
+		fc.FindItemEasyRewards = overlayRewards(m, "FindItemEasyRewards")
+	}
+	if len(cc.FindItemHardRewards) == 0 {
+		fc.FindItemHardRewards = overlayRewards(m, "FindItemHardRewards")
+	}
+	if len(cc.ExploreEasyRewards) == 0 {
+		fc.ExploreEasyRewards = overlayRewards(m, "ExploreEasyRewards")
+	}
+	if len(cc.ExploreHardRewards) == 0 {
+		fc.ExploreHardRewards = overlayRewards(m, "ExploreHardRewards")
+	}
+	if len(cc.EscortEasyRewards) == 0 {
+		fc.EscortEasyRewards = overlayRewards(m, "EscortEasyRewards")
+	}
+	if len(cc.EscortHardRewards) == 0 {
+		fc.EscortHardRewards = overlayRewards(m, "EscortHardRewards")
+	}
+
+	return http.StatusOK, true, fc
+}
+
+// apiPatchConfig handles PATCH /admin/api/v1/automission-config.
+func (m *AutoMissionModule) apiPatchConfig(r *http.Request) (int, bool, any) {
+	var body struct {
+		RestockPeriod   string `json:"RestockPeriod"`
+		MaxMissions     string `json:"MaxMissions"`
+		EscortTimeLimit string `json:"EscortTimeLimit"`
+		complexConfig
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return http.StatusBadRequest, false, "malformed request body: " + err.Error()
+	}
+
+	// Save scalar keys through the normal config system.
+	if body.RestockPeriod != "" {
+		_ = configs.SetVal("Modules.automission.RestockPeriod", body.RestockPeriod)
+	}
+	if body.MaxMissions != "" {
+		_ = configs.SetVal("Modules.automission.MaxMissions", body.MaxMissions)
+	}
+	if body.EscortTimeLimit != "" {
+		_ = configs.SetVal("Modules.automission.EscortTimeLimit", body.EscortTimeLimit)
+	}
+
+	// Save complex keys via plugin storage.
+	if err := m.saveComplexConfig(body.complexConfig); err != nil {
+		return http.StatusInternalServerError, false, "failed to save config: " + err.Error()
+	}
+
+	return http.StatusOK, true, "saved"
+}
+
+// overlayRewards reads a reward pool from the overlay config (config.yaml defaults).
+func overlayRewards(m *AutoMissionModule, key string) []rewardEntry {
+	v := m.plug.Config.Get(key)
+	if v == nil {
+		return nil
+	}
+	raw, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	var result []rewardEntry
+	for _, item := range raw {
+		entry := asStringMap(item)
+		if entry == nil {
+			continue
+		}
+		result = append(result, rewardEntry{
+			Type:   stringVal(entry, "Type", "gold"),
+			Amount: intVal(entry, "Amount", 0),
+		})
+	}
+	return result
+}
+
+// intsToAny converts []int to []any for configSlice compatibility.
+func intsToAny(ids []int) []any {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]any, len(ids))
+	for i, id := range ids {
+		out[i] = id
+	}
+	return out
+}
+
+// rewardsToAny converts []rewardEntry to []any (map[string]any per entry).
+func rewardsToAny(entries []rewardEntry) []any {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]any, len(entries))
+	for i, e := range entries {
+		out[i] = map[string]any{
+			"Type":   e.Type,
+			"Amount": e.Amount,
+		}
+	}
+	return out
+}

--- a/modules/automission/automission.go
+++ b/modules/automission/automission.go
@@ -1,0 +1,598 @@
+package automission
+
+import (
+	"embed"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/characters"
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/gametime"
+	"github.com/GoMudEngine/GoMud/internal/mobs"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+var (
+	//go:embed files/*
+	files embed.FS
+)
+
+// One tag per mission type, plus a convenience check helper.
+const (
+	tagKillMob  = "missionboard kill_mob"
+	tagFindItem = "missionboard find_item"
+	tagExplore  = "missionboard explore"
+	tagEscort   = "missionboard escort"
+
+	acceptedMissionsKey = "automission_accepted"
+)
+
+// allBoardTags is the full set of tags this module reserves.
+var allBoardTags = []string{tagKillMob, tagFindItem, tagExplore, tagEscort}
+
+// isBoardRoom returns true if the room has at least one mission board tag.
+func isBoardRoom(room *rooms.Room) bool {
+	for _, tag := range allBoardTags {
+		if room.HasTag(tag) {
+			return true
+		}
+	}
+	return false
+}
+
+// acceptedEntry records a mission ID together with the board room it came from,
+// so turn-in can enforce that the player returns to the correct board.
+type acceptedEntry struct {
+	MissionId   int
+	BoardRoomId int
+}
+
+func init() {
+	m := &AutoMissionModule{
+		plug:   plugins.New("automission", "1.0"),
+		boards: make(map[int][]*Mission),
+	}
+
+	if err := m.plug.AttachFileSystem(files); err != nil {
+		panic(err)
+	}
+
+	m.plug.ReserveTags(allBoardTags...)
+
+	m.plug.Web.AdminPage("Config", "automission-config",
+		"html/admin/automission-config.html", true, "Modules", "Auto Mission", nil)
+	m.plug.Web.AdminPage("About", "automission-about",
+		"html/admin/automission-about.html", true, "Modules", "Auto Mission", nil)
+
+	m.plug.Web.AdminAPIEndpoint("GET", "automission-config", m.apiGetConfig)
+	m.plug.Web.AdminAPIEndpoint("PATCH", "automission-config", m.apiPatchConfig)
+
+	m.plug.AddUserCommand("mission", m.missionCommand, true, false)
+
+	rooms.OnRoomLook.Register(m.onRoomLook)
+
+	events.RegisterListener(events.NewRound{}, m.onNewRound)
+	events.RegisterListener(events.MobDeath{}, m.onMobDeath)
+	events.RegisterListener(events.ItemOwnership{}, m.onItemOwnership)
+	events.RegisterListener(events.RoomChange{}, m.onRoomChange)
+	events.RegisterListener(events.PlayerDespawn{}, m.onPlayerDespawn)
+}
+
+// AutoMissionModule holds all runtime state for the mission board system.
+type AutoMissionModule struct {
+	plug             *plugins.Plugin
+	boards           map[int][]*Mission // boardRoomId -> missions for that board
+	lastRestockRound uint64
+	missionIdCounter int
+}
+
+// userRecord is a convenience alias used throughout the module.
+type userRecord = users.UserRecord
+
+// allMissions returns a flat iterator over every mission across all boards.
+func (m *AutoMissionModule) allMissions() []*Mission {
+	var all []*Mission
+	for _, ms := range m.boards {
+		all = append(all, ms...)
+	}
+	return all
+}
+
+// onRoomLook injects a mission board alert when the room has any board tag.
+func (m *AutoMissionModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
+	for _, tag := range allBoardTags {
+		for _, t := range d.Tags {
+			if strings.EqualFold(t, tag) {
+				d.RoomAlerts = append(d.RoomAlerts,
+					`<ansi fg="yellow-bold">There's a mission board here!</ansi> <ansi fg="command">mission list</ansi> lists missions.`,
+				)
+				return d
+			}
+		}
+	}
+	return d
+}
+
+// ensureBoardMissions generates missions for a board room if none exist yet.
+// Called lazily when a player interacts with a board that was missed during restock.
+func (m *AutoMissionModule) ensureBoardMissions(room *rooms.Room) {
+	if _, ok := m.boards[room.RoomId]; ok {
+		return
+	}
+	maxMissions := 6
+	if v, ok := m.plug.Config.Get("MaxMissions").(int); ok && v > 0 {
+		maxMissions = v
+	}
+	missions := m.generateMissionsForBoard(room, maxMissions)
+	if len(missions) > 0 {
+		m.boards[room.RoomId] = missions
+	}
+}
+
+// missionsForBoard returns the mission slice for a given board room,
+// generating them on demand if the board has not been stocked yet.
+func (m *AutoMissionModule) missionsForBoard(roomId int) []*Mission {
+	if ms, ok := m.boards[roomId]; ok {
+		return ms
+	}
+	room := rooms.LoadRoom(roomId)
+	if room != nil && isBoardRoom(room) {
+		m.ensureBoardMissions(room)
+	}
+	return m.boards[roomId]
+}
+
+// onNewRound handles restock timing and escort expiry each game round.
+func (m *AutoMissionModule) onNewRound(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.NewRound)
+	if !ok {
+		return events.Continue
+	}
+	currentRound := evt.RoundNumber
+
+	if m.lastRestockRound == 0 {
+		m.restock(currentRound)
+		return events.Continue
+	}
+
+	nextRestockAt := gametime.GetDate(m.lastRestockRound).AddPeriod(m.restockPeriod())
+	if currentRound >= nextRestockAt {
+		m.restock(currentRound)
+		return events.Continue
+	}
+
+	m.checkEscortExpiry(currentRound)
+	return events.Continue
+}
+
+// restock regenerates missions for every board room in the world.
+func (m *AutoMissionModule) restock(currentRound uint64) {
+	// Fail all active escort missions.
+	for _, mission := range m.allMissions() {
+		if mission.Type != MissionTypeEscort {
+			continue
+		}
+		for userId, instanceId := range mission.EscortMobs {
+			if mob := mobs.GetInstance(instanceId); mob != nil {
+				mob.Command("emote collapses and perishes.;suicide vanish")
+				if user := users.GetByUserId(userId); user != nil {
+					user.Character.TrackCharmed(instanceId, false)
+				}
+			}
+			if user := users.GetByUserId(userId); user != nil {
+				user.SendText(buildBanner(mission.Title, "", "red"))
+			}
+		}
+	}
+
+	// Clear accepted state from all online users.
+	for _, uid := range users.GetOnlineUserIds() {
+		if user := users.GetByUserId(uid); user != nil {
+			user.SetTempData(acceptedMissionsKey, nil)
+		}
+	}
+
+	m.boards = make(map[int][]*Mission)
+
+	maxMissions := 6
+	if v, ok := m.plug.Config.Get("MaxMissions").(int); ok && v > 0 {
+		maxMissions = v
+	}
+
+	// Discover all board rooms and generate missions for each one.
+	boardRoomIds := m.findAllBoardRoomIds()
+	for _, roomId := range boardRoomIds {
+		room := rooms.LoadRoom(roomId)
+		if room == nil {
+			continue
+		}
+		missions := m.generateMissionsForBoard(room, maxMissions)
+		if len(missions) > 0 {
+			m.boards[roomId] = missions
+		}
+	}
+
+	m.lastRestockRound = currentRound
+
+	// Notify players standing at any board room.
+	for _, uid := range users.GetOnlineUserIds() {
+		user := users.GetByUserId(uid)
+		if user == nil {
+			continue
+		}
+		room := rooms.LoadRoom(user.Character.RoomId)
+		if room != nil && isBoardRoom(room) {
+			user.SendText(`<ansi fg="yellow">The mission board has been refreshed with new missions!</ansi>`)
+		}
+	}
+}
+
+// checkEscortExpiry fails expired escort missions each round.
+func (m *AutoMissionModule) checkEscortExpiry(currentRound uint64) {
+	for _, mission := range m.allMissions() {
+		if mission.Type != MissionTypeEscort {
+			continue
+		}
+		for userId, instanceId := range mission.EscortMobs {
+			expiry, hasExpiry := mission.EscortExpiries[userId]
+			if !hasExpiry || currentRound < expiry {
+				continue
+			}
+			if slices.Contains(mission.CompletedBy, userId) {
+				continue
+			}
+			if mob := mobs.GetInstance(instanceId); mob != nil {
+				mob.Command("emote collapses and perishes.;suicide vanish")
+			}
+			if user := users.GetByUserId(userId); user != nil {
+				user.Character.TrackCharmed(instanceId, false)
+				user.SendText(buildBanner(mission.Title, "", "red"))
+				m.removeAcceptedEntry(user, mission.Id)
+			}
+			delete(mission.EscortMobs, userId)
+			delete(mission.EscortExpiries, userId)
+			mission.AcceptedBy = removeInt(mission.AcceptedBy, userId)
+		}
+	}
+}
+
+// onMobDeath handles kill_mob completion and escort mob death.
+func (m *AutoMissionModule) onMobDeath(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.MobDeath)
+	if !ok {
+		return events.Continue
+	}
+
+	for _, mission := range m.allMissions() {
+		if mission.Type == MissionTypeKillMob && mission.TargetMobId == evt.MobId {
+			for _, userId := range evt.KilledByUsers {
+				if slices.Contains(mission.AcceptedBy, userId) && !slices.Contains(mission.CompletedBy, userId) {
+					m.markReadyToTurnIn(mission, userId)
+				}
+			}
+		}
+
+		if mission.Type == MissionTypeEscort {
+			for userId, instanceId := range mission.EscortMobs {
+				if instanceId == evt.InstanceId {
+					m.failMission(mission, userId)
+					delete(mission.EscortMobs, userId)
+					delete(mission.EscortExpiries, userId)
+				}
+			}
+		}
+	}
+
+	return events.Continue
+}
+
+// onItemOwnership handles find_item completion.
+func (m *AutoMissionModule) onItemOwnership(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.ItemOwnership)
+	if !ok || !evt.Gained || evt.UserId == 0 {
+		return events.Continue
+	}
+
+	for _, mission := range m.allMissions() {
+		if mission.Type != MissionTypeFindItem {
+			continue
+		}
+		if evt.Item.ItemId != mission.TargetItemId {
+			continue
+		}
+		if slices.Contains(mission.AcceptedBy, evt.UserId) && !slices.Contains(mission.CompletedBy, evt.UserId) {
+			m.markReadyToTurnIn(mission, evt.UserId)
+		}
+	}
+
+	return events.Continue
+}
+
+// onRoomChange handles explore completion and escort zone arrival.
+func (m *AutoMissionModule) onRoomChange(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.RoomChange)
+	if !ok || evt.UserId == 0 {
+		return events.Continue
+	}
+
+	toRoom := rooms.LoadRoom(evt.ToRoomId)
+	if toRoom == nil {
+		return events.Continue
+	}
+
+	user := users.GetByUserId(evt.UserId)
+	if user == nil {
+		return events.Continue
+	}
+
+	for _, mission := range m.allMissions() {
+		if !slices.Contains(mission.AcceptedBy, evt.UserId) {
+			continue
+		}
+		if slices.Contains(mission.CompletedBy, evt.UserId) {
+			continue
+		}
+
+		switch mission.Type {
+		case MissionTypeExplore:
+			if evt.ToRoomId == mission.TargetRoomId {
+				m.markReadyToTurnIn(mission, evt.UserId)
+			}
+
+		case MissionTypeEscort:
+			instanceId, hasEscort := mission.EscortMobs[evt.UserId]
+			if !hasEscort {
+				continue
+			}
+			mob := mobs.GetInstance(instanceId)
+			if mob == nil {
+				continue
+			}
+			if mob.Character.IsCharmed(evt.UserId) && toRoom.Zone == mission.TargetZone {
+				mob.Command(fmt.Sprintf(`say Thank you for escorting me! I am finally home!`))
+				mob.Command(`emote bows graciously and disappears.;suicide vanish`, 1)
+				user.Character.TrackCharmed(instanceId, false)
+				delete(mission.EscortMobs, evt.UserId)
+				delete(mission.EscortExpiries, evt.UserId)
+				m.markReadyToTurnIn(mission, evt.UserId)
+			}
+		}
+	}
+
+	// After processing all mission completions, check whether the player
+	// has just arrived at a board room with missions ready to turn in.
+	if isBoardRoom(toRoom) {
+		var readyTitles []string
+		for _, mission := range m.missionsForBoard(toRoom.RoomId) {
+			if slices.Contains(mission.ReadyToTurnIn, evt.UserId) {
+				readyTitles = append(readyTitles, mission.Title)
+			}
+		}
+		if len(readyTitles) > 0 {
+			user.SendText(
+				`<ansi fg="yellow-bold">You have completed missions ready to turn in here!</ansi>` +
+					` Type <ansi fg="command">mission turn in</ansi> to claim your reward.`,
+			)
+		}
+	}
+
+	return events.Continue
+}
+func (m *AutoMissionModule) onPlayerDespawn(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerDespawn)
+	if !ok {
+		return events.Continue
+	}
+
+	for _, mission := range m.allMissions() {
+		if mission.Type == MissionTypeEscort {
+			if instanceId, has := mission.EscortMobs[evt.UserId]; has {
+				if mob := mobs.GetInstance(instanceId); mob != nil {
+					mob.Command("emote collapses and perishes.;suicide vanish")
+				}
+				delete(mission.EscortMobs, evt.UserId)
+				delete(mission.EscortExpiries, evt.UserId)
+			}
+		}
+		mission.AcceptedBy = removeInt(mission.AcceptedBy, evt.UserId)
+		mission.ReadyToTurnIn = removeInt(mission.ReadyToTurnIn, evt.UserId)
+	}
+
+	return events.Continue
+}
+
+// markReadyToTurnIn adds the user to ReadyToTurnIn and notifies them.
+func (m *AutoMissionModule) markReadyToTurnIn(mission *Mission, userId int) {
+	if slices.Contains(mission.ReadyToTurnIn, userId) {
+		return
+	}
+	mission.ReadyToTurnIn = append(mission.ReadyToTurnIn, userId)
+
+	user := users.GetByUserId(userId)
+	if user == nil {
+		return
+	}
+	boardRoom := rooms.LoadRoom(mission.BoardRoomId)
+	boardDesc := "a mission board"
+	if boardRoom != nil {
+		boardDesc = boardRoom.Title
+	}
+	banner := buildBanner("MISSION COMPLETE!", mission.Title, "yellow") +
+		fmt.Sprintf("\n"+`<ansi fg="yellow">Return to <ansi fg="cyan">%s</ansi> to claim your reward.</ansi>`, boardDesc)
+	user.SendText(banner)
+}
+
+// failMission notifies the user of failure and removes their accepted state.
+func (m *AutoMissionModule) failMission(mission *Mission, userId int) {
+	if user := users.GetByUserId(userId); user != nil {
+		user.SendText(buildBanner("MISSION FAILED", mission.Title, "red"))
+		m.removeAcceptedEntry(user, mission.Id)
+	}
+	mission.AcceptedBy = removeInt(mission.AcceptedBy, userId)
+	mission.ReadyToTurnIn = removeInt(mission.ReadyToTurnIn, userId)
+}
+
+// spawnEscortMob spawns the escort mob and charms it to the user.
+func (m *AutoMissionModule) spawnEscortMob(mission *Mission, user *userRecord, room *rooms.Room) {
+	mob := mobs.NewMobById(mobs.MobId(mission.EscortMobSpecId), room.RoomId)
+	if mob == nil {
+		return
+	}
+	room.AddMob(mob.InstanceId)
+	mob.Character.Charm(user.UserId, characters.CharmPermanent, "emote collapses and perishes.;suicide vanish")
+	user.Character.TrackCharmed(mob.InstanceId, true)
+
+	mission.EscortMobs[user.UserId] = mob.InstanceId
+
+	gd := gametime.GetDate(util.GetRoundCount())
+	mission.EscortExpiries[user.UserId] = gd.AddPeriod(m.escortTimeLimit())
+
+	mob.Command(fmt.Sprintf(`say Thank you! Please escort me to %s!`, mission.TargetZone))
+}
+
+// restockPeriod returns the configured restock period string.
+func (m *AutoMissionModule) restockPeriod() string {
+	if v, ok := m.plug.Config.Get("RestockPeriod").(string); ok && v != "" {
+		return v
+	}
+	return "1 real day"
+}
+
+// escortTimeLimit returns the configured escort time limit string.
+func (m *AutoMissionModule) escortTimeLimit() string {
+	if v, ok := m.plug.Config.Get("EscortTimeLimit").(string); ok && v != "" {
+		return v
+	}
+	return "1 hour"
+}
+
+// findAllBoardRoomIds returns room IDs of every loaded room that has at least
+// one mission board tag. Uses online players to seed room loading; falls back
+// to zone root rooms so boards are discovered even with no players online.
+func (m *AutoMissionModule) findAllBoardRoomIds() []int {
+	seen := make(map[int]bool)
+	var result []int
+
+	check := func(roomId int) {
+		if seen[roomId] {
+			return
+		}
+		seen[roomId] = true
+		room := rooms.LoadRoom(roomId)
+		if room != nil && isBoardRoom(room) {
+			result = append(result, roomId)
+		}
+	}
+
+	for _, uid := range users.GetOnlineUserIds() {
+		if user := users.GetByUserId(uid); user != nil {
+			check(user.Character.RoomId)
+		}
+	}
+	for _, zone := range rooms.GetAllZoneNames() {
+		if rootId, err := rooms.GetZoneRoot(zone); err == nil {
+			check(rootId)
+		}
+	}
+	return result
+}
+
+// -------------------------------------------------------------------------
+// Per-user accepted entry helpers
+// -------------------------------------------------------------------------
+
+func getAcceptedEntries(user *userRecord) []acceptedEntry {
+	v := user.GetTempData(acceptedMissionsKey)
+	if v == nil {
+		return nil
+	}
+	if entries, ok := v.([]acceptedEntry); ok {
+		return entries
+	}
+	return nil
+}
+
+func addAcceptedEntry(user *userRecord, missionId, boardRoomId int) {
+	entries := getAcceptedEntries(user)
+	entries = append(entries, acceptedEntry{MissionId: missionId, BoardRoomId: boardRoomId})
+	user.SetTempData(acceptedMissionsKey, entries)
+}
+
+func (m *AutoMissionModule) removeAcceptedEntry(user *userRecord, missionId int) {
+	entries := getAcceptedEntries(user)
+	for i, e := range entries {
+		if e.MissionId == missionId {
+			entries = append(entries[:i], entries[i+1:]...)
+			break
+		}
+	}
+	user.SetTempData(acceptedMissionsKey, entries)
+}
+
+// acceptedMissionIds returns just the IDs from the user's accepted entries.
+func acceptedMissionIds(user *userRecord) []int {
+	entries := getAcceptedEntries(user)
+	ids := make([]int, len(entries))
+	for i, e := range entries {
+		ids[i] = e.MissionId
+	}
+	return ids
+}
+
+// boardRoomForAcceptedMission returns the board room ID the user accepted a
+// given mission from, or 0 if not found.
+func boardRoomForAcceptedMission(user *userRecord, missionId int) int {
+	for _, e := range getAcceptedEntries(user) {
+		if e.MissionId == missionId {
+			return e.BoardRoomId
+		}
+	}
+	return 0
+}
+
+// -------------------------------------------------------------------------
+// Misc helpers
+// -------------------------------------------------------------------------
+
+// missionTypeTag returns a short display label for a mission type tag.
+func missionTypeLabel(tag string) string {
+	switch tag {
+	case tagKillMob:
+		return "Kill"
+	case tagFindItem:
+		return "Find"
+	case tagExplore:
+		return "Explore"
+	case tagEscort:
+		return "Escort"
+	}
+	return tag
+}
+
+// boardTypeDescription returns a human-readable list of mission types a room offers.
+func boardTypeDescription(room *rooms.Room) string {
+	var types []string
+	for _, tag := range allBoardTags {
+		if room.HasTag(tag) {
+			types = append(types, missionTypeLabel(tag))
+		}
+	}
+	if len(types) == 0 {
+		return "missions"
+	}
+	return strings.Join(types, "/") + " missions"
+}
+
+// removeInt removes the first occurrence of v from s.
+func removeInt(s []int, v int) []int {
+	for i, x := range s {
+		if x == v {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+	return s
+}

--- a/modules/automission/commands.go
+++ b/modules/automission/commands.go
@@ -1,0 +1,286 @@
+package automission
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/templates"
+	"github.com/GoMudEngine/GoMud/internal/users"
+)
+
+// missionCommand is the top-level handler for the "mission" user command.
+func (m *AutoMissionModule) missionCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+	args := strings.Fields(rest)
+
+	if len(args) == 0 {
+		return m.cmdList("", user, room)
+	}
+
+	sub := strings.ToLower(args[0])
+	subRest := strings.TrimSpace(strings.TrimPrefix(rest, args[0]))
+
+	switch sub {
+	case "list":
+		return m.cmdList(subRest, user, room)
+	case "accept":
+		return m.cmdAccept(subRest, user, room)
+	case "turn", "turnin":
+		if sub == "turn" && len(args) >= 2 && strings.ToLower(args[1]) == "in" {
+			return m.cmdTurnIn(user, room)
+		}
+		if sub == "turnin" {
+			return m.cmdTurnIn(user, room)
+		}
+		return m.cmdList("", user, room)
+	default:
+		return m.cmdAccept(rest, user, room)
+	}
+}
+
+// cmdList shows missions.
+// At a board room: shows that board's missions.
+// Elsewhere: shows only the user's accepted missions across all boards.
+func (m *AutoMissionModule) cmdList(_ string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+	atBoard := isBoardRoom(room)
+
+	var displayMissions []*Mission
+	var tableTitle string
+
+	if atBoard {
+		displayMissions = m.missionsForBoard(room.RoomId)
+		tableTitle = room.Title + " — " + boardTypeDescription(room)
+		if len(displayMissions) == 0 {
+			user.SendText(`There are no missions available here right now. Check back later!`)
+			return true, nil
+		}
+	} else {
+		acceptedIds := acceptedMissionIds(user)
+		for _, mission := range m.allMissions() {
+			if slices.Contains(acceptedIds, mission.Id) {
+				displayMissions = append(displayMissions, mission)
+			}
+		}
+		tableTitle = "Your Active Missions"
+		if len(displayMissions) == 0 {
+			user.SendText(`You have no active missions. Visit a mission board to browse available missions.`)
+			return true, nil
+		}
+	}
+
+	headers := []string{"#", "Title", "Difficulty", "Reward", "Status"}
+	formatting := []string{
+		`<ansi fg="cyan">%s</ansi>`,
+		`<ansi fg="yellow">%s</ansi>`,
+		`<ansi fg="white">%s</ansi>`,
+		`<ansi fg="gold">%s</ansi>`,
+		`<ansi fg="green">%s</ansi>`,
+	}
+
+	acceptedIds := acceptedMissionIds(user)
+	rows := [][]string{}
+	for i, mission := range displayMissions {
+		status := ""
+		if slices.Contains(mission.ReadyToTurnIn, user.UserId) {
+			status = "[READY]"
+		} else if slices.Contains(acceptedIds, mission.Id) {
+			status = "[ACCEPTED]"
+		} else if slices.Contains(mission.CompletedBy, user.UserId) {
+			status = "[COMPLETED]"
+		}
+		rows = append(rows, []string{
+			strconv.Itoa(i + 1),
+			mission.Title,
+			string(mission.Difficulty),
+			rewardDescription(mission.Reward),
+			status,
+		})
+	}
+
+	tableData := templates.GetTable(tableTitle, headers, rows, formatting)
+	tplTxt, _ := templates.Process("tables/generic", tableData, user.UserId)
+	user.SendText(tplTxt)
+
+	if atBoard {
+		user.SendText(`Type <ansi fg="command">mission accept #</ansi> to accept a mission.`)
+	}
+
+	return true, nil
+}
+
+// cmdAccept accepts a mission by index or name fragment.
+// Must be executed at a board room; the board room ID is stored with the acceptance.
+func (m *AutoMissionModule) cmdAccept(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+	if !isBoardRoom(room) {
+		user.SendText(`You must be at a mission board to accept missions.`)
+		return true, nil
+	}
+
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		user.SendText(`Accept which mission? Try <ansi fg="command">mission list</ansi> to see available missions.`)
+		return true, nil
+	}
+
+	boardMissions := m.missionsForBoard(room.RoomId)
+	mission := resolveMissionFrom(boardMissions, rest)
+	if mission == nil {
+		user.SendText(fmt.Sprintf(`No mission found matching '%s'.`, rest))
+		return true, nil
+	}
+
+	if slices.Contains(mission.AcceptedBy, user.UserId) {
+		user.SendText(`You have already accepted that mission.`)
+		return true, nil
+	}
+
+	if slices.Contains(mission.CompletedBy, user.UserId) {
+		user.SendText(`You have already completed that mission.`)
+		return true, nil
+	}
+
+	// Check whether the user already has an active mission of this type.
+	for _, active := range m.allMissions() {
+		if active.Type != mission.Type {
+			continue
+		}
+		if slices.Contains(active.AcceptedBy, user.UserId) || slices.Contains(active.ReadyToTurnIn, user.UserId) {
+			user.SendText(fmt.Sprintf(`You already have an active <ansi fg="yellow">%s</ansi> mission. Turn it in or wait for the board to restock.`, string(mission.Type)))
+			return true, nil
+		}
+	}
+
+	mission.AcceptedBy = append(mission.AcceptedBy, user.UserId)
+	addAcceptedEntry(user, mission.Id, room.RoomId)
+
+	if mission.Type == MissionTypeEscort {
+		m.spawnEscortMob(mission, user, room)
+	}
+
+	user.SendText(fmt.Sprintf(`You have accepted the mission: <ansi fg="yellow">%s</ansi>.`, mission.Title))
+	return true, nil
+}
+
+// cmdTurnIn delivers rewards for all missions that are ready to turn in at this board.
+// Only missions accepted at this specific board room can be turned in here.
+func (m *AutoMissionModule) cmdTurnIn(user *users.UserRecord, room *rooms.Room) (bool, error) {
+	if !isBoardRoom(room) {
+		user.SendText(`You must be at a mission board to turn in missions.`)
+		return true, nil
+	}
+
+	var readyHere []*Mission
+	var readyElsewhere []*Mission
+
+	for _, mission := range m.allMissions() {
+		if !slices.Contains(mission.ReadyToTurnIn, user.UserId) {
+			continue
+		}
+		originRoomId := boardRoomForAcceptedMission(user, mission.Id)
+		if originRoomId == room.RoomId || (originRoomId == 0 && mission.BoardRoomId == room.RoomId) {
+			readyHere = append(readyHere, mission)
+		} else {
+			readyElsewhere = append(readyElsewhere, mission)
+		}
+	}
+
+	if len(readyHere) == 0 {
+		if len(readyElsewhere) > 0 {
+			// Give a helpful hint about where they need to go.
+			var hints []string
+			seen := make(map[int]bool)
+			for _, mission := range readyElsewhere {
+				originId := boardRoomForAcceptedMission(user, mission.Id)
+				if originId == 0 {
+					originId = mission.BoardRoomId
+				}
+				if seen[originId] {
+					continue
+				}
+				seen[originId] = true
+				if originRoom := rooms.LoadRoom(originId); originRoom != nil {
+					hints = append(hints, fmt.Sprintf(`<ansi fg="yellow">%s</ansi>`, originRoom.Title))
+				}
+			}
+			if len(hints) > 0 {
+				user.SendText(fmt.Sprintf(`You have no missions to turn in here. Return to: %s.`, strings.Join(hints, ", ")))
+			} else {
+				user.SendText(`You have no missions to turn in here. Return to the board where you accepted them.`)
+			}
+		} else {
+			user.SendText(`You have no missions ready to turn in.`)
+		}
+		return true, nil
+	}
+
+	for _, mission := range readyHere {
+		// For find_item missions, verify the player has the item and take it.
+		if mission.Type == MissionTypeFindItem {
+			if !takeItemFromUser(user, mission.TargetItemId) {
+				spec := items.GetItemSpec(mission.TargetItemId)
+				itemName := "the required item"
+				if spec != nil {
+					itemName = fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, spec.Name)
+				}
+				user.SendText(fmt.Sprintf(`You need to have %s on you to turn in this mission.`, itemName))
+				continue
+			}
+		}
+
+		deliverReward(mission.Reward, user)
+
+		mission.CompletedBy = append(mission.CompletedBy, user.UserId)
+		mission.ReadyToTurnIn = removeInt(mission.ReadyToTurnIn, user.UserId)
+		mission.AcceptedBy = removeInt(mission.AcceptedBy, user.UserId)
+		m.removeAcceptedEntry(user, mission.Id)
+
+		banner := buildBanner("REWARD CLAIMED!", mission.Title, "green") +
+			"\n" + fmt.Sprintf(`<ansi fg="green">Reward: </ansi>%s`, rewardDescription(mission.Reward))
+		user.SendText(banner)
+	}
+
+	return true, nil
+}
+
+// resolveMissionFrom finds a mission by 1-based index or title substring within a given slice.
+func resolveMissionFrom(missions []*Mission, input string) *Mission {
+	if idx, err := strconv.Atoi(input); err == nil {
+		idx--
+		if idx >= 0 && idx < len(missions) {
+			return missions[idx]
+		}
+		return nil
+	}
+
+	lower := strings.ToLower(input)
+	for _, mission := range missions {
+		if strings.Contains(strings.ToLower(mission.Title), lower) {
+			return mission
+		}
+	}
+	return nil
+}
+
+// takeItemFromUser finds an item with the given spec ID in the user's inventory
+// or equipped slots and removes it. Returns true if the item was found and taken.
+func takeItemFromUser(user *users.UserRecord, itemId int) bool {
+	// Check inventory first.
+	for _, item := range user.Character.GetAllBackpackItems() {
+		if item.ItemId == itemId {
+			user.Character.RemoveItem(item)
+			return true
+		}
+	}
+	// Check equipped slots.
+	for _, item := range user.Character.GetAllWornItems() {
+		if item.ItemId == itemId {
+			user.Character.RemoveFromBody(item)
+			return true
+		}
+	}
+	return false
+}

--- a/modules/automission/files/data-overlays/config.yaml
+++ b/modules/automission/files/data-overlays/config.yaml
@@ -1,0 +1,79 @@
+################################################################################
+# If modified, these settings will be copied into your config overrides
+# folder under `Modules.automission`.
+#
+# Reward pools are per mission type. The key pattern is:
+#   <Type><Difficulty>Rewards      - reward pool entries (Type/Amount)
+#   <Type><Difficulty>RewardItems  - item spec IDs for item-type rewards
+#
+# Where <Type> is one of: KillMob, FindItem, Explore, Escort
+# And <Difficulty> is one of: Easy, Hard
+################################################################################
+
+# - RestockPeriod -
+#   How often to restock the mission board (gametime period string).
+#   Supports formats like "1 real day", "4 real hours", "2 game days".
+RestockPeriod: "1 real day"
+
+# - MaxMissions -
+#   Maximum number of missions on the board at any time.
+MaxMissions: 3
+
+# - EscortTimeLimit -
+#   Time limit for escort missions (period string).
+EscortTimeLimit: "1 hour"
+
+# Kill Mob rewards
+KillMobEasyRewards:
+  - Type: gold
+    Amount: 100
+  - Type: experience
+    Amount: 500
+KillMobHardRewards:
+  - Type: gold
+    Amount: 300
+  - Type: experience
+    Amount: 1500
+
+# Find Item rewards
+FindItemEasyRewards:
+  - Type: gold
+    Amount: 100
+  - Type: experience
+    Amount: 500
+FindItemHardRewards:
+  - Type: gold
+    Amount: 300
+  - Type: experience
+    Amount: 1500
+
+# Explore rewards
+ExploreEasyRewards:
+  - Type: gold
+    Amount: 100
+  - Type: experience
+    Amount: 500
+ExploreHardRewards:
+  - Type: gold
+    Amount: 300
+  - Type: experience
+    Amount: 1500
+
+# Escort rewards
+EscortEasyRewards:
+  - Type: gold
+    Amount: 150
+  - Type: experience
+    Amount: 750
+EscortHardRewards:
+  - Type: gold
+    Amount: 450
+  - Type: experience
+    Amount: 2250
+
+# Item ID lists for item-type rewards (add spec IDs to enable item rewards).
+# EscortMobIds, KillMobEasyRewardItems, KillMobHardRewardItems,
+# FindItemEasyRewardItems, FindItemHardRewardItems, ExploreEasyRewardItems,
+# ExploreHardRewardItems, EscortEasyRewardItems, EscortHardRewardItems
+# are intentionally omitted here as empty lists cause a nil panic in the
+# config system. Set them via config-overrides.yaml or the admin Config page.

--- a/modules/automission/files/data-overlays/keywords.yaml
+++ b/modules/automission/files/data-overlays/keywords.yaml
@@ -1,0 +1,4 @@
+help:
+  command:
+    general:
+      - mission

--- a/modules/automission/files/datafiles/html/admin/automission-about.html
+++ b/modules/automission/files/datafiles/html/admin/automission-about.html
@@ -1,0 +1,115 @@
+{{template "header" .}}
+
+<style>
+    .about-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .about-subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .about-section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .about-section h2 { font-size: 1.05rem; margin: 0 0 0.6rem; color: var(--color-text-strong); }
+    .about-section h3 { font-size: 0.9rem; font-weight: 700; margin: 1rem 0 0.4rem; color: var(--color-text-strong); }
+    .about-section p { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; }
+    .about-section p:last-child { margin-bottom: 0; }
+    .about-section ul { font-size: 0.9rem; color: var(--color-text-secondary); line-height: 1.6; margin: 0 0 0.5rem; padding-left: 1.4rem; }
+    .tag-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.875rem; }
+    .tag-table th { text-align: left; padding: 0.4rem 0.75rem; background: var(--color-border-faint); color: var(--color-text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--color-border); }
+    .tag-table td { padding: 0.45rem 0.75rem; border-bottom: 1px solid var(--color-border-light); vertical-align: top; }
+    .tag-table tr:last-child td { border-bottom: none; }
+    .tag-name { font-family: monospace; color: var(--color-primary); font-size: 0.85rem; white-space: nowrap; }
+    .note { font-size: 0.82rem; color: var(--color-text-faint); margin-top: 0.6rem; font-style: italic; }
+</style>
+
+<h1 class="about-h1">Auto Mission</h1>
+<p class="about-subtitle">Module overview, player commands, room tags, and configuration reference.</p>
+
+<div class="about-section">
+    <h2>Overview</h2>
+    <p>Auto Mission generates and manages a dynamic mission board system. Each room tagged as a mission board independently generates its own pool of missions based on which type tags it carries. Missions are restocked across all board rooms simultaneously on a configurable timer.</p>
+    <p>Four mission types are supported, each with separate easy and hard difficulty tiers. Difficulty affects both target selection and reward. Targets are chosen using server telemetry — frequently killed mobs and commonly found items populate the easier tiers; rarer ones populate the harder tiers. Exploration mission difficulty is based on path distance from the board room.</p>
+    <p>All mission state is in-memory only and does not survive a server restart.</p>
+</div>
+
+<div class="about-section">
+    <h2>Player Commands</h2>
+    <table class="tag-table">
+        <thead><tr><th style="width:34%">Command</th><th>Description</th></tr></thead>
+        <tbody>
+            <tr>
+                <td class="tag-name">mission list</td>
+                <td>At a board room: lists all missions available at that board with difficulty, reward, and current status. Elsewhere: lists only the player's currently accepted missions across all boards.</td>
+            </tr>
+            <tr>
+                <td class="tag-name">mission accept &lt;# or name&gt;</td>
+                <td>Accepts a mission by its list index or a partial title match. Must be at the board room that offers the mission. Escort missions spawn the escort mob immediately on accept.</td>
+            </tr>
+            <tr>
+                <td class="tag-name">mission turn in</td>
+                <td>Claims rewards for all completed missions that were accepted at this board. Must be at the same board room where each mission was accepted. If ready missions belong to a different board, the player is told which room to return to.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="about-section">
+    <h2>Mission Types</h2>
+
+    <h3>Kill Mob</h3>
+    <p>A specific mob type must be killed. The target is chosen from telemetry kill data — easy missions target frequently killed mobs, hard missions target rarely killed ones. Any kill of the target mob while the mission is accepted counts.</p>
+
+    <h3>Find Item</h3>
+    <p>A specific item must be acquired. The target is chosen from telemetry item drop data. The mission completes as soon as the player picks up or receives the target item while the mission is accepted.</p>
+
+    <h3>Explore</h3>
+    <p>A specific room must be visited. Candidate rooms are sampled from loaded zones and path distance from the board room determines difficulty — closer rooms are easy, farther rooms are hard. The mission completes when the player enters the target room.</p>
+
+    <h3>Escort</h3>
+    <p>A charmed NPC must be guided to its destination zone. The escort mob spawns in the board room when the mission is accepted and follows the player. The mission completes when the player (with the escort mob still alive and charmed) enters any room in the target zone. If the escort mob is killed or the time limit expires, the mission fails and the mob is removed. Escort missions require <code>EscortMobIds</code> to be configured and the <code>missionboard escort</code> tag to be present.</p>
+</div>
+
+<div class="about-section">
+    <h2>Room Tags</h2>
+    <p>Each tag enables one mission type at the room. A room with multiple tags generates missions of all enabled types up to <code>MaxMissions</code> total. The <code>mission accept</code> and <code>mission turn in</code> commands only function in rooms carrying at least one of these tags.</p>
+    <table class="tag-table">
+        <thead><tr><th style="width:34%">Tag</th><th>Effect</th></tr></thead>
+        <tbody>
+            <tr><td class="tag-name">missionboard kill_mob</td><td>Enables kill-mob mission generation at this room.</td></tr>
+            <tr><td class="tag-name">missionboard find_item</td><td>Enables find-item mission generation at this room.</td></tr>
+            <tr><td class="tag-name">missionboard explore</td><td>Enables exploration mission generation at this room. Path distance from this room determines easy vs. hard difficulty.</td></tr>
+            <tr><td class="tag-name">missionboard escort</td><td>Enables escort mission generation at this room. Has no effect if <code>EscortMobIds</code> is empty.</td></tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="about-section">
+    <h2>Configuration Reference</h2>
+
+    <h3>General</h3>
+    <table class="tag-table">
+        <thead><tr><th style="width:30%">Key</th><th style="width:20%">Default</th><th>Description</th></tr></thead>
+        <tbody>
+            <tr><td class="tag-name">RestockPeriod</td><td><code>"1 real day"</code></td><td>How often all board rooms are restocked. Accepts gametime period strings (e.g. <code>"4 real hours"</code>, <code>"2 game days"</code>). On restock, all active escort missions are failed and all accepted mission state is cleared.</td></tr>
+            <tr><td class="tag-name">MaxMissions</td><td><code>6</code></td><td>Maximum number of missions generated per board room per restock.</td></tr>
+            <tr><td class="tag-name">EscortTimeLimit</td><td><code>"1 hour"</code></td><td>Time limit for each escort mission instance. Accepts gametime period strings. The timer starts when the mission is accepted.</td></tr>
+            <tr><td class="tag-name">EscortMobIds</td><td><em>empty</em></td><td>List of mob spec IDs eligible to be used as escort targets. One is chosen at random per escort mission. If empty, escort missions are not generated regardless of room tags.</td></tr>
+        </tbody>
+    </table>
+
+    <h3>Reward Pools</h3>
+    <p>Each mission type has its own easy and hard reward pool. When a mission is generated, one entry is chosen at random from the matching pool. If a hard pool is empty, the easy pool is used with amounts multiplied by 3. If both are empty, a gold fallback is used.</p>
+    <p>Each pool entry has a <code>Type</code> (<code>gold</code>, <code>experience</code>, or <code>item</code>) and an <code>Amount</code> (ignored for <code>item</code> type). Item rewards draw a random ID from the corresponding <code>RewardItems</code> list; if that list is empty the reward falls back to gold.</p>
+    <table class="tag-table">
+        <thead><tr><th style="width:40%">Key</th><th>Description</th></tr></thead>
+        <tbody>
+            <tr><td class="tag-name">KillMobEasyRewards</td><td>Reward pool for easy kill-mob missions.</td></tr>
+            <tr><td class="tag-name">KillMobHardRewards</td><td>Reward pool for hard kill-mob missions.</td></tr>
+            <tr><td class="tag-name">FindItemEasyRewards</td><td>Reward pool for easy find-item missions.</td></tr>
+            <tr><td class="tag-name">FindItemHardRewards</td><td>Reward pool for hard find-item missions.</td></tr>
+            <tr><td class="tag-name">ExploreEasyRewards</td><td>Reward pool for easy exploration missions.</td></tr>
+            <tr><td class="tag-name">ExploreHardRewards</td><td>Reward pool for hard exploration missions.</td></tr>
+            <tr><td class="tag-name">EscortEasyRewards</td><td>Reward pool for easy escort missions.</td></tr>
+            <tr><td class="tag-name">EscortHardRewards</td><td>Reward pool for hard escort missions.</td></tr>
+            <tr><td class="tag-name">KillMobEasyRewardItems<br>KillMobHardRewardItems<br>FindItemEasyRewardItems<br>FindItemHardRewardItems<br>ExploreEasyRewardItems<br>ExploreHardRewardItems<br>EscortEasyRewardItems<br>EscortHardRewardItems</td><td>Item spec ID lists for item-type rewards. One ID is chosen at random when an <code>item</code> reward entry is selected. If empty, the reward falls back to gold.</td></tr>
+        </tbody>
+    </table>
+    <p class="note">Scalar keys (RestockPeriod, MaxMissions, EscortTimeLimit) are editable on the Config page and persisted to config-overrides.yaml. All other keys are managed through the Config page and stored in plugin-data.</p>
+</div>
+
+{{template "footer" .}}

--- a/modules/automission/files/datafiles/html/admin/automission-config.html
+++ b/modules/automission/files/datafiles/html/admin/automission-config.html
@@ -1,0 +1,475 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    #status-bar { display: none; padding: 0.6rem 1rem; border-radius: 4px; font-size: 0.875rem; margin-bottom: 1rem; }
+    #status-bar.success { background: var(--color-success-bg); color: var(--color-success-text); display: block; }
+    #status-bar.error   { background: var(--color-error-bg); color: var(--color-error-text); display: block; }
+
+    .btn { padding: 0.4rem 1rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+    .btn-primary { background: var(--color-primary); color: var(--color-surface-white); }
+    .btn-primary:hover { background: var(--color-primary-hover); }
+    .btn-primary:disabled { background: var(--color-text-secondary); cursor: default; }
+    .btn-sm { padding: 0.2rem 0.55rem; font-size: 0.8rem; border-radius: 3px; border: none; cursor: pointer; font-weight: 600; }
+    .btn-add { background: var(--color-btn-save-bg, #27ae60); color: #fff; }
+    .btn-add:hover { opacity: 0.85; }
+
+    .section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+    .section h2 { font-size: 1rem; margin: 0 0 0.15rem; color: var(--color-text-strong); }
+    .section .desc { font-size: 0.8rem; color: var(--color-text-faint); margin: 0 0 0.75rem; }
+
+    .field-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem; }
+    .field-row label { font-size: 0.875rem; color: var(--color-text-secondary); min-width: 130px; }
+    .field-row input[type="text"], .field-row input[type="number"] {
+        flex: 1; padding: 0.3rem 0.5rem; border: 1px solid var(--color-border); border-radius: 3px;
+        font-size: 0.875rem; font-family: inherit; background: var(--color-surface-alt);
+    }
+
+    /* tabs */
+    .tab-bar { display: flex; gap: 0; border-bottom: 2px solid var(--color-border); margin-bottom: 1.25rem; }
+    .tab-btn {
+        padding: 0.5rem 1.1rem; border: none; background: none; cursor: pointer;
+        font-size: 0.875rem; font-weight: 600; color: var(--color-text-secondary);
+        border-bottom: 2px solid transparent; margin-bottom: -2px;
+    }
+    .tab-btn:hover { color: var(--color-text-strong); }
+    .tab-btn.active { color: var(--color-primary); border-bottom-color: var(--color-primary); }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+
+    /* reward sub-panels inside a tab */
+    .reward-panel { margin-bottom: 1.25rem; }
+    .reward-panel h3 { font-size: 0.9rem; font-weight: 700; color: var(--color-text-strong); margin: 0 0 0.2rem; }
+    .reward-panel .desc { font-size: 0.78rem; color: var(--color-text-faint); margin: 0 0 0.6rem; }
+
+    /* chips */
+    .chip-list { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-bottom: 0.5rem; min-height: 1.8rem; }
+    .chip {
+        display: inline-flex; align-items: center; gap: 0.3rem;
+        background: var(--color-chip-bg, #e8f0fe); color: var(--color-chip-text, #1a56db);
+        border-radius: 4px; padding: 0.2rem 0.5rem; font-size: 0.8rem; font-weight: 600;
+    }
+    .chip .chip-id { font-family: monospace; }
+    .chip .chip-name { font-weight: 400; color: var(--color-text-secondary); }
+    .chip .chip-remove {
+        background: none; border: none; cursor: pointer; font-size: 0.9rem; line-height: 1;
+        color: var(--color-text-faint); padding: 0 0.1rem; margin-left: 0.1rem;
+    }
+    .chip .chip-remove:hover { color: var(--color-danger, #c0392b); }
+
+    /* reward table */
+    .reward-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    .reward-table td { padding: 0.3rem 0.4rem; border-bottom: 1px solid var(--color-border-light); vertical-align: middle; }
+    .reward-table tr:last-child td { border-bottom: none; }
+    .reward-table select, .reward-table input[type="number"] {
+        padding: 0.2rem 0.4rem; border: 1px solid var(--color-border); border-radius: 3px;
+        font-size: 0.875rem; background: var(--color-surface-alt); width: 100%;
+    }
+    .reward-add-row { display: flex; gap: 0.4rem; margin-top: 0.5rem; align-items: center; }
+    .reward-add-row select, .reward-add-row input[type="number"] {
+        flex: 1; padding: 0.25rem 0.4rem; border: 1px solid var(--color-border); border-radius: 3px;
+        font-size: 0.875rem; background: var(--color-surface-alt);
+    }
+
+    .save-bar { display: flex; gap: 0.5rem; margin-top: 1rem; }
+    hr.reward-divider { border: none; border-top: 1px solid var(--color-border-light); margin: 1rem 0; }
+</style>
+
+<h1>automission - Module Config</h1>
+<p class="subtitle">Configuration for the <strong>automission</strong> module. Click <strong>Save All</strong> to apply changes.</p>
+
+<div id="status-bar"></div>
+
+<!-- General -->
+<div class="section">
+    <h2>General</h2>
+    <p class="desc">Core timing and board settings.</p>
+    <div class="field-row">
+        <label>Restock Period</label>
+        <input type="text" id="f-restock" placeholder="1 real day">
+    </div>
+    <div class="field-row">
+        <label>Max Missions</label>
+        <input type="number" id="f-maxmissions" min="1" max="50" placeholder="6">
+    </div>
+    <div class="field-row">
+        <label>Escort Time Limit</label>
+        <input type="text" id="f-escortlimit" placeholder="1 hour">
+    </div>
+</div>
+
+<!-- Escort Mob IDs -->
+<div class="section">
+    <h2>Escort Mob IDs</h2>
+    <p class="desc">Mobs eligible for escort missions. Leave empty to disable escort missions entirely.</p>
+    <div class="chip-list" id="escort-mob-chips"></div>
+    <button class="btn-sm btn-add" onclick="pickMob('escort-mob-chips')">+ Add Mob</button>
+</div>
+
+<!-- Per-type reward pools -->
+<div class="section">
+    <h2>Reward Pools</h2>
+    <p class="desc">Each mission type has its own easy and hard reward pools. One entry is picked at random when a mission of that type is generated.</p>
+
+    <div class="tab-bar">
+        <button class="tab-btn active" onclick="showTab('kill_mob', this)">Kill Mob</button>
+        <button class="tab-btn"        onclick="showTab('find_item', this)">Find Item</button>
+        <button class="tab-btn"        onclick="showTab('explore',   this)">Explore</button>
+        <button class="tab-btn"        onclick="showTab('escort',    this)">Escort</button>
+    </div>
+
+    <!-- Kill Mob -->
+    <div class="tab-panel active" id="tab-kill_mob">
+        <div class="reward-panel">
+            <h3>Easy Rewards</h3>
+            <p class="desc">Awarded for easy kill missions.</p>
+            <table class="reward-table"><tbody id="KillMobEasy-rewards-body"></tbody></table>
+            <div class="reward-add-row">
+                <select id="KillMobEasy-reward-type" onchange="onNewRewardTypeChange(this)"><option value="gold">gold</option><option value="experience">experience</option><option value="item">item</option></select>
+                <input type="number" id="KillMobEasy-reward-amount" placeholder="Amount" min="0">
+                <button class="btn-sm btn-add" onclick="addRewardRow('KillMobEasy-rewards-body','KillMobEasy-reward-type','KillMobEasy-reward-amount')">+ Add</button>
+            </div>
+        </div>
+        <div class="reward-panel">
+            <h3>Easy Reward Items</h3>
+            <p class="desc">Items drawn when an easy reward entry has Type = item.</p>
+            <div class="chip-list" id="KillMobEasy-item-chips"></div>
+            <button class="btn-sm btn-add" onclick="pickItem('KillMobEasy-item-chips')">+ Add Item</button>
+        </div>
+        <hr class="reward-divider">
+        <div class="reward-panel">
+            <h3>Hard Rewards</h3>
+            <p class="desc">Awarded for hard kill missions.</p>
+            <table class="reward-table"><tbody id="KillMobHard-rewards-body"></tbody></table>
+            <div class="reward-add-row">
+                <select id="KillMobHard-reward-type" onchange="onNewRewardTypeChange(this)"><option value="gold">gold</option><option value="experience">experience</option><option value="item">item</option></select>
+                <input type="number" id="KillMobHard-reward-amount" placeholder="Amount" min="0">
+                <button class="btn-sm btn-add" onclick="addRewardRow('KillMobHard-rewards-body','KillMobHard-reward-type','KillMobHard-reward-amount')">+ Add</button>
+            </div>
+        </div>
+        <div class="reward-panel">
+            <h3>Hard Reward Items</h3>
+            <p class="desc">Items drawn when a hard reward entry has Type = item.</p>
+            <div class="chip-list" id="KillMobHard-item-chips"></div>
+            <button class="btn-sm btn-add" onclick="pickItem('KillMobHard-item-chips')">+ Add Item</button>
+        </div>
+    </div>
+
+    <!-- Find Item -->
+    <div class="tab-panel" id="tab-find_item">
+        <div class="reward-panel">
+            <h3>Easy Rewards</h3>
+            <p class="desc">Awarded for easy find-item missions.</p>
+            <table class="reward-table"><tbody id="FindItemEasy-rewards-body"></tbody></table>
+            <div class="reward-add-row">
+                <select id="FindItemEasy-reward-type" onchange="onNewRewardTypeChange(this)"><option value="gold">gold</option><option value="experience">experience</option><option value="item">item</option></select>
+                <input type="number" id="FindItemEasy-reward-amount" placeholder="Amount" min="0">
+                <button class="btn-sm btn-add" onclick="addRewardRow('FindItemEasy-rewards-body','FindItemEasy-reward-type','FindItemEasy-reward-amount')">+ Add</button>
+            </div>
+        </div>
+        <div class="reward-panel">
+            <h3>Easy Reward Items</h3>
+            <p class="desc">Items drawn when an easy reward entry has Type = item.</p>
+            <div class="chip-list" id="FindItemEasy-item-chips"></div>
+            <button class="btn-sm btn-add" onclick="pickItem('FindItemEasy-item-chips')">+ Add Item</button>
+        </div>
+        <hr class="reward-divider">
+        <div class="reward-panel">
+            <h3>Hard Rewards</h3>
+            <p class="desc">Awarded for hard find-item missions.</p>
+            <table class="reward-table"><tbody id="FindItemHard-rewards-body"></tbody></table>
+            <div class="reward-add-row">
+                <select id="FindItemHard-reward-type" onchange="onNewRewardTypeChange(this)"><option value="gold">gold</option><option value="experience">experience</option><option value="item">item</option></select>
+                <input type="number" id="FindItemHard-reward-amount" placeholder="Amount" min="0">
+                <button class="btn-sm btn-add" onclick="addRewardRow('FindItemHard-rewards-body','FindItemHard-reward-type','FindItemHard-reward-amount')">+ Add</button>
+            </div>
+        </div>
+        <div class="reward-panel">
+            <h3>Hard Reward Items</h3>
+            <p class="desc">Items drawn when a hard reward entry has Type = item.</p>
+            <div class="chip-list" id="FindItemHard-item-chips"></div>
+            <button class="btn-sm btn-add" onclick="pickItem('FindItemHard-item-chips')">+ Add Item</button>
+        </div>
+    </div>
+
+    <!-- Explore -->
+    <div class="tab-panel" id="tab-explore">
+        <div class="reward-panel">
+            <h3>Easy Rewards</h3>
+            <p class="desc">Awarded for easy exploration missions.</p>
+            <table class="reward-table"><tbody id="ExploreEasy-rewards-body"></tbody></table>
+            <div class="reward-add-row">
+                <select id="ExploreEasy-reward-type" onchange="onNewRewardTypeChange(this)"><option value="gold">gold</option><option value="experience">experience</option><option value="item">item</option></select>
+                <input type="number" id="ExploreEasy-reward-amount" placeholder="Amount" min="0">
+                <button class="btn-sm btn-add" onclick="addRewardRow('ExploreEasy-rewards-body','ExploreEasy-reward-type','ExploreEasy-reward-amount')">+ Add</button>
+            </div>
+        </div>
+        <div class="reward-panel">
+            <h3>Easy Reward Items</h3>
+            <p class="desc">Items drawn when an easy reward entry has Type = item.</p>
+            <div class="chip-list" id="ExploreEasy-item-chips"></div>
+            <button class="btn-sm btn-add" onclick="pickItem('ExploreEasy-item-chips')">+ Add Item</button>
+        </div>
+        <hr class="reward-divider">
+        <div class="reward-panel">
+            <h3>Hard Rewards</h3>
+            <p class="desc">Awarded for hard exploration missions.</p>
+            <table class="reward-table"><tbody id="ExploreHard-rewards-body"></tbody></table>
+            <div class="reward-add-row">
+                <select id="ExploreHard-reward-type" onchange="onNewRewardTypeChange(this)"><option value="gold">gold</option><option value="experience">experience</option><option value="item">item</option></select>
+                <input type="number" id="ExploreHard-reward-amount" placeholder="Amount" min="0">
+                <button class="btn-sm btn-add" onclick="addRewardRow('ExploreHard-rewards-body','ExploreHard-reward-type','ExploreHard-reward-amount')">+ Add</button>
+            </div>
+        </div>
+        <div class="reward-panel">
+            <h3>Hard Reward Items</h3>
+            <p class="desc">Items drawn when a hard reward entry has Type = item.</p>
+            <div class="chip-list" id="ExploreHard-item-chips"></div>
+            <button class="btn-sm btn-add" onclick="pickItem('ExploreHard-item-chips')">+ Add Item</button>
+        </div>
+    </div>
+
+    <!-- Escort -->
+    <div class="tab-panel" id="tab-escort">
+        <div class="reward-panel">
+            <h3>Easy Rewards</h3>
+            <p class="desc">Awarded for easy escort missions.</p>
+            <table class="reward-table"><tbody id="EscortEasy-rewards-body"></tbody></table>
+            <div class="reward-add-row">
+                <select id="EscortEasy-reward-type" onchange="onNewRewardTypeChange(this)"><option value="gold">gold</option><option value="experience">experience</option><option value="item">item</option></select>
+                <input type="number" id="EscortEasy-reward-amount" placeholder="Amount" min="0">
+                <button class="btn-sm btn-add" onclick="addRewardRow('EscortEasy-rewards-body','EscortEasy-reward-type','EscortEasy-reward-amount')">+ Add</button>
+            </div>
+        </div>
+        <div class="reward-panel">
+            <h3>Easy Reward Items</h3>
+            <p class="desc">Items drawn when an easy reward entry has Type = item.</p>
+            <div class="chip-list" id="EscortEasy-item-chips"></div>
+            <button class="btn-sm btn-add" onclick="pickItem('EscortEasy-item-chips')">+ Add Item</button>
+        </div>
+        <hr class="reward-divider">
+        <div class="reward-panel">
+            <h3>Hard Rewards</h3>
+            <p class="desc">Awarded for hard escort missions.</p>
+            <table class="reward-table"><tbody id="EscortHard-rewards-body"></tbody></table>
+            <div class="reward-add-row">
+                <select id="EscortHard-reward-type" onchange="onNewRewardTypeChange(this)"><option value="gold">gold</option><option value="experience">experience</option><option value="item">item</option></select>
+                <input type="number" id="EscortHard-reward-amount" placeholder="Amount" min="0">
+                <button class="btn-sm btn-add" onclick="addRewardRow('EscortHard-rewards-body','EscortHard-reward-type','EscortHard-reward-amount')">+ Add</button>
+            </div>
+        </div>
+        <div class="reward-panel">
+            <h3>Hard Reward Items</h3>
+            <p class="desc">Items drawn when a hard reward entry has Type = item.</p>
+            <div class="chip-list" id="EscortHard-item-chips"></div>
+            <button class="btn-sm btn-add" onclick="pickItem('EscortHard-item-chips')">+ Add Item</button>
+        </div>
+    </div>
+</div>
+
+<div class="save-bar">
+    <button class="btn btn-primary" id="save-btn" onclick="saveAll()">Save All</button>
+</div>
+
+<script>
+(function () {
+    'use strict';
+
+    // All per-type reward pool prefixes (match rewardKeyPrefix() in rewards.go)
+    const REWARD_PREFIXES = [
+        'KillMobEasy', 'KillMobHard',
+        'FindItemEasy', 'FindItemHard',
+        'ExploreEasy', 'ExploreHard',
+        'EscortEasy', 'EscortHard',
+    ];
+
+    // -------------------------------------------------------------------------
+    // Tabs
+    // -------------------------------------------------------------------------
+
+    window.showTab = function (id, btn) {
+        document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.getElementById('tab-' + id).classList.add('active');
+        btn.classList.add('active');
+    };
+
+    // -------------------------------------------------------------------------
+    // Chip helpers
+    // -------------------------------------------------------------------------
+
+    function addChip(listId, id, name) {
+        const list = document.getElementById(listId);
+        if (list.querySelector('[data-id="' + id + '"]')) return;
+        const chip = document.createElement('span');
+        chip.className = 'chip';
+        chip.dataset.id = String(id);
+        chip.innerHTML =
+            '<span class="chip-id">#' + escHtml(String(id)) + '</span>' +
+            (name ? '<span class="chip-name">' + escHtml(name) + '</span>' : '') +
+            '<button class="chip-remove" title="Remove" onclick="this.parentElement.remove()">\u00d7</button>';
+        list.appendChild(chip);
+    }
+
+    function getChipIds(listId) {
+        return Array.from(document.querySelectorAll('#' + listId + ' .chip'))
+            .map(c => parseInt(c.dataset.id, 10))
+            .filter(n => !isNaN(n) && n > 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Picker launchers
+    // -------------------------------------------------------------------------
+
+    window.pickMob = function (listId) {
+        Picker.open({
+            ...PickerConfigs.mobs,
+            title: 'Select Escort Mob',
+            onSelect: (mob) => {
+                addChip(listId, mob.MobId, (mob.Character && mob.Character.Name) || mob._name || '');
+            },
+        });
+    };
+
+    window.pickItem = function (listId) {
+        Picker.open({
+            ...PickerConfigs.items,
+            title: 'Select Reward Item',
+            onSelect: (item) => { addChip(listId, item.ItemId, item.Name || ''); },
+        });
+    };
+
+    // -------------------------------------------------------------------------
+    // Reward table helpers
+    // -------------------------------------------------------------------------
+
+    window.addRewardRow = function (tbodyId, typeSelId, amountInputId) {
+        const type   = document.getElementById(typeSelId).value;
+        const amount = parseInt(document.getElementById(amountInputId).value, 10) || 0;
+        appendRewardRow(tbodyId, type, amount);
+        document.getElementById(amountInputId).value = '';
+    };
+
+    function appendRewardRow(tbodyId, type, amount) {
+        const tbody = document.getElementById(tbodyId);
+        const tr = document.createElement('tr');
+        const hidden = type === 'item' ? ' style="visibility:hidden"' : '';
+        tr.innerHTML =
+            '<td><select onchange="onRewardTypeChange(this)">' +
+                '<option value="gold"'       + (type === 'gold'       ? ' selected' : '') + '>gold</option>' +
+                '<option value="experience"' + (type === 'experience' ? ' selected' : '') + '>experience</option>' +
+                '<option value="item"'       + (type === 'item'       ? ' selected' : '') + '>item</option>' +
+            '</select></td>' +
+            '<td' + hidden + '><input type="number" value="' + escHtml(String(amount)) + '" min="0"></td>' +
+            '<td><button class="btn-sm" style="background:var(--color-danger,#c0392b);color:#fff" ' +
+                'onclick="this.closest(\'tr\').remove()">Remove</button></td>';
+        tbody.appendChild(tr);
+    }
+
+    window.onRewardTypeChange = function (sel) {
+        sel.closest('tr').querySelector('td:nth-child(2)').style.visibility =
+            sel.value === 'item' ? 'hidden' : '';
+    };
+
+    window.onNewRewardTypeChange = function (sel) {
+        sel.closest('.reward-add-row').querySelector('input[type="number"]').style.visibility =
+            sel.value === 'item' ? 'hidden' : '';
+    };
+
+    function getRewardRows(tbodyId) {
+        return Array.from(document.querySelectorAll('#' + tbodyId + ' tr')).map(tr => ({
+            Type:   (tr.querySelector('select') || {}).value || 'gold',
+            Amount: parseInt((tr.querySelector('input[type="number"]') || {}).value || '0', 10) || 0,
+        }));
+    }
+
+    // -------------------------------------------------------------------------
+    // Load
+    // -------------------------------------------------------------------------
+
+    const _mobNames  = {};
+    const _itemNames = {};
+
+    async function init() {
+        const [mobsRes, itemsRes, cfgRes] = await AdminAPI.all([
+            AdminAPI.get('/admin/api/v1/mobs'),
+            AdminAPI.get('/admin/api/v1/items'),
+            AdminAPI.get('/admin/api/v1/automission-config', true),
+        ]);
+
+        if (mobsRes.ok) {
+            for (const m of (mobsRes.data && mobsRes.data.data) || [])
+                _mobNames[String(m.MobId)] = (m.Character && m.Character.Name) || '';
+        }
+        if (itemsRes.ok) {
+            for (const i of (itemsRes.data && itemsRes.data.data) || [])
+                _itemNames[String(i.ItemId)] = i.Name || '';
+        }
+
+        if (!cfgRes || !cfgRes.ok) {
+            showStatus('Failed to load configuration: ' + (cfgRes ? cfgRes.error : 'no response'), false);
+            return;
+        }
+
+        const cfg = (cfgRes.data && cfgRes.data.data) || {};
+
+        document.getElementById('f-restock').value     = cfg.RestockPeriod   || '1 real day';
+        document.getElementById('f-maxmissions').value = cfg.MaxMissions     || '6';
+        document.getElementById('f-escortlimit').value = cfg.EscortTimeLimit || '1 hour';
+
+        (cfg.EscortMobIds || []).forEach(id =>
+            addChip('escort-mob-chips', id, _mobNames[String(id)] || ''));
+
+        for (const pfx of REWARD_PREFIXES) {
+            (cfg[pfx + 'Rewards'] || []).forEach(r =>
+                appendRewardRow(pfx + '-rewards-body', r.Type || 'gold', r.Amount || 0));
+            (cfg[pfx + 'RewardItems'] || []).forEach(id =>
+                addChip(pfx + '-item-chips', id, _itemNames[String(id)] || ''));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Save
+    // -------------------------------------------------------------------------
+
+    window.saveAll = async function () {
+        const btn = document.getElementById('save-btn');
+        btn.disabled = true; btn.textContent = 'Saving...';
+
+        const payload = {
+            RestockPeriod:   document.getElementById('f-restock').value.trim()     || '1 real day',
+            MaxMissions:     document.getElementById('f-maxmissions').value.trim()  || '6',
+            EscortTimeLimit: document.getElementById('f-escortlimit').value.trim()  || '1 hour',
+            EscortMobIds:    getChipIds('escort-mob-chips'),
+        };
+
+        for (const pfx of REWARD_PREFIXES) {
+            payload[pfx + 'Rewards']     = getRewardRows(pfx + '-rewards-body');
+            payload[pfx + 'RewardItems'] = getChipIds(pfx + '-item-chips');
+        }
+
+        const res = await AdminAPI.patch('/admin/api/v1/automission-config', payload);
+        btn.disabled = false; btn.textContent = 'Save All';
+
+        if (!res || !res.ok) { showStatus('Save failed: ' + (res ? res.error : 'no response'), false); return; }
+        showStatus('Configuration saved.', true);
+    };
+
+    // -------------------------------------------------------------------------
+    // Util
+    // -------------------------------------------------------------------------
+
+    function showStatus(msg, success) {
+        const bar = document.getElementById('status-bar');
+        bar.textContent = msg; bar.className = success ? 'success' : 'error';
+        clearTimeout(bar._t); bar._t = setTimeout(() => { bar.className = ''; bar.style.display = 'none'; }, 6000);
+    }
+    function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+    init();
+})();
+</script>
+
+{{template "footer" .}}

--- a/modules/automission/files/datafiles/templates/help/mission.template
+++ b/modules/automission/files/datafiles/templates/help/mission.template
@@ -1,0 +1,37 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">mission</ansi>
+
+The <ansi fg="command">mission</ansi> command lets you browse, accept, and turn in missions from
+mission boards found throughout the world.
+
+<ansi fg="yellow">Usage:</ansi>
+
+  <ansi fg="command">mission list</ansi>
+    At a mission board: shows all missions available at that board,
+    with difficulty, reward, and your current status for each.
+    Elsewhere: shows only the missions you have currently accepted.
+
+  <ansi fg="command">mission accept <number or name></ansi>
+    Accepts a mission by its list number or a partial title match.
+    You must be at the mission board that offers the mission.
+    Escort missions spawn the escort NPC immediately on accept.
+
+  <ansi fg="command">mission turn in</ansi>
+    Claims rewards for all completed missions at the current board.
+    You must return to the same board where you accepted the mission.
+    If your ready missions belong to a different board, you will be
+    told which room to return to.
+
+<ansi fg="yellow">Mission Types:</ansi>
+
+  <ansi fg="white-bold">Kill</ansi>     Hunt down and kill a specific type of mob.
+  <ansi fg="white-bold">Find</ansi>     Acquire a specific item and bring it back.
+  <ansi fg="white-bold">Explore</ansi>  Travel to a specific room.
+  <ansi fg="white-bold">Escort</ansi>   Guide an NPC safely to their destination zone
+           within a time limit.
+
+<ansi fg="yellow">Difficulty:</ansi>
+
+  Missions come in <ansi fg="white-bold">easy</ansi> and <ansi fg="white-bold">hard</ansi> tiers. Hard missions offer
+  greater rewards but target rarer mobs, items, or more distant rooms.
+
+<ansi fg="magenta-bold">See also:</ansi> <ansi fg="command">help look</ansi>

--- a/modules/automission/missions.go
+++ b/modules/automission/missions.go
@@ -1,0 +1,544 @@
+package automission
+
+import (
+	"errors"
+
+	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/mapper"
+	"github.com/GoMudEngine/GoMud/internal/mobs"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/telemetry"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+// MissionType identifies the kind of objective.
+type MissionType string
+
+const (
+	MissionTypeKillMob  MissionType = "kill_mob"
+	MissionTypeFindItem MissionType = "find_item"
+	MissionTypeExplore  MissionType = "explore"
+	MissionTypeEscort   MissionType = "escort"
+)
+
+// boardTagForType maps each mission type to the room tag that enables it.
+var boardTagForType = map[MissionType]string{
+	MissionTypeKillMob:  tagKillMob,
+	MissionTypeFindItem: tagFindItem,
+	MissionTypeExplore:  tagExplore,
+	MissionTypeEscort:   tagEscort,
+}
+
+// MissionDifficulty is either easy or hard.
+type MissionDifficulty string
+
+const (
+	DifficultyEasy MissionDifficulty = "easy"
+	DifficultyHard MissionDifficulty = "hard"
+)
+
+// Mission holds all state for one active mission board entry.
+type Mission struct {
+	Id          int
+	BoardRoomId int // room the mission was generated for; turn-in must happen here
+	Type        MissionType
+	Difficulty  MissionDifficulty
+	Title       string
+	Description string
+
+	TargetMobId     int
+	TargetItemId    int
+	TargetRoomId    int
+	TargetZone      string
+	EscortMobSpecId int
+
+	EscortMobs     map[int]int    // userId -> mobInstanceId
+	EscortExpiries map[int]uint64 // userId -> round when escort expires
+
+	Reward RewardConfig
+
+	AcceptedBy    []int
+	CompletedBy   []int
+	ReadyToTurnIn []int
+}
+
+// generateMissionsForBoard creates up to count missions for a single board room,
+// restricting generation to the mission types whose tags are present on that room.
+// Slots are distributed evenly across available types first, then remaining
+// slots are filled randomly. A generator is retired once it returns nil.
+func (m *AutoMissionModule) generateMissionsForBoard(boardRoom *rooms.Room, count int) []*Mission {
+	type generatorFunc func(MissionDifficulty, *usedTargets) *Mission
+
+	type namedGen struct {
+		gen  generatorFunc
+		fail int // consecutive failures
+	}
+
+	var gens []namedGen
+
+	if boardRoom.HasTag(tagKillMob) {
+		gens = append(gens, namedGen{gen: m.generateKillMob})
+	}
+	if boardRoom.HasTag(tagFindItem) {
+		gens = append(gens, namedGen{gen: m.generateFindItem})
+	}
+	if boardRoom.HasTag(tagExplore) {
+		gens = append(gens, namedGen{gen: m.generateExploreRoom(boardRoom.RoomId)})
+	}
+	if boardRoom.HasTag(tagEscort) && len(m.escortMobIds()) > 0 {
+		gens = append(gens, namedGen{gen: m.generateEscort(boardRoom.RoomId)})
+	}
+
+	if len(gens) == 0 {
+		return nil
+	}
+
+	difficulties := []MissionDifficulty{DifficultyEasy, DifficultyHard}
+	used := &usedTargets{
+		mobIds:  make(map[int]bool),
+		itemIds: make(map[int]bool),
+		roomIds: make(map[int]bool),
+	}
+
+	var result []*Mission
+
+	// Phase 1: round-robin across all available generators to ensure even
+	// distribution. Each generator gets one turn per round until count is met
+	// or all generators are exhausted.
+	for len(result) < count && len(gens) > 0 {
+		// Shuffle each round so the order varies.
+		for i := len(gens) - 1; i > 0; i-- {
+			j := util.Rand(i + 1)
+			gens[i], gens[j] = gens[j], gens[i]
+		}
+
+		progress := false
+		i := 0
+		for i < len(gens) && len(result) < count {
+			diff := difficulties[util.Rand(len(difficulties))]
+			mission := gens[i].gen(diff, used)
+			if mission == nil {
+				gens[i].fail++
+				if gens[i].fail >= 3 {
+					// Generator exhausted — retire it.
+					gens = append(gens[:i], gens[i+1:]...)
+					continue
+				}
+			} else {
+				gens[i].fail = 0
+				m.missionIdCounter++
+				mission.Id = m.missionIdCounter
+				mission.BoardRoomId = boardRoom.RoomId
+				mission.EscortMobs = make(map[int]int)
+				mission.EscortExpiries = make(map[int]uint64)
+				mission.Reward = m.selectReward(mission.Type, diff)
+				result = append(result, mission)
+				progress = true
+			}
+			i++
+		}
+		// If no generator produced anything this round, stop.
+		if !progress {
+			break
+		}
+	}
+
+	return result
+}
+
+// usedTargets tracks which mob IDs, item IDs, and room IDs have already been
+// assigned to missions on the current board to prevent repeats.
+type usedTargets struct {
+	mobIds  map[int]bool
+	itemIds map[int]bool
+	roomIds map[int]bool
+}
+
+// generateKillMob creates a kill_mob mission using telemetry.
+// Falls back to all known mob specs when telemetry has no kill data.
+func (m *AutoMissionModule) generateKillMob(diff MissionDifficulty, used *usedTargets) *Mission {
+	results := telemetry.Query().
+		Category(telemetry.CatMobKill).
+		GroupBy(telemetry.GroupByMobId).
+		SortDesc().
+		Results()
+
+	var pool []int
+
+	if len(results) == 0 {
+		// No telemetry yet — use all known mob specs as candidates.
+		for _, mob := range mobs.GetAllMobInfo() {
+			id := int(mob.MobId)
+			if id > 0 && !used.mobIds[id] {
+				pool = append(pool, id)
+			}
+		}
+	} else {
+		bucket := len(results) / 10
+		if bucket < 1 {
+			bucket = 1
+		}
+		if diff == DifficultyEasy {
+			for i := 0; i < bucket; i++ {
+				id := results[i].MobId
+				if !used.mobIds[id] {
+					pool = append(pool, id)
+				}
+			}
+		} else {
+			start := len(results) - bucket
+			for i := start; i < len(results); i++ {
+				id := results[i].MobId
+				if !used.mobIds[id] {
+					pool = append(pool, id)
+				}
+			}
+		}
+	}
+
+	if len(pool) == 0 {
+		return nil
+	}
+
+	mobId := pool[util.Rand(len(pool))]
+	spec := mobs.GetMobSpec(mobs.MobId(mobId))
+	if spec == nil {
+		return nil
+	}
+
+	used.mobIds[mobId] = true
+	name := spec.Character.Name
+
+	var title string
+	if diff == DifficultyHard {
+		title = `Defeat a <ansi fg="mobname">` + name + `</ansi> (Hard)`
+	} else {
+		title = `Defeat a <ansi fg="mobname">` + name + `</ansi>`
+	}
+
+	return &Mission{
+		Type:        MissionTypeKillMob,
+		Difficulty:  diff,
+		Title:       title,
+		Description: `Hunt down and kill a <ansi fg="mobname">` + name + `</ansi>.`,
+		TargetMobId: mobId,
+	}
+}
+
+// generateFindItem creates a find_item mission using telemetry.
+// Skips quest items and already-used item IDs.
+func (m *AutoMissionModule) generateFindItem(diff MissionDifficulty, used *usedTargets) *Mission {
+	results := telemetry.Query().
+		Category(telemetry.CatItemDrop).
+		GroupBy(telemetry.GroupByItemId).
+		SortDesc().
+		Results()
+
+	if len(results) == 0 {
+		return nil
+	}
+
+	bucket := len(results) / 10
+	if bucket < 1 {
+		bucket = 1
+	}
+
+	// Build a candidate list from the appropriate difficulty bucket,
+	// excluding quest items and already-used item IDs.
+	var pool []int
+	if diff == DifficultyEasy {
+		for i := 0; i < bucket; i++ {
+			id := results[i].ItemId
+			if used.itemIds[id] {
+				continue
+			}
+			spec := items.GetItemSpec(id)
+			if spec == nil || spec.QuestToken != "" {
+				continue
+			}
+			pool = append(pool, id)
+		}
+	} else {
+		start := len(results) - bucket
+		for i := start; i < len(results); i++ {
+			id := results[i].ItemId
+			if used.itemIds[id] {
+				continue
+			}
+			spec := items.GetItemSpec(id)
+			if spec == nil || spec.QuestToken != "" {
+				continue
+			}
+			pool = append(pool, id)
+		}
+	}
+	if len(pool) == 0 {
+		return nil
+	}
+
+	itemId := pool[util.Rand(len(pool))]
+	spec := items.GetItemSpec(itemId)
+	if spec == nil {
+		return nil
+	}
+
+	used.itemIds[itemId] = true
+	name := spec.Name
+
+	var title string
+	if diff == DifficultyHard {
+		title = `Acquire a <ansi fg="itemname">` + name + `</ansi> (Hard)`
+	} else {
+		title = `Acquire a <ansi fg="itemname">` + name + `</ansi>`
+	}
+
+	return &Mission{
+		Type:         MissionTypeFindItem,
+		Difficulty:   diff,
+		Title:        title,
+		Description:  `Find and bring back a <ansi fg="itemname">` + name + `</ansi>.`,
+		TargetItemId: itemId,
+	}
+}
+
+// generateExploreRoom returns a generator that picks a reachable, unused room.
+func (m *AutoMissionModule) generateExploreRoom(boardRoomId int) func(MissionDifficulty, *usedTargets) *Mission {
+	return func(diff MissionDifficulty, used *usedTargets) *Mission {
+		zoneNames := rooms.GetAllZoneNames()
+		if len(zoneNames) == 0 {
+			return nil
+		}
+
+		shuffled := make([]string, len(zoneNames))
+		copy(shuffled, zoneNames)
+		for i := len(shuffled) - 1; i > 0; i-- {
+			j := util.Rand(i + 1)
+			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+		}
+
+		var candidates []roomCandidate
+		zonesChecked := 0
+		for _, zone := range shuffled {
+			if zonesChecked >= 5 {
+				break
+			}
+			zonesChecked++
+
+			roomIds := rooms.GetAllZoneRoomsIds(zone)
+			if len(roomIds) == 0 {
+				continue
+			}
+
+			sample := roomIds
+			if len(sample) > 20 {
+				perm := make([]int, len(roomIds))
+				copy(perm, roomIds)
+				for i := len(perm) - 1; i > 0; i-- {
+					j := util.Rand(i + 1)
+					perm[i], perm[j] = perm[j], perm[i]
+				}
+				sample = perm[:20]
+			}
+
+			for _, rid := range sample {
+				if used.roomIds[rid] {
+					continue
+				}
+				steps, err := mapper.GetPath(boardRoomId, rid)
+				if err != nil {
+					if errors.Is(err, mapper.ErrPathNotFound) || errors.Is(err, mapper.ErrPathDestMatch) {
+						continue
+					}
+					continue
+				}
+				candidates = append(candidates, roomCandidate{roomId: rid, dist: len(steps)})
+			}
+		}
+
+		if len(candidates) == 0 {
+			return nil
+		}
+
+		median := medianDist(candidates)
+
+		var easy, hard []roomCandidate
+		for _, c := range candidates {
+			if c.dist < median {
+				easy = append(easy, c)
+			} else {
+				hard = append(hard, c)
+			}
+		}
+
+		pool := easy
+		if diff == DifficultyHard {
+			pool = hard
+		}
+		if len(pool) == 0 {
+			pool = candidates
+		}
+
+		chosen := pool[util.Rand(len(pool))]
+		room := rooms.LoadRoom(chosen.roomId)
+		if room == nil {
+			return nil
+		}
+
+		used.roomIds[chosen.roomId] = true
+
+		var title string
+		if diff == DifficultyHard {
+			title = `Explore <ansi fg="cyan">` + room.Title + `</ansi> (Hard)`
+		} else {
+			title = `Explore <ansi fg="cyan">` + room.Title + `</ansi>`
+		}
+
+		return &Mission{
+			Type:         MissionTypeExplore,
+			Difficulty:   diff,
+			Title:        title,
+			Description:  `Travel to <ansi fg="cyan">` + room.Title + `</ansi> in the ` + room.Zone + ` region.`,
+			TargetRoomId: chosen.roomId,
+		}
+	}
+}
+
+// generateEscort returns a generator that creates escort missions whose
+// destination zone is reachable from boardRoomId and is not the same zone
+// as the board room itself.
+func (m *AutoMissionModule) generateEscort(boardRoomId int) func(MissionDifficulty, *usedTargets) *Mission {
+	boardRoom := rooms.LoadRoom(boardRoomId)
+	boardZone := ""
+	if boardRoom != nil {
+		boardZone = boardRoom.Zone
+	}
+
+	return func(diff MissionDifficulty, used *usedTargets) *Mission {
+		ids := m.escortMobIds()
+		if len(ids) == 0 {
+			return nil
+		}
+
+		// Shuffle so we don't always try the same mob first.
+		shuffled := make([]int, len(ids))
+		copy(shuffled, ids)
+		for i := len(shuffled) - 1; i > 0; i-- {
+			j := util.Rand(i + 1)
+			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+		}
+
+		for _, specId := range shuffled {
+			if used.mobIds[specId] {
+				continue
+			}
+
+			spec := mobs.GetMobSpec(mobs.MobId(specId))
+			if spec == nil {
+				continue
+			}
+
+			zone := spec.Zone
+
+			if zone == "" {
+				continue
+			}
+
+			// Skip mobs whose destination is the same zone as the board room.
+			if boardZone != "" && zone == boardZone {
+				continue
+			}
+
+			if !zoneIsReachable(boardRoomId, zone) {
+				continue
+			}
+
+			name := spec.Character.Name
+			used.mobIds[specId] = true
+			var title string
+			if diff == DifficultyHard {
+				title = `Escort <ansi fg="mobname">` + name + `</ansi> to ` + zone + ` (Hard)`
+			} else {
+				title = `Escort <ansi fg="mobname">` + name + `</ansi> to ` + zone
+			}
+
+			return &Mission{
+				Type:            MissionTypeEscort,
+				Difficulty:      diff,
+				Title:           title,
+				Description:     `<ansi fg="mobname">` + name + `</ansi> needs to reach ` + zone + `. Keep them safe and get them there in time.`,
+				TargetZone:      zone,
+				EscortMobSpecId: specId,
+			}
+		}
+
+		return nil
+	}
+}
+
+// zoneIsReachable returns true if any room in zone has a path from boardRoomId.
+// Shuffles the candidate rooms so the same rooms aren't always checked first.
+func zoneIsReachable(boardRoomId int, zone string) bool {
+	roomIds := rooms.GetAllZoneRoomsIds(zone)
+	if len(roomIds) == 0 {
+		return false
+	}
+	// Shuffle and sample up to 10 rooms.
+	perm := make([]int, len(roomIds))
+	copy(perm, roomIds)
+	for i := len(perm) - 1; i > 0; i-- {
+		j := util.Rand(i + 1)
+		perm[i], perm[j] = perm[j], perm[i]
+	}
+	sample := perm
+	if len(sample) > 10 {
+		sample = perm[:10]
+	}
+	for _, rid := range sample {
+		_, err := mapper.GetPath(boardRoomId, rid)
+		if err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// escortMobIds reads the EscortMobIds config key and returns []int.
+func (m *AutoMissionModule) escortMobIds() []int {
+	raw := m.configSlice("EscortMobIds")
+	if len(raw) == 0 {
+		return nil
+	}
+	ids := make([]int, 0, len(raw))
+	for _, v := range raw {
+		if id := toInt(v); id > 0 {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// medianDist returns the median distance from a roomCandidate slice.
+func medianDist(cs []roomCandidate) int {
+	if len(cs) == 0 {
+		return 0
+	}
+	sorted := make([]int, len(cs))
+	for i, c := range cs {
+		sorted[i] = c.dist
+	}
+	for i := 1; i < len(sorted); i++ {
+		key := sorted[i]
+		j := i - 1
+		for j >= 0 && sorted[j] > key {
+			sorted[j+1] = sorted[j]
+			j--
+		}
+		sorted[j+1] = key
+	}
+	return sorted[len(sorted)/2]
+}
+
+type roomCandidate struct {
+	roomId int
+	dist   int
+}

--- a/modules/automission/rewards.go
+++ b/modules/automission/rewards.go
@@ -1,0 +1,248 @@
+package automission
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/util"
+	"github.com/GoMudEngine/ansitags"
+)
+
+// RewardConfig describes what a mission pays out on completion.
+type RewardConfig struct {
+	Type   string // "gold", "item", "experience"
+	Amount int
+	ItemId int // only set when Type == "item"
+}
+
+// rewardKeyPrefix returns the config key prefix for a given mission type and difficulty.
+// e.g. MissionTypeKillMob + DifficultyEasy -> "KillMobEasy"
+func rewardKeyPrefix(mType MissionType, diff MissionDifficulty) string {
+	var typePart string
+	switch mType {
+	case MissionTypeKillMob:
+		typePart = "KillMob"
+	case MissionTypeFindItem:
+		typePart = "FindItem"
+	case MissionTypeExplore:
+		typePart = "Explore"
+	case MissionTypeEscort:
+		typePart = "Escort"
+	default:
+		typePart = "KillMob"
+	}
+	var diffPart string
+	if diff == DifficultyHard {
+		diffPart = "Hard"
+	} else {
+		diffPart = "Easy"
+	}
+	return typePart + diffPart
+}
+
+// deliverReward grants the reward to the user.
+func deliverReward(reward RewardConfig, user *userRecord) {
+	switch reward.Type {
+	case "gold":
+		user.Character.Gold += reward.Amount
+		events.AddToQueue(events.EquipmentChange{
+			UserId:     user.UserId,
+			GoldChange: reward.Amount,
+		})
+	case "experience":
+		user.GrantXP(reward.Amount, "mission")
+	case "item":
+		spec := items.GetItemSpec(reward.ItemId)
+		if spec != nil {
+			item := items.New(reward.ItemId)
+			if user.Character.StoreItem(item) {
+				events.AddToQueue(events.ItemOwnership{
+					UserId: user.UserId,
+					Item:   item,
+					Gained: true,
+				})
+			}
+		}
+	}
+}
+
+// selectReward picks a reward for the given mission type and difficulty.
+// It looks up the per-type pool first, then falls back to a generic default.
+func (m *AutoMissionModule) selectReward(mType MissionType, diff MissionDifficulty) RewardConfig {
+	prefix := rewardKeyPrefix(mType, diff)
+	pool := m.configSlice(prefix + "Rewards")
+	itemPool := m.configSlice(prefix + "RewardItems")
+
+	// If the specific pool is empty, fall back to the easy pool for that type
+	// (scaled up for hard), then to a bare default.
+	if len(pool) == 0 && diff == DifficultyHard {
+		easyPrefix := rewardKeyPrefix(mType, DifficultyEasy)
+		pool = m.configSlice(easyPrefix + "Rewards")
+		itemPool = m.configSlice(easyPrefix + "RewardItems")
+		if len(pool) > 0 {
+			idx := util.Rand(len(pool))
+			entry := asStringMap(pool[idx])
+			rc := RewardConfig{
+				Type:   stringVal(entry, "Type", "gold"),
+				Amount: intVal(entry, "Amount", 100) * 3,
+			}
+			if rc.Type == "item" {
+				if id := pickItemId(itemPool); id > 0 {
+					rc.ItemId = id
+				} else {
+					rc.Type = "gold"
+				}
+			}
+			return rc
+		}
+		return defaultReward(mType, diff)
+	}
+
+	if len(pool) == 0 {
+		return defaultReward(mType, diff)
+	}
+
+	idx := util.Rand(len(pool))
+	entry := asStringMap(pool[idx])
+	rc := RewardConfig{
+		Type:   stringVal(entry, "Type", "gold"),
+		Amount: intVal(entry, "Amount", 100),
+	}
+
+	if rc.Type == "item" {
+		if id := pickItemId(itemPool); id > 0 {
+			rc.ItemId = id
+		} else {
+			rc.Type = "gold"
+		}
+	}
+
+	return rc
+}
+
+// defaultReward returns a hardcoded fallback reward when no pool is configured.
+func defaultReward(mType MissionType, diff MissionDifficulty) RewardConfig {
+	amount := 100
+	if diff == DifficultyHard {
+		amount = 300
+	}
+	return RewardConfig{Type: "gold", Amount: amount}
+}
+
+// rewardDescription returns a colored, human-readable reward string.
+func rewardDescription(r RewardConfig) string {
+	switch r.Type {
+	case "gold":
+		return fmt.Sprintf(`<ansi fg="gold">%d gold</ansi>`, r.Amount)
+	case "experience":
+		return fmt.Sprintf(`<ansi fg="experience">%d experience</ansi>`, r.Amount)
+	case "item":
+		spec := items.GetItemSpec(r.ItemId)
+		if spec != nil {
+			return fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, spec.Name)
+		}
+		return `<ansi fg="itemname">an item</ansi>`
+	}
+	return "unknown reward"
+}
+
+// buildBanner formats a fixed-width mission notification banner.
+// ANSI tags in title and subtitle are stripped before display so markup
+// does not corrupt the border alignment.
+func buildBanner(title, subtitle, color string) string {
+	const width = 44
+	border := strings.Repeat("=", width-2)
+
+	titlePlain := ansitags.Parse(title, ansitags.StripTags)
+	titleLine := padCenter(titlePlain, width-4)
+
+	var subtitleLine string
+	if subtitle != "" {
+		subtitlePlain := ansitags.Parse(subtitle, ansitags.StripTags)
+		subtitleLine = padCenter(subtitlePlain, width-4)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("<ansi fg=\"%s\">", color))
+	sb.WriteString(fmt.Sprintf("╔%s╗\n", border))
+	sb.WriteString(fmt.Sprintf("║  %-*s  ║\n", width-6, titleLine))
+	if subtitle != "" {
+		sb.WriteString(fmt.Sprintf("║  %-*s  ║\n", width-6, subtitleLine))
+	}
+	sb.WriteString(fmt.Sprintf("╚%s╝", border))
+	sb.WriteString("</ansi>")
+
+	return sb.String()
+}
+
+// padCenter centers s within fieldWidth, truncating with "..." if too long.
+func padCenter(s string, fieldWidth int) string {
+	if len(s) > fieldWidth {
+		if fieldWidth > 3 {
+			return s[:fieldWidth-3] + "..."
+		}
+		return s[:fieldWidth]
+	}
+	return s
+}
+
+// pickItemId selects a random item ID from a config slice.
+func pickItemId(pool []any) int {
+	if len(pool) == 0 {
+		return 0
+	}
+	return toInt(pool[util.Rand(len(pool))])
+}
+
+// configSlice is defined in admin_api.go.
+
+// asStringMap converts map[any]any or map[string]any to map[string]any.
+func asStringMap(v any) map[string]any {
+	if mm, ok := v.(map[any]any); ok {
+		out := make(map[string]any, len(mm))
+		for k, val := range mm {
+			out[fmt.Sprint(k)] = val
+		}
+		return out
+	}
+	if mm, ok := v.(map[string]any); ok {
+		return mm
+	}
+	return nil
+}
+
+func stringVal(m map[string]any, key, def string) string {
+	if m == nil {
+		return def
+	}
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return def
+}
+
+func intVal(m map[string]any, key string, def int) int {
+	if m == nil {
+		return def
+	}
+	if v, ok := m[key]; ok {
+		return toInt(v)
+	}
+	return def
+}
+
+func toInt(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case float64:
+		return int(n)
+	case int64:
+		return int(n)
+	}
+	return 0
+}


### PR DESCRIPTION
# Description

Adds a new `automission` module that provides a dynamic, telemetry-driven mission board system for rooms.

Players visit rooms tagged with mission board tags to browse, accept, and complete missions. Missions are generated automatically from server telemetry and restocked on a configurable timer.

---

## Changes

- New `modules/automission` module with full plugin registration, admin pages, and user command
- Four mission types: `kill_mob`, `find_item`, `explore`, and `escort`, each enabled independently via room tags (`missionboard kill_mob`, `missionboard find_item`, `missionboard explore`, `missionboard escort`)
- Per-board mission generation — each tagged room generates its own independent mission pool; two boards with the same tags produce different missions
- Missions must be turned in at the same board room they were accepted from; players are told which room to return to if they try the wrong board
- Telemetry-driven target selection: kill and find missions select targets from kill/drop frequency data with easy/hard difficulty tiers; falls back to all known mobs/items when telemetry is sparse
- Explore missions use mapper path distance from the board room to determine difficulty
- Escort missions spawn a charmed NPC that must be guided to its destination zone within a configurable time limit; validates zone reachability via the mapper before generating; excludes mobs whose home zone matches the board room's zone
- Deduplication: no mob, item, room, or escort mob repeats within a single board's mission pool
- Quest items excluded from find_item missions
- One active mission per type enforced at accept time
- Find_item turn-in requires the player to have the item in inventory or equipped; item is taken on successful turn-in
- Per-type reward pools (`KillMobEasyRewards`, `FindItemHardRewards`, etc.) with gold, experience, and item reward types; item rewards fall back to gold if no item IDs are configured
- Room alert injected via `OnRoomLook` when entering a board room
- Turn-in reminder shown when entering a board room with ready missions
- `mission list` shows `[ACCEPTED]`, `[READY]`, and `[COMPLETED]` status per mission; shows accept hint at board rooms
- ANSI tags stripped from mission titles before banner rendering to prevent border corruption
- Admin Config page with tabbed per-type reward pool editor using standard item/mob pickers
- Admin About page with full command, room tag, and config key reference
- `help mission` template registered; `mission` added to keywords for the help menu
- `modules/all-modules.go` import added
