### PR TITLE
Telemetry improvements

### DIFF
--- a/_datafiles/html/admin/telemetry-api.html
+++ b/_datafiles/html/admin/telemetry-api.html
@@ -59,16 +59,19 @@
             <table class="params-table">
                 <thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
                 <tbody>
-                    <tr><td class="param-name">category</td><td>string <span class="param-opt">optional</span></td><td>One of <code>item_drop</code>, <code>item_pickup</code>, <code>mob_kill</code>, <code>player_death</code>, <code>item_purchase</code></td></tr>
+                    <tr><td class="param-name">category</td><td>string <span class="param-opt">optional</span></td><td>One of <code>item_drop</code>, <code>item_pickup</code>, <code>mob_kill</code>, <code>player_death</code>, <code>item_purchase</code>, <code>char_created</code>, <code>help_topic</code></td></tr>
                     <tr><td class="param-name">itemId</td><td>int <span class="param-opt">optional</span></td><td>Filter by item spec ID</td></tr>
                     <tr><td class="param-name">mobId</td><td>int <span class="param-opt">optional</span></td><td>Filter by mob spec ID</td></tr>
                     <tr><td class="param-name">roomId</td><td>int <span class="param-opt">optional</span></td><td>Filter by room ID</td></tr>
                     <tr><td class="param-name">zone</td><td>string <span class="param-opt">optional</span></td><td>Exact zone name match</td></tr>
+                    <tr><td class="param-name">raceId</td><td>int <span class="param-opt">optional</span></td><td>Filter by race ID. Used with <code>char_created</code> records.</td></tr>
+                    <tr><td class="param-name">topic</td><td>string <span class="param-opt">optional</span></td><td>Filter by topic string. Used with <code>help_topic</code> records.</td></tr>
                     <tr><td class="param-name">date</td><td>string <span class="param-opt">optional</span></td><td>Exact date <code>YYYYMMDD</code>. Shorthand for <code>dateFrom</code> + <code>dateTo</code> set to the same value.</td></tr>
                     <tr><td class="param-name">dateFrom</td><td>string <span class="param-opt">optional</span></td><td>Start of date range <code>YYYYMMDD</code>, inclusive</td></tr>
                     <tr><td class="param-name">dateTo</td><td>string <span class="param-opt">optional</span></td><td>End of date range <code>YYYYMMDD</code>, inclusive</td></tr>
-                    <tr><td class="param-name">groupby</td><td>string <span class="param-opt">optional</span></td><td>Roll up matching records by a single dimension. Counts are summed across all records sharing the same value. Non-key fields are omitted from results. Accepted values: <code>mob</code> (or <code>mobid</code>), <code>item</code> (or <code>itemid</code>), <code>zone</code>, <code>room</code> (or <code>roomid</code>), <code>date</code>, <code>category</code></td></tr>
+                    <tr><td class="param-name">groupby</td><td>string <span class="param-opt">optional</span></td><td>Roll up matching records by a single dimension. Counts are summed across all records sharing the same value. Non-key fields are omitted from results. Accepted values: <code>mob</code> (or <code>mobid</code>), <code>item</code> (or <code>itemid</code>), <code>zone</code>, <code>room</code> (or <code>roomid</code>), <code>date</code>, <code>category</code>, <code>race</code> (or <code>raceid</code>), <code>topic</code></td></tr>
                     <tr><td class="param-name">sort</td><td>string <span class="param-opt">optional</span></td><td><code>asc</code> or <code>desc</code> (default <code>desc</code>). Sorts by <code>count</code>.</td></tr>
+                    <tr><td class="param-name">limit</td><td>int <span class="param-opt">optional</span></td><td>Maximum number of records to return after sorting. Omit or set to <code>0</code> for no limit.</td></tr>
                 </tbody>
             </table>
             <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
@@ -105,12 +108,14 @@
             <span class="api-desc">Clear matching telemetry records</span>
         </summary>
         <div class="api-body">
-            <p>Removes all records matching the supplied filters and saves the result to disk. Omit all parameters to clear every record. Accepts the same filter parameters as <code>GET</code> except <code>sort</code>.</p>
+            <p>Removes all records matching the supplied filters and saves the result to disk. Omit all parameters to clear every record. Accepts the same filter parameters as <code>GET</code> except <code>groupby</code>, <code>sort</code>, and <code>limit</code>.</p>
             <table class="params-table">
                 <thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
                 <tbody>
                     <tr><td class="param-name">category</td><td>string <span class="param-opt">optional</span></td><td>Restrict deletion to one category</td></tr>
                     <tr><td class="param-name">zone</td><td>string <span class="param-opt">optional</span></td><td>Restrict deletion to one zone</td></tr>
+                    <tr><td class="param-name">raceId</td><td>int <span class="param-opt">optional</span></td><td>Restrict deletion to a specific race ID</td></tr>
+                    <tr><td class="param-name">topic</td><td>string <span class="param-opt">optional</span></td><td>Restrict deletion to a specific topic string</td></tr>
                     <tr><td class="param-name">date</td><td>string <span class="param-opt">optional</span></td><td>Delete records for a single day <code>YYYYMMDD</code></td></tr>
                     <tr><td class="param-name">dateFrom</td><td>string <span class="param-opt">optional</span></td><td>Start of date range to delete, inclusive</td></tr>
                     <tr><td class="param-name">dateTo</td><td>string <span class="param-opt">optional</span></td><td>End of date range to delete, inclusive</td></tr>

--- a/_datafiles/html/admin/telemetry.html
+++ b/_datafiles/html/admin/telemetry.html
@@ -67,6 +67,8 @@
             <option value="mob_kill">mob_kill</option>
             <option value="player_death">player_death</option>
             <option value="item_purchase">item_purchase</option>
+            <option value="char_created">char_created</option>
+            <option value="help_topic">help_topic</option>
         </select>
     </div>
     <div class="filter-group">
@@ -86,6 +88,14 @@
         <input type="text" id="f-zone" placeholder="any">
     </div>
     <div class="filter-group">
+        <label>Race ID</label>
+        <input type="number" id="f-raceId" placeholder="any" min="0">
+    </div>
+    <div class="filter-group">
+        <label>Topic</label>
+        <input type="text" id="f-topic" placeholder="any">
+    </div>
+    <div class="filter-group">
         <label>Date From (YYYYMMDD)</label>
         <input type="text" id="f-dateFrom" placeholder="e.g. 20260101" maxlength="8">
     </div>
@@ -103,6 +113,8 @@
             <option value="room">Room</option>
             <option value="date">Date</option>
             <option value="category">Category</option>
+            <option value="race">Race</option>
+            <option value="topic">Topic</option>
         </select>
     </div>
     <div class="filter-group">
@@ -135,11 +147,13 @@
                 <th onclick="sortBy('mobid')">Mob</th>
                 <th onclick="sortBy('roomid')">Room</th>
                 <th onclick="sortBy('zone')">Zone</th>
+                <th onclick="sortBy('raceid')">Race ID</th>
+                <th onclick="sortBy('topic')">Topic</th>
                 <th onclick="sortBy('count')">Count</th>
             </tr>
         </thead>
         <tbody id="data-body">
-            <tr><td colspan="7" class="empty">Use the filters above and click Query to load data.</td></tr>
+            <tr><td colspan="9" class="empty">Use the filters above and click Query to load data.</td></tr>
         </tbody>
     </table>
 </div>
@@ -220,6 +234,8 @@ function buildParams() {
     const mobId    = document.getElementById('f-mobId').value;
     const roomId   = document.getElementById('f-roomId').value;
     const zone     = document.getElementById('f-zone').value;
+    const raceId   = document.getElementById('f-raceId').value;
+    const topic    = document.getElementById('f-topic').value;
     const dateFrom = document.getElementById('f-dateFrom').value;
     const dateTo   = document.getElementById('f-dateTo').value;
     const groupby  = document.getElementById('f-groupby').value;
@@ -230,6 +246,8 @@ function buildParams() {
     if (mobId)    p.set('mobId', mobId);
     if (roomId)   p.set('roomId', roomId);
     if (zone)     p.set('zone', zone);
+    if (raceId)   p.set('raceId', raceId);
+    if (topic)    p.set('topic', topic);
     if (dateFrom) p.set('dateFrom', dateFrom);
     if (dateTo)   p.set('dateTo', dateTo);
     if (groupby)  p.set('groupby', groupby);
@@ -277,7 +295,7 @@ function renderTable() {
     const summary = document.getElementById('summary');
 
     if (!currentData || currentData.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="7" class="empty">No records found.</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="9" class="empty">No records found.</td></tr>';
         summary.textContent = '';
         return;
     }
@@ -292,6 +310,8 @@ function renderTable() {
         <td>${mobCell(r.mobid)}</td>
         <td>${roomCell(r.roomid)}</td>
         <td>${zoneCell(r.zone)}</td>
+        <td>${r.raceid ? String(r.raceid) : ''}</td>
+        <td>${esc(r.topic || '')}</td>
         <td class="num">${(r.count || 0).toLocaleString()}</td>
     </tr>`).join('');
 }

--- a/_datafiles/html/admin/telemetry.html
+++ b/_datafiles/html/admin/telemetry.html
@@ -124,6 +124,16 @@
             <option value="asc">Count asc</option>
         </select>
     </div>
+    <div class="filter-group">
+        <label>Limit</label>
+        <select id="f-limit">
+            <option value="100">100</option>
+            <option value="250">250</option>
+            <option value="500">500</option>
+            <option value="1000">1000</option>
+            <option value="0">All</option>
+        </select>
+    </div>
     <div class="filter-group" style="justify-content: flex-end;">
         <label>&nbsp;</label>
         <button class="btn btn-primary" onclick="loadData()">Query</button>
@@ -240,6 +250,7 @@ function buildParams() {
     const dateTo   = document.getElementById('f-dateTo').value;
     const groupby  = document.getElementById('f-groupby').value;
     const sort     = document.getElementById('f-sort').value;
+    const limit    = document.getElementById('f-limit').value;
 
     if (cat)      p.set('category', cat);
     if (itemId)   p.set('itemId', itemId);
@@ -251,6 +262,7 @@ function buildParams() {
     if (dateFrom) p.set('dateFrom', dateFrom);
     if (dateTo)   p.set('dateTo', dateTo);
     if (groupby)  p.set('groupby', groupby);
+    if (limit && limit !== '0') p.set('limit', limit);
     p.set('sort', sort);
     return p;
 }
@@ -301,7 +313,9 @@ function renderTable() {
     }
 
     const total = currentData.reduce((s, r) => s + (r.count || 0), 0);
-    summary.textContent = currentData.length + ' records, ' + total.toLocaleString() + ' total count';
+    const limitVal = parseInt(document.getElementById('f-limit').value, 10);
+    const limitNote = (limitVal > 0 && currentData.length >= limitVal) ? ` (limit ${limitVal} reached)` : '';
+    summary.textContent = currentData.length + ' records, ' + total.toLocaleString() + ' total count' + limitNote;
 
     tbody.innerHTML = currentData.map(r => `<tr>
         <td>${fmtDate(r.date)}</td>

--- a/internal/telemetry/hooks.go
+++ b/internal/telemetry/hooks.go
@@ -93,7 +93,12 @@ func onPurchase(e events.Event) events.ListenerReturn {
 		return events.Continue
 	}
 
-	Track(CatItemPurchase, "", evt.ItemId, evt.SellerMobId, 0)
+	zone := ""
+	if r := rooms.LoadRoom(evt.RoomId); r != nil {
+		zone = r.Zone
+	}
+
+	Track(CatItemPurchase, zone, evt.ItemId, evt.SellerMobId, evt.RoomId)
 	return events.Continue
 }
 

--- a/internal/telemetry/query.go
+++ b/internal/telemetry/query.go
@@ -35,6 +35,7 @@ type QueryBuilder struct {
 	hasSort    bool
 	groupBy    GroupByField
 	hasGroupBy bool
+	limit      int // 0 means no limit
 }
 
 func (q *QueryBuilder) Category(c string) *QueryBuilder { q.category = c; return q }
@@ -44,6 +45,9 @@ func (q *QueryBuilder) MobId(id int) *QueryBuilder      { q.mobId = id; return q
 func (q *QueryBuilder) RoomId(id int) *QueryBuilder     { q.roomId = id; return q }
 func (q *QueryBuilder) RaceId(id int) *QueryBuilder     { q.raceId = id; return q }
 func (q *QueryBuilder) Topic(t string) *QueryBuilder    { q.topic = t; return q }
+
+// Limit caps the number of records returned by Results. Zero means no limit.
+func (q *QueryBuilder) Limit(n int) *QueryBuilder { q.limit = n; return q }
 
 // Date filters to an exact YYYYMMDD date.
 func (q *QueryBuilder) Date(d string) *QueryBuilder { q.dateFrom = d; q.dateTo = d; return q }
@@ -92,6 +96,10 @@ func (q *QueryBuilder) Results() []Record {
 			}
 			return out[i].Count < out[j].Count
 		})
+	}
+
+	if q.limit > 0 && len(out) > q.limit {
+		out = out[:q.limit]
 	}
 
 	return out

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -214,10 +214,10 @@ func TrackFull(category, zone string, itemId, mobId, roomId, raceId int, topic s
 // Clear removes all in-memory records matching the given filters and marks
 // the affected dates dirty so Save() will update or remove their files.
 // Pass empty/zero values to match any value for that field.
-func Clear(category, zone, date, dateTo string, itemId, mobId, roomId int) {
+func Clear(category, zone, date, dateTo string, itemId, mobId, roomId, raceId int, topic string) {
 	kept := make([]Record, 0, len(records))
 	for _, r := range records {
-		if matchesFilter(r, category, zone, date, dateTo, itemId, mobId, roomId, 0, "") {
+		if matchesFilter(r, category, zone, date, dateTo, itemId, mobId, roomId, raceId, topic) {
 			dirty[r.Date] = true
 			continue
 		}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,12 +41,13 @@ var (
 	records []Record
 	index   = map[string]int{}  // recordKey -> slice index
 	dirty   = map[string]bool{} // date -> needs save
-	dataDir string              // directory that holds per-date YAML files
+	dataDir string              // directory that holds per-date JSON files
 )
 
-// Load reads all YYYYMMDD.yaml files from <dataFilesPath>/telemetry/ and
-// rebuilds the in-memory index. Safe to call when the directory does not
-// exist yet.
+// Load reads all YYYYMMDD.json files from <dataFilesPath>/telemetry/ and
+// rebuilds the in-memory index. Any legacy YYYYMMDD.yaml files found are
+// migrated to JSON and then deleted. Safe to call when the directory does
+// not exist yet.
 func Load(dataFilesPath string) {
 	dataDir = util.FilePath(dataFilesPath, `/`, `telemetry`)
 
@@ -67,33 +69,63 @@ func Load(dataFilesPath string) {
 
 	fileCount := 0
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+		if e.IsDir() {
 			continue
 		}
 
-		data, err := util.ReadFile(filepath.Join(dataDir, e.Name()))
-		if err != nil {
-			mudlog.Error("telemetry.Load", "file", e.Name(), "error", err)
-			continue
-		}
+		name := e.Name()
+		path := filepath.Join(dataDir, name)
 
-		var loaded []Record
-		if err := yaml.Unmarshal(data, &loaded); err != nil {
-			mudlog.Error("telemetry.Load", "file", e.Name(), "error", err)
-			continue
-		}
+		switch {
+		case strings.HasSuffix(name, ".json"):
+			data, err := util.ReadFile(path)
+			if err != nil {
+				mudlog.Error("telemetry.Load", "file", name, "error", err)
+				continue
+			}
+			var loaded []Record
+			if err := json.Unmarshal(data, &loaded); err != nil {
+				mudlog.Error("telemetry.Load", "file", name, "error", err)
+				continue
+			}
+			for _, r := range loaded {
+				records = append(records, r)
+				index[recordKey(r.Date, r.Category, r.Zone, r.ItemId, r.MobId, r.RoomId, r.RaceId, r.Topic)] = len(records) - 1
+			}
+			fileCount++
 
-		for _, r := range loaded {
-			records = append(records, r)
-			index[recordKey(r.Date, r.Category, r.Zone, r.ItemId, r.MobId, r.RoomId, r.RaceId, r.Topic)] = len(records) - 1
+		case strings.HasSuffix(name, ".yaml"):
+			data, err := util.ReadFile(path)
+			if err != nil {
+				mudlog.Error("telemetry.Load", "file", name, "error", err)
+				continue
+			}
+			var loaded []Record
+			if err := yaml.Unmarshal(data, &loaded); err != nil {
+				mudlog.Error("telemetry.Load", "file", name, "error", err)
+				continue
+			}
+			jsonPath := strings.TrimSuffix(path, ".yaml") + ".json"
+			if err := writeJSONFile(jsonPath, loaded); err != nil {
+				mudlog.Error("telemetry.Load", "action", "migrate", "file", name, "error", err)
+				continue
+			}
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				mudlog.Error("telemetry.Load", "action", "remove-yaml", "file", name, "error", err)
+			}
+			mudlog.Info("telemetry.Load", "action", "migrated", "from", name, "to", filepath.Base(jsonPath))
+			for _, r := range loaded {
+				records = append(records, r)
+				index[recordKey(r.Date, r.Category, r.Zone, r.ItemId, r.MobId, r.RoomId, r.RaceId, r.Topic)] = len(records) - 1
+			}
+			fileCount++
 		}
-		fileCount++
 	}
 
 	mudlog.Info("telemetry.Load", "files", fileCount, "records", len(records))
 }
 
-// Save writes one YAML file per dirty date to the telemetry directory.
+// Save writes one JSON file per dirty date to the telemetry directory.
 // Dates whose records were all cleared have their file deleted.
 // Clean dates are not touched.
 func Save() error {
@@ -123,7 +155,7 @@ func Save() error {
 	}
 
 	for date := range dirty {
-		path := filepath.Join(dataDir, date+".yaml")
+		path := filepath.Join(dataDir, date+".json")
 		recs := byDate[date]
 
 		if len(recs) == 0 {
@@ -134,13 +166,7 @@ func Save() error {
 			continue
 		}
 
-		data, err := yaml.Marshal(recs)
-		if err != nil {
-			mudlog.Error("telemetry.Save", "action", "marshal", "date", date, "error", err)
-			return fmt.Errorf("telemetry.Save marshal %s: %w", date, err)
-		}
-
-		if err := util.WriteFile(path, data, 0644); err != nil {
+		if err := writeJSONFile(path, recs); err != nil {
 			mudlog.Error("telemetry.Save", "action", "write", "file", path, "error", err)
 			return fmt.Errorf("telemetry.Save write %s: %w", date, err)
 		}
@@ -209,6 +235,14 @@ func Query() *QueryBuilder {
 // Len returns the total number of records currently in memory.
 func Len() int {
 	return len(records)
+}
+
+func writeJSONFile(path string, recs []Record) error {
+	data, err := json.Marshal(recs)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return util.WriteFile(path, data, 0644)
 }
 
 func rebuildIndex() {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -191,7 +191,7 @@ func TestClear(t *testing.T) {
 	Track(CatItemDrop, "frostfang", 5, 1, 10)
 	Track(CatMobKill, "dungeon", 0, 2, 20)
 
-	Clear(CatMobKill, "frostfang", "", "", 0, 0, 0)
+	Clear(CatMobKill, "frostfang", "", "", 0, 0, 0, 0, "")
 
 	results := Query().Category(CatMobKill).Results()
 	assert.Len(t, results, 1)
@@ -254,7 +254,7 @@ func TestSave_DeletesFileWhenDateCleared(t *testing.T) {
 	require.NoError(t, Save())
 
 	// Clear only the first date.
-	Clear("", "", "20260101", "20260101", 0, 0, 0)
+	Clear("", "", "20260101", "20260101", 0, 0, 0, 0, "")
 	require.NoError(t, Save())
 
 	assert.NoFileExists(t, filepath.Join(dataDir, "20260101.json"))

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -219,8 +219,8 @@ func TestSaveLoad_RoundTrip(t *testing.T) {
 	require.NoError(t, Save())
 
 	// Verify two separate files were written.
-	assert.FileExists(t, filepath.Join(dataDir, "20260101.yaml"))
-	assert.FileExists(t, filepath.Join(dataDir, "20260102.yaml"))
+	assert.FileExists(t, filepath.Join(dataDir, "20260101.json"))
+	assert.FileExists(t, filepath.Join(dataDir, "20260102.json"))
 
 	// Reload from directory.
 	resetState()
@@ -257,8 +257,8 @@ func TestSave_DeletesFileWhenDateCleared(t *testing.T) {
 	Clear("", "", "20260101", "20260101", 0, 0, 0)
 	require.NoError(t, Save())
 
-	assert.NoFileExists(t, filepath.Join(dataDir, "20260101.yaml"))
-	assert.FileExists(t, filepath.Join(dataDir, "20260102.yaml"))
+	assert.NoFileExists(t, filepath.Join(dataDir, "20260101.json"))
+	assert.FileExists(t, filepath.Join(dataDir, "20260102.json"))
 }
 
 func TestLoad_EmptyDirectory(t *testing.T) {

--- a/internal/usercommands/admin.telemetry.go
+++ b/internal/usercommands/admin.telemetry.go
@@ -54,7 +54,7 @@ func Telemetry(rest string, user *users.UserRecord, room *rooms.Room, flags even
 				date = strings.TrimPrefix(arg, "date=")
 			}
 		}
-		telemetry.Clear(category, "", date, "", 0, 0, 0)
+		telemetry.Clear(category, "", date, "", 0, 0, 0, 0, "")
 		user.SendText(`Telemetry records cleared.`)
 		return true, nil
 

--- a/internal/web/admin_telemetry.go
+++ b/internal/web/admin_telemetry.go
@@ -52,6 +52,14 @@ func apiV1GetTelemetry(w http.ResponseWriter, r *http.Request) {
 			qb = qb.RoomId(id)
 		}
 	}
+	if v := q.Get("raceId"); v != "" {
+		if id, err := strconv.Atoi(v); err == nil {
+			qb = qb.RaceId(id)
+		}
+	}
+	if v := q.Get("topic"); v != "" {
+		qb = qb.Topic(v)
+	}
 
 	switch q.Get("groupby") {
 	case "mob", "mobid":
@@ -66,6 +74,10 @@ func apiV1GetTelemetry(w http.ResponseWriter, r *http.Request) {
 		qb = qb.GroupBy(telemetry.GroupByDate)
 	case "category":
 		qb = qb.GroupBy(telemetry.GroupByCategory)
+	case "race", "raceid":
+		qb = qb.GroupBy(telemetry.GroupByRaceId)
+	case "topic":
+		qb = qb.GroupBy(telemetry.GroupByTopic)
 	}
 
 	if q.Get("sort") == "asc" {

--- a/internal/web/admin_telemetry.go
+++ b/internal/web/admin_telemetry.go
@@ -16,7 +16,9 @@ func adminTelemetryAPI(w http.ResponseWriter, r *http.Request) {
 }
 
 // GET /admin/api/v1/telemetry
-// Query params: category, itemId, mobId, roomId, zone, date, dateFrom, dateTo, groupby (mob|item|zone|room|date|category), sort (asc|desc)
+// Query params: category, itemId, mobId, roomId, zone, raceId, topic, date, dateFrom, dateTo,
+//
+//	groupby (mob|item|zone|room|date|category|race|topic), sort (asc|desc), limit (int)
 func apiV1GetTelemetry(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
@@ -86,6 +88,12 @@ func apiV1GetTelemetry(w http.ResponseWriter, r *http.Request) {
 		qb = qb.SortDesc()
 	}
 
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			qb = qb.Limit(n)
+		}
+	}
+
 	results := qb.Results()
 	if results == nil {
 		results = []telemetry.Record{}
@@ -98,7 +106,7 @@ func apiV1GetTelemetry(w http.ResponseWriter, r *http.Request) {
 }
 
 // DELETE /admin/api/v1/telemetry
-// Query params: category, zone, date, dateFrom, dateTo (all optional - omit to clear all)
+// Query params: category, zone, raceId, topic, date, dateFrom, dateTo (all optional - omit to clear all)
 func apiV1DeleteTelemetry(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
@@ -116,7 +124,15 @@ func apiV1DeleteTelemetry(w http.ResponseWriter, r *http.Request) {
 		date = v
 	}
 
-	telemetry.Clear(category, zone, date, dateTo, 0, 0, 0)
+	var raceId int
+	if v := q.Get("raceId"); v != "" {
+		if id, err := strconv.Atoi(v); err == nil {
+			raceId = id
+		}
+	}
+	topic := q.Get("topic")
+
+	telemetry.Clear(category, zone, date, dateTo, 0, 0, 0, raceId, topic)
 
 	if err := telemetry.Save(); err != nil {
 		writeAPIError(w, http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
# Description

Improves the telemetry package's storage format, data correctness, query capabilities, and admin tooling.

## Changes

- **JSON storage migration** — telemetry records are now stored as `YYYYMMDD.json` files instead of YAML. On load, any existing `.yaml` files are automatically parsed, written out as JSON, and deleted.
- **`char_created` and `help_topic` categories** — added missing categories to the admin UI category dropdown, filter inputs for `raceId` and `topic`, corresponding table columns, and `race`/`topic` group-by options.
- **`Clear` signature fix** — `Clear()` now accepts `raceId` and `topic` parameters and passes them through to the filter, allowing surgical deletion of `char_created` and `help_topic` records by their key dimensions.
- **DELETE endpoint fix** — `apiV1DeleteTelemetry` now reads and forwards `raceId` and `topic` query params to `Clear`.
- **`onPurchase` zone fix** — the purchase event hook now resolves zone from `RoomId` (consistent with the mob-kill and player-death hooks) and records `RoomId` instead of `0`.
- **Result limiting** — `QueryBuilder` gains a `Limit(n)` method; the GET API accepts a `limit` param; the admin UI adds a limit dropdown (100 / 250 / 500 / 1000 / All) with a summary note when the limit is reached.
- **API reference updated** — `telemetry-api.html` now documents all seven categories, `raceId`, `topic`, and `limit` GET params, the full `groupby` value set, and `raceId`/`topic` DELETE params.
