### PR TITLE
Panel layout additions, stability

### DIFF
--- a/_datafiles/guides/building/scripting/FUNCTIONS_PANELS.md
+++ b/_datafiles/guides/building/scripting/FUNCTIONS_PANELS.md
@@ -72,11 +72,21 @@ Layout
 
 `charset` selects the box-drawing characters used for all panel borders.
 
-| Value | Example top border | Corners |
-| --- | --- | --- |
-| `"single"` (default) | `┌─ Title ───┐` | `┌ ┐ └ ┘` |
-| `"double"` | `╔═ Title ═══╗` | `╔ ╗ ╚ ╝` |
-| `"rounded"` | `╭─ Title ───╮` | `╭ ╮ ╰ ╯` |
+| Value | Top-left | Horizontal-top | Top-right | Vertical-left | Vertical-right | Bottom-left | Horizontal-bottom | Bottom-right |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `"single"` (default) | `┌` | `─` | `┐` | `│` | `│` | `└` | `─` | `┘` |
+| `"double"` | `╔` | `═` | `╗` | `║` | `║` | `╚` | `═` | `╝` |
+| `"rounded"` | `╭` | `─` | `╮` | `│` | `│` | `╰` | `─` | `╯` |
+
+An **8-character literal** can be used instead of a named preset. The characters
+are read in order: TopLeft, HorizontalTop, TopRight, VerticalLeft, VerticalRight,
+BottomLeft, HorizontalBottom, BottomRight. This allows asymmetric left/right and
+top/bottom borders:
+
+```javascript
+// Double top, single bottom, double left, single right
+var layout = PanelLayoutNew({ charset: "╔═╗║│╚─┘" });
+```
 
 ### Titles
 
@@ -140,7 +150,7 @@ Creates a blank panel layout entirely in script, with no YAML file required.
 | Property | Type | Default | Explanation |
 | --- | --- | --- | --- |
 | `border` | string | `"full"` | `"full"` or `"open"` — see [Border styles](#border-styles) |
-| `charset` | string | `"single"` | `"single"`, `"double"`, or `"rounded"` — see [Character sets](#character-sets) |
+| `charset` | string | `"single"` | `"single"`, `"double"`, `"rounded"`, or an 8-character literal — see [Character sets](#character-sets) |
 | `gap` | int | `1` | Spaces between panels placed side by side, and between slots |
 | `margin` | int | `0` | Spaces prepended to every output line |
 
@@ -218,11 +228,14 @@ Returns the panel for chaining.
 
 | Argument | Explanation |
 | --- | --- |
-| name | `"single"`, `"double"`, or `"rounded"`. An unrecognised value falls back to `"single"`. |
+| name | `"single"`, `"double"`, `"rounded"`, or an 8-character literal (TopLeft, HorizontalTop, TopRight, VerticalLeft, VerticalRight, BottomLeft, HorizontalBottom, BottomRight). An unrecognised value falls back to `"single"`. |
 
 ```javascript
 // Give one panel a double border while the rest use the layout default
 layout.Panel("highlight").SetCharset("double");
+
+// Asymmetric: double top/left, single bottom/right
+layout.Panel("custom").SetCharset("╔═╗║│╚─┘");
 ```
 
 ---

--- a/_datafiles/html/admin/panels-api.html
+++ b/_datafiles/html/admin/panels-api.html
@@ -1,0 +1,262 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 2rem; font-size: 0.9rem; }
+    .api-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .api-entry { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; }
+    .api-entry summary { display: flex; align-items: baseline; gap: 0.75rem; padding: 0.65rem 1rem; cursor: pointer; user-select: none; list-style: none; }
+    .api-entry summary::-webkit-details-marker { display: none; }
+    .api-entry summary::before { content: "\25B6"; font-size: 0.65rem; color: var(--color-text-faint); transition: transform 0.15s; flex-shrink: 0; }
+    .api-entry[open] summary::before { transform: rotate(90deg); }
+    .api-entry summary:hover { background: var(--color-surface-alt); }
+    .method { font-family: monospace; font-size: 0.8rem; font-weight: 700; padding: 0.15rem 0.45rem; border-radius: 3px; flex-shrink: 0; }
+    .method-get    { background: var(--color-success-bg); color: var(--color-success-text); }
+    .method-post   { background: var(--color-info-bg); color: var(--color-info-text); }
+    .method-put    { background: var(--color-method-put-bg); color: var(--color-method-put-text); }
+    .api-path { font-family: monospace; font-size: 0.9rem; color: var(--color-primary); }
+    .api-desc { font-size: 0.85rem; color: var(--color-text-muted); margin-left: auto; text-align: right; }
+    .api-body { padding: 0.75rem 1rem 1rem; border-top: 1px solid var(--color-border-light); background: var(--color-surface-alt); }
+    .api-body p { font-size: 0.85rem; color: var(--color-text-tertiary); margin-bottom: 0.5rem; }
+    .curl-block { background: var(--color-code-bg); color: var(--color-code-text); font-family: monospace; font-size: 0.82rem; padding: 0.85rem 1rem; border-radius: 5px; white-space: pre; overflow-x: auto; line-height: 1.6; margin-bottom: 0.5rem; }
+    .curl-block .kw   { color: var(--color-api-kw); }
+    .curl-block .str  { color: var(--color-api-str); }
+    .curl-block .flag { color: var(--color-api-flag); }
+    .response-examples { margin-top: 1rem; display: flex; flex-direction: column; gap: 0.4rem; }
+    .resp-entry { border: 1px solid var(--color-border); border-radius: 4px; overflow: hidden; }
+    .resp-entry summary { display: flex; align-items: baseline; gap: 0.6rem; padding: 0.45rem 0.75rem; cursor: pointer; user-select: none; list-style: none; background: var(--color-page-bg); font-size: 0.82rem; }
+    .resp-entry summary::-webkit-details-marker { display: none; }
+    .resp-entry summary::before { content: "\25B6"; font-size: 0.6rem; color: var(--color-text-faint); transition: transform 0.15s; flex-shrink: 0; }
+    .resp-entry[open] summary::before { transform: rotate(90deg); }
+    .resp-entry summary:hover { background: var(--color-api-summary-hover); }
+    .resp-body { padding: 0.6rem 0.75rem 0.75rem; border-top: 1px solid var(--color-border-light); background: var(--color-surface-alt); }
+    .resp-body p { font-size: 0.82rem; color: var(--color-text-tertiary); margin-bottom: 0.4rem; }
+    .status-ok  { background: var(--color-success-bg); color: var(--color-success-text); }
+    .status-err { background: var(--color-error-bg); color: var(--color-error-text); }
+    .resp-label { font-size: 0.8rem; color: var(--color-text-tertiary); }
+</style>
+
+<h1>Panel Layouts API Reference</h1>
+<p class="subtitle">REST endpoints for reading, validating, previewing, and saving panel layout YAML files.</p>
+
+<h2 style="font-size:1.1rem;margin-bottom:0.5rem;margin-top:0">YAML Format Reference</h2>
+<div style="background:var(--color-surface-white);border:1px solid var(--color-border);border-radius:6px;padding:1.25rem 1.5rem;margin-bottom:2rem;font-size:0.875rem;line-height:1.7">
+
+    <p style="margin-bottom:1rem;color:var(--color-text-tertiary)">A panel layout file is a YAML document that describes how a set of bordered panels are arranged on screen. The file is loaded by Go code which then populates each panel with rows of data before rendering.</p>
+
+    <h3 style="font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--color-text-subtle);border-bottom:1px solid var(--color-border-light);padding-bottom:0.3rem;margin-bottom:0.75rem">Top-level fields</h3>
+    <table style="width:100%;border-collapse:collapse;font-size:0.85rem;margin-bottom:1.25rem">
+        <thead><tr style="border-bottom:1px solid var(--color-border-light)">
+            <th style="text-align:left;padding:0.3rem 0.6rem 0.3rem 0;color:var(--color-text-muted);font-weight:600;white-space:nowrap">Field</th>
+            <th style="text-align:left;padding:0.3rem 0.6rem;color:var(--color-text-muted);font-weight:600">Values / Notes</th>
+        </tr></thead>
+        <tbody>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>border</code></td>
+            <td style="padding:0.4rem 0.6rem">
+                <code>"full"</code> &mdash; every content row has side borders &nbsp;<code>│ label&nbsp;&nbsp;value │</code><br>
+                <code>"open"</code> &mdash; only the first and last content rows have side borders<br>
+                <em style="color:var(--color-text-faint)">Default: <code>"full"</code></em>
+            </td>
+        </tr>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>charset</code></td>
+            <td style="padding:0.4rem 0.6rem">
+                <code>"single"</code> &mdash; <code>┌─┐ │ └─┘</code> &nbsp;<em style="color:var(--color-text-faint)">(default)</em><br>
+                <code>"double"</code> &mdash; <code>╔═╗ ║ ╚═╝</code><br>
+                <code>"rounded"</code> &mdash; <code>╭─╮ │ ╰─╯</code><br>
+                8-rune literal in the order: <code>TopLeft HorizTop TopRight VertLeft VertRight BottomLeft HorizBottom BottomRight</code><br>
+                Example: <code>"╔═╗║║╚═╝"</code>
+            </td>
+        </tr>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>gap</code></td>
+            <td style="padding:0.4rem 0.6rem">Number of spaces between panels placed side by side and between top-level slots.</td>
+        </tr>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>margin</code></td>
+            <td style="padding:0.4rem 0.6rem">Spaces prepended to every output line. Optional, default <code>0</code>.</td>
+        </tr>
+        <tr>
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>default_color</code></td>
+            <td style="padding:0.4rem 0.6rem">
+                Optional ANSI <code>fg</code> color that wraps the entire rendered output in a single <code>&lt;ansi&gt;</code> tag.<br>
+                Accepts a numeric 256-color code (e.g. <code>"214"</code>) or a named alias (e.g. <code>"gold"</code>).<br>
+                Omit or leave blank to disable.
+            </td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3 style="font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--color-text-subtle);border-bottom:1px solid var(--color-border-light);padding-bottom:0.3rem;margin-bottom:0.75rem">Layout model</h3>
+    <p style="margin-bottom:0.5rem;color:var(--color-text-tertiary)">Panels are arranged in a three-level hierarchy:</p>
+    <ul style="margin:0 0 1.25rem 1.25rem;color:var(--color-text-tertiary)">
+        <li><strong>slots</strong> &mdash; top-level horizontal columns, rendered side by side</li>
+        <li><strong>rows</strong> &mdash; within a slot, panel groups stacked vertically top-to-bottom</li>
+        <li><strong>panels</strong> &mdash; within a row, individual panels placed side by side left-to-right</li>
+    </ul>
+
+    <h3 style="font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--color-text-subtle);border-bottom:1px solid var(--color-border-light);padding-bottom:0.3rem;margin-bottom:0.75rem">Per-panel fields</h3>
+    <table style="width:100%;border-collapse:collapse;font-size:0.85rem;margin-bottom:1.25rem">
+        <thead><tr style="border-bottom:1px solid var(--color-border-light)">
+            <th style="text-align:left;padding:0.3rem 0.6rem 0.3rem 0;color:var(--color-text-muted);font-weight:600;white-space:nowrap">Field</th>
+            <th style="text-align:left;padding:0.3rem 0.6rem;color:var(--color-text-muted);font-weight:600">Values / Notes</th>
+        </tr></thead>
+        <tbody>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>id</code></td>
+            <td style="padding:0.4rem 0.6rem">Unique string identifier. Used in Go code: <code>layout.Panel("id").Add(...)</code>. Required.</td>
+        </tr>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>title</code></td>
+            <td style="padding:0.4rem 0.6rem">Rendered verbatim into the top border. May contain ANSI tags &mdash; visual width is measured with tags stripped. Omit for a plain border line with no title gap.</td>
+        </tr>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>min_width</code></td>
+            <td style="padding:0.4rem 0.6rem">Minimum inner content width in characters. Expands automatically if content is wider. Total panel width = <code>min_width + 4</code> (two border chars + two padding spaces).</td>
+        </tr>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>columns</code></td>
+            <td style="padding:0.4rem 0.6rem">Number of label+value pairs rendered per line. Optional, default <code>1</code>.</td>
+        </tr>
+        <tr style="border-bottom:1px solid var(--color-border-faint)">
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>column_gap</code></td>
+            <td style="padding:0.4rem 0.6rem">Spaces between columns when <code>columns &gt; 1</code>. Optional, default <code>2</code>.</td>
+        </tr>
+        <tr>
+            <td style="padding:0.4rem 0.6rem 0.4rem 0;white-space:nowrap"><code>charset</code></td>
+            <td style="padding:0.4rem 0.6rem">Per-panel charset override. Accepts the same values as the top-level <code>charset</code>. Falls back to the top-level charset when omitted.</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3 style="font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--color-text-subtle);border-bottom:1px solid var(--color-border-light);padding-bottom:0.3rem;margin-bottom:0.75rem">Minimal example</h3>
+    <pre style="background:var(--color-code-bg);color:var(--color-code-text);font-family:monospace;font-size:0.82rem;padding:0.85rem 1rem;border-radius:5px;overflow-x:auto;line-height:1.6;margin:0">border: open
+charset: single
+gap: 1
+margin: 1
+
+slots:
+  - rows:
+      - panels:
+          - id: info
+            title: ' Info '
+            min_width: 30
+  - rows:
+      - panels:
+          - id: stats
+            title: ' Stats '
+            min_width: 40
+            columns: 2
+            column_gap: 2</pre>
+
+</div>
+
+<div class="api-list">
+
+    <!-- GET /admin/api/v1/panels -->
+    <details class="api-entry">
+        <summary>
+            <span class="method method-get">GET</span>
+            <span class="api-path">/admin/api/v1/panels</span>
+            <span class="api-desc">Return all panel layout files</span>
+        </summary>
+        <div class="api-body">
+            <p>Returns an array of every panel layout file found under the <code>panel-layouts/</code> data directory. Each entry includes the relative <code>name</code> (e.g. <code>character/status</code>) and the raw <code>yaml</code> content.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/panels</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":[{"name":"character/status","yaml":"border: open\ncharset: single\n..."}]}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <!-- POST /admin/api/v1/panels/validate -->
+    <details class="api-entry">
+        <summary>
+            <span class="method method-post">POST</span>
+            <span class="api-path">/admin/api/v1/panels/validate</span>
+            <span class="api-desc">Validate a panel layout YAML</span>
+        </summary>
+        <div class="api-body">
+            <p>Parses the supplied YAML and checks for structural problems: unknown border or charset values, missing or duplicate panel IDs, empty slots or rows, and negative numeric fields. Returns <code>valid: true</code> and an empty <code>issues</code> array when the layout is clean.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> <span class="flag">-X</span> POST \
+     <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
+     <span class="flag">-d</span> <span class="str">'{"yaml":"border: open\ncharset: single\ngap: 1\nslots:\n  - rows:\n      - panels:\n          - id: info\n            title: Info\n            min_width: 25\n"}'</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/panels/validate</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Valid layout</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"valid":true,"issues":[]}}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Invalid layout (issues found)</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"valid":false,"issues":[{"message":"slot 1, row 1, panel 1: missing id"},{"message":"unknown border style \"fancy\" (valid: \"full\", \"open\")"}]}}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">YAML parse error</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"invalid YAML: yaml: line 3: ..."}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <!-- POST /admin/api/v1/panels/preview -->
+    <details class="api-entry">
+        <summary>
+            <span class="method method-post">POST</span>
+            <span class="api-path">/admin/api/v1/panels/preview</span>
+            <span class="api-desc">Render a plain-text preview of a panel layout</span>
+        </summary>
+        <div class="api-body">
+            <p>Parses the supplied YAML, fills every panel with dummy rows, and returns the rendered plain-text output. ANSI tags in titles are stripped so the result is safe to display in a browser. Sole panels in a row receive 4 dummy rows; panels with horizontal siblings receive 2.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> <span class="flag">-X</span> POST \
+     <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
+     <span class="flag">-d</span> <span class="str">'{"yaml":"border: open\ncharset: single\ngap: 1\nslots:\n  - rows:\n      - panels:\n          - id: info\n            title: Info\n            min_width: 25\n"}'</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/panels/preview</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"preview":"┌─ Info ───────────────────┐\n│ label-1 value-1          │\n..."}}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">YAML parse error</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"preview panel layout: yaml: ..."}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <!-- PUT /admin/api/v1/panels/{name} -->
+    <details class="api-entry">
+        <summary>
+            <span class="method method-put">PUT</span>
+            <span class="api-path">/admin/api/v1/panels/{name}</span>
+            <span class="api-desc">Overwrite an existing panel layout file</span>
+        </summary>
+        <div class="api-body">
+            <p>Overwrites the panel layout file identified by <code>{name}</code> (e.g. <code>character/status</code>). The file must already exist; this endpoint does not create new layout files. The YAML is validated for parse errors before writing.</p>
+            <p>Encode slashes in the name as <code>%2F</code> or pass the full path directly &mdash; the route uses a wildcard catch-all so nested paths are preserved.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> <span class="flag">-X</span> PUT \
+     <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
+     <span class="flag">-d</span> <span class="str">'{"yaml":"border: open\ncharset: single\n..."}'</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/panels/character/status</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">File not found or invalid YAML</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"panel layout \"character/status\": stat ...: no such file or directory"}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+</div>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/panels.html
+++ b/_datafiles/html/admin/panels.html
@@ -1,0 +1,601 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .page-layout { display: grid; grid-template-columns: 240px 1fr; gap: 1.25rem; align-items: start; }
+    @media (max-width: 900px) { .page-layout { grid-template-columns: 1fr; } }
+
+    .sidebar { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; display: flex; flex-direction: column; }
+    .sidebar-header { padding: 0.6rem 0.9rem; border-bottom: 1px solid var(--color-border-light); }
+    .sidebar-header input[type="search"] { width: 100%; }
+    .panel-list { overflow-y: auto; max-height: 80vh; }
+    .panel-group-label {
+        padding: 0.35rem 0.9rem 0.2rem;
+        font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 0.07em; color: var(--color-text-faint);
+        background: var(--color-page-bg);
+        border-bottom: 1px solid var(--color-border-faint);
+        position: sticky; top: 0;
+    }
+    .panel-row {
+        padding: 0.45rem 0.9rem 0.45rem 1.2rem; cursor: pointer;
+        border-bottom: 1px solid var(--color-border-faint);
+        font-size: 0.875rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .panel-row:last-child { border-bottom: none; }
+    .panel-row:hover { background: var(--color-row-hover); }
+    .panel-row.active { background: var(--color-primary); color: var(--color-surface-white); }
+    .no-panels { padding: 1.5rem; text-align: center; color: var(--color-text-faint); font-size: 0.85rem; }
+
+    .editor-panel { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem; }
+    .editor-placeholder { color: var(--color-text-placeholder); text-align: center; padding: 4rem 1rem; font-size: 0.9rem; }
+
+    .status-bar { display: none; padding: 0.55rem 0.9rem; border-radius: 4px; font-size: 0.85rem; margin-bottom: 1rem; }
+    .status-bar.success { background: var(--color-success-bg); color: var(--color-success-text); display: block; }
+    .status-bar.error   { background: var(--color-error-bg); color: var(--color-error-text); display: block; }
+
+    .section-title {
+        font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+        color: var(--color-text-subtle); padding: 0.5rem 0 0.4rem;
+        border-bottom: 1px solid var(--color-border-light); margin-bottom: 0.75rem;
+        display: flex; align-items: center; justify-content: space-between;
+    }
+    .section-title-name { flex: 1; }
+
+    /* Preview area */
+    .preview-tabs { display: flex; gap: 0; margin-bottom: 0; border-bottom: 1px solid var(--color-border-medium); }
+    .preview-tab {
+        padding: 0.35rem 0.85rem; font-size: 0.8rem; font-weight: 600; cursor: pointer;
+        border: 1px solid transparent; border-bottom: none; border-radius: 4px 4px 0 0;
+        background: none; color: var(--color-text-muted); margin-bottom: -1px;
+        position: relative;
+    }
+    .preview-tab:hover { color: var(--color-text); background: var(--color-page-bg); }
+    .preview-tab.active {
+        background: var(--color-surface-white); color: var(--color-primary);
+        border-color: var(--color-border-medium); border-bottom-color: var(--color-surface-white);
+        z-index: 1;
+    }
+    .preview-box {
+        font-family: 'Courier New', Courier, monospace; font-size: 0.85rem;
+        white-space: pre; overflow-x: auto;
+        background: #111; color: #ccc;
+        border: 1px solid var(--color-border-medium); border-top: none;
+        border-radius: 0 0 4px 4px;
+        padding: 0.75rem 1rem;
+        min-height: 4rem;
+        margin-bottom: 1rem;
+        line-height: 1.4;
+    }
+    .preview-placeholder { color: var(--color-text-faint); font-style: italic; font-family: inherit; font-size: 0.85rem; }
+    .preview-ruler { color: #555; }
+
+    /* YAML editor */
+    .yaml-editor {
+        width: 100%; min-height: 480px;
+        font-family: 'Courier New', Courier, monospace; font-size: 0.82rem;
+        padding: 0.6rem 0.75rem;
+        border: 1px solid var(--color-border-medium); border-radius: 4px;
+        background: var(--color-surface-white); color: var(--color-text);
+        resize: vertical; tab-size: 2;
+        box-sizing: border-box;
+    }
+    .yaml-editor:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; border-color: transparent; }
+
+    .btn-row { display: flex; gap: 0.6rem; margin-top: 1rem; flex-wrap: wrap; align-items: center; }
+    .validation-errors {
+        margin-top: 0.6rem;
+        padding: 0.6rem 0.85rem;
+        background: var(--color-error-bg);
+        color: var(--color-error-text);
+        border: 1px solid var(--color-btn-delete-border);
+        border-radius: 4px;
+        font-size: 0.82rem;
+    }
+    .validation-errors ul { margin: 0.35rem 0 0 1.1rem; padding: 0; }
+    .validation-errors li { margin-bottom: 0.2rem; }
+    .validation-errors strong { display: block; margin-bottom: 0.2rem; }
+
+    /* Help modal */
+    .help-btn {
+        background: none; border: 1px solid var(--color-border-medium); border-radius: 50%;
+        width: 1.4rem; height: 1.4rem; font-size: 0.75rem; font-weight: 700;
+        color: var(--color-text-muted); cursor: pointer; line-height: 1;
+        display: inline-flex; align-items: center; justify-content: center;
+        flex-shrink: 0;
+    }
+    .help-btn:hover { background: var(--color-page-bg); color: var(--color-primary); border-color: var(--color-primary); }
+    .help-overlay {
+        display: none; position: fixed; inset: 0;
+        background: rgba(0,0,0,0.45);
+        align-items: center; justify-content: center; z-index: 9999;
+    }
+    .help-overlay.open { display: flex; }
+    .help-modal {
+        background: var(--color-surface-white); border-radius: 8px;
+        box-shadow: 0 8px 40px var(--color-shadow);
+        width: 680px; max-width: 96vw; max-height: 88vh;
+        display: flex; flex-direction: column; overflow: hidden;
+    }
+    .help-modal-header {
+        padding: 0.85rem 1.1rem 0.7rem; border-bottom: 1px solid var(--color-border);
+        display: flex; align-items: center; justify-content: space-between; flex-shrink: 0;
+    }
+    .help-modal-title { font-size: 1rem; font-weight: 700; color: var(--color-primary); }
+    .help-modal-close { background: none; border: none; font-size: 1.3rem; cursor: pointer; color: var(--color-text-faint); line-height: 1; }
+    .help-modal-close:hover { color: var(--color-text); }
+    .help-modal-body { overflow-y: auto; padding: 1rem 1.25rem 1.25rem; flex: 1; font-size: 0.875rem; line-height: 1.7; }
+    .help-modal-body h3 {
+        font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+        color: var(--color-text-subtle); border-bottom: 1px solid var(--color-border-light);
+        padding-bottom: 0.3rem; margin: 1rem 0 0.6rem;
+    }
+    .help-modal-body h3:first-child { margin-top: 0; }
+    .help-modal-body table { width: 100%; border-collapse: collapse; margin-bottom: 0.75rem; }
+    .help-modal-body th {
+        text-align: left; padding: 0.25rem 0.5rem 0.25rem 0;
+        color: var(--color-text-muted); font-weight: 600; font-size: 0.8rem;
+        border-bottom: 1px solid var(--color-border-light);
+    }
+    .help-modal-body td { padding: 0.35rem 0.5rem 0.35rem 0; border-bottom: 1px solid var(--color-border-faint); vertical-align: top; }
+    .help-modal-body td:first-child { white-space: nowrap; }
+    .help-modal-body td em { color: var(--color-text-faint); font-style: italic; }
+    .help-modal-body ul { margin: 0 0 0.75rem 1.1rem; color: var(--color-text-tertiary); }
+    .help-modal-body pre {
+        background: var(--color-code-bg); color: var(--color-code-text);
+        font-family: monospace; font-size: 0.8rem; padding: 0.75rem 0.9rem;
+        border-radius: 4px; overflow-x: auto; line-height: 1.55; margin: 0;
+    }
+        padding: 0.45rem 1.2rem; background: var(--color-primary);
+        color: var(--color-surface-white); border: none; border-radius: 4px;
+        font-size: 0.875rem; font-weight: 600; cursor: pointer;
+    }
+    .btn-save:hover { background: var(--color-primary-hover); }
+    .btn-save:disabled { opacity: 0.5; cursor: default; }
+    .btn-preview {
+        padding: 0.45rem 1.1rem; background: var(--color-surface-white);
+        color: var(--color-primary); border: 1px solid var(--color-primary);
+        border-radius: 4px; font-size: 0.875rem; font-weight: 600; cursor: pointer;
+    }
+    .btn-preview:hover { background: var(--color-page-bg); }
+    .btn-reset {
+        padding: 0.45rem 1rem; background: var(--color-surface-white);
+        color: var(--color-text-muted); border: 1px solid var(--color-border-medium);
+        border-radius: 4px; font-size: 0.875rem; cursor: pointer;
+    }
+    .btn-reset:hover { background: var(--color-page-bg); }
+
+    .dirty-indicator {
+        font-size: 0.75rem; color: var(--color-text-faint);
+        font-style: italic; margin-left: auto;
+    }
+    .dirty-indicator.dirty { color: var(--color-warning-text, #b45309); }
+</style>
+
+<h1>Panel Layouts</h1>
+<p class="subtitle">View and edit panel layout YAML files. Preview renders dummy data to show the structure.</p>
+
+<div class="page-layout">
+    <div class="sidebar">
+        <div class="sidebar-header">
+            <input type="search" id="panelSearch" placeholder="Search panels..." oninput="filterPanels()" />
+        </div>
+        <div id="panelList" class="panel-list">
+            <div class="no-panels">Loading...</div>
+        </div>
+    </div>
+
+    <div class="editor-panel">
+        <div id="editorPlaceholder" class="editor-placeholder">Select a panel layout from the list to edit it.</div>
+        <div id="editorForm" style="display:none">
+            <div id="statusBar" class="status-bar"></div>
+
+            <div class="section-title">
+                <span class="section-title-name" id="editorTitle"></span>
+            </div>
+
+            <div id="previewContainer">
+                <div class="preview-tabs">
+                    <button class="preview-tab active" id="tabPlain" onclick="switchTab('plain')">Plain text</button>
+                    <button class="preview-tab" id="tabAnsi" onclick="switchTab('ansi')">ANSI colors</button>
+                </div>
+                <div id="previewBox" class="preview-box">
+                    <span class="preview-placeholder">Preview will appear here.</span>
+                </div>
+            </div>
+
+            <div class="section-title" style="margin-top:0.5rem">
+                <span class="section-title-name">YAML</span>
+                <button class="help-btn" onclick="openHelp()" title="YAML format reference">?</button>
+                <span class="dirty-indicator" id="dirtyIndicator"></span>
+            </div>
+
+            <textarea class="yaml-editor" id="yamlEditor" spellcheck="false" oninput="onEditorInput()"></textarea>
+
+            <div id="validationErrors" style="display:none" class="validation-errors"></div>
+
+            <div class="btn-row">
+                <button class="btn-save" id="btnSave" onclick="savePanel()">SAVE CHANGES</button>
+                <button class="btn-preview" onclick="previewPanel()">PREVIEW</button>
+                <button class="btn-reset" id="btnReset" onclick="resetPanel()" style="display:none">RESET</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+let panelsData = [];      // [{name, yaml}, ...]
+let activeName = null;
+let originalYaml = '';    // yaml as loaded from server
+let previewedYaml = '';   // yaml that was last previewed
+let previewPlain = '';    // last plain-text preview
+let previewAnsi  = '';    // last ansi-tagged preview
+let activeTab = 'plain';
+
+// ---- Load ----
+async function loadPanels() {
+    const res = await AdminAPI.get('/admin/api/v1/panels');
+    if (!res.ok) { showStatus('error', 'Failed to load panels: ' + (res.error || 'unknown error')); return; }
+    panelsData = (res.data && res.data.data) || [];
+    panelsData.sort((a, b) => a.name.localeCompare(b.name));
+    renderList();
+}
+
+// ---- Sidebar list ----
+function filterPanels() {
+    const q = document.getElementById('panelSearch').value.toLowerCase();
+    document.querySelectorAll('.panel-row').forEach(row => {
+        row.style.display = row.dataset.name.toLowerCase().includes(q) ? '' : 'none';
+    });
+    // Show/hide group labels based on whether any children are visible.
+    document.querySelectorAll('.panel-group-label').forEach(label => {
+        let next = label.nextElementSibling;
+        let anyVisible = false;
+        while (next && !next.classList.contains('panel-group-label')) {
+            if (next.style.display !== 'none') anyVisible = true;
+            next = next.nextElementSibling;
+        }
+        label.style.display = anyVisible ? '' : 'none';
+    });
+}
+
+function renderList() {
+    const list = document.getElementById('panelList');
+    if (panelsData.length === 0) {
+        list.innerHTML = '<div class="no-panels">No panel layouts found.</div>';
+        return;
+    }
+
+    // Group by directory prefix.
+    const groups = {};
+    for (const p of panelsData) {
+        const slash = p.name.lastIndexOf('/');
+        const group = slash >= 0 ? p.name.slice(0, slash) : '';
+        const leaf  = slash >= 0 ? p.name.slice(slash + 1) : p.name;
+        if (!groups[group]) groups[group] = [];
+        groups[group].push({ name: p.name, leaf });
+    }
+
+    let html = '';
+    const sortedGroups = Object.keys(groups).sort();
+    for (const group of sortedGroups) {
+        if (group) {
+            html += `<div class="panel-group-label">${escHtml(group)}</div>`;
+        }
+        for (const item of groups[group]) {
+            html += `<div class="panel-row" data-name="${escAttr(item.name)}" onclick="selectPanel(${escAttr(JSON.stringify(item.name))})">${escHtml(item.leaf)}</div>`;
+        }
+    }
+    list.innerHTML = html;
+    if (activeName) highlightRow(activeName);
+}
+
+function highlightRow(name) {
+    document.querySelectorAll('.panel-row').forEach(r => r.classList.remove('active'));
+    const row = document.querySelector(`.panel-row[data-name="${escAttr(name)}"]`);
+    if (row) { row.classList.add('active'); row.scrollIntoView({ block: 'nearest' }); }
+}
+
+// ---- Select ----
+function selectPanel(name) {
+    activeName = name;
+    highlightRow(name);
+
+    const entry = panelsData.find(p => p.name === name);
+    if (!entry) return;
+
+    originalYaml = entry.yaml;
+    previewPlain = '';
+    previewAnsi  = '';
+    previewedYaml = '';
+
+    document.getElementById('editorPlaceholder').style.display = 'none';
+    document.getElementById('editorForm').style.display = '';
+    document.getElementById('statusBar').className = 'status-bar';
+    document.getElementById('statusBar').textContent = '';
+    document.getElementById('editorTitle').textContent = name;
+    document.getElementById('yamlEditor').value = originalYaml;
+    document.getElementById('btnReset').style.display = 'none';
+    updateDirtyIndicator();
+    clearValidationErrors();
+
+    // Auto-preview on load.
+    previewPanel();
+}
+
+// ---- Dirty tracking ----
+function onEditorInput() {
+    updateDirtyIndicator();
+    updateResetButton();
+    clearValidationErrors();
+}
+
+function updateDirtyIndicator() {
+    const current = document.getElementById('yamlEditor').value;
+    const indicator = document.getElementById('dirtyIndicator');
+    if (current !== originalYaml) {
+        indicator.textContent = 'unsaved changes';
+        indicator.className = 'dirty-indicator dirty';
+    } else {
+        indicator.textContent = '';
+        indicator.className = 'dirty-indicator';
+    }
+}
+
+function updateResetButton() {
+    const current = document.getElementById('yamlEditor').value;
+    document.getElementById('btnReset').style.display = (current !== originalYaml) ? '' : 'none';
+}
+
+function resetPanel() {
+    if (!confirm('Discard unsaved changes and restore the original YAML?')) return;
+    document.getElementById('yamlEditor').value = originalYaml;
+    updateDirtyIndicator();
+    updateResetButton();
+    previewPanel();
+}
+
+// ---- Preview ----
+function switchTab(tab) {
+    activeTab = tab;
+    document.getElementById('tabPlain').classList.toggle('active', tab === 'plain');
+    document.getElementById('tabAnsi').classList.toggle('active', tab === 'ansi');
+    renderPreviewBox();
+}
+
+function makeRuler(width) {
+    if (width <= 0) return '';
+    // Build top (numbers) and bottom (tick line) as character arrays.
+    const top = Array(width).fill(' ');
+    const bot = Array(width).fill('─');
+
+    // Collect all positions that get a label: 0, every multiple of 5, and the last column.
+    const ticks = new Set();
+    ticks.add(0);
+    for (let i = 5; i < width; i += 5) ticks.add(i);
+    ticks.add(width - 1);
+
+    for (const pos of ticks) {
+        const label = String(pos);
+        // Right-align the label so its last character sits at `pos`.
+        const start = pos - label.length + 1;
+        for (let j = 0; j < label.length; j++) {
+            if (start + j >= 0) top[start + j] = label[j];
+        }
+        bot[pos] = '┴';
+    }
+
+    return top.join('') + '\n' + bot.join('');
+}
+
+function renderPreviewBox() {
+    const box = document.getElementById('previewBox');
+    if (!previewPlain && !previewAnsi) {
+        box.innerHTML = '<span class="preview-placeholder">Preview will appear here.</span>';
+        return;
+    }
+
+    // Measure width from the plain text (no ANSI tags to skew the count).
+    const firstLine = previewPlain.split('\n').find(l => l.length > 0) || '';
+    const width = firstLine.length;
+    const ruler = makeRuler(width);
+
+    if (activeTab === 'ansi') {
+        box.style.whiteSpace = 'pre';
+        const rulerHtml = escHtml(ruler);
+        const contentHtml = ansitags.parse(previewAnsi);
+        box.innerHTML = '<span class="preview-ruler">' + rulerHtml + '\n</span>' + contentHtml;
+    } else {
+        box.style.whiteSpace = 'pre';
+        box.innerHTML = '<span class="preview-ruler">' + escHtml(ruler) + '\n</span>' + escHtml(previewPlain);
+    }
+}
+
+async function previewPanel() {
+    const yaml = document.getElementById('yamlEditor').value;
+    if (!yaml.trim()) return;
+
+    const box = document.getElementById('previewBox');
+    box.textContent = 'Generating preview...';
+
+    const res = await AdminAPI.post('/admin/api/v1/panels/preview', { yaml });
+    if (!res.ok) {
+        box.textContent = 'Preview error: ' + (res.error || 'unknown error');
+        return;
+    }
+    const data = res.data && res.data.data;
+    previewPlain = (data && data.preview)      || '';
+    previewAnsi  = (data && data.preview_ansi) || '';
+    previewedYaml = yaml;
+    renderPreviewBox();
+}
+
+function clearValidationErrors() {
+    const box = document.getElementById('validationErrors');
+    box.style.display = 'none';
+    box.innerHTML = '';
+    document.getElementById('btnSave').disabled = false;
+}
+
+function showValidationErrors(issues) {
+    const box = document.getElementById('validationErrors');
+    const items = issues.map(i => `<li>${escHtml(i.message)}</li>`).join('');
+    box.innerHTML = `<strong>Validation errors — fix before saving:</strong><ul>${items}</ul>`;
+    box.style.display = '';
+    document.getElementById('btnSave').disabled = true;
+}
+
+async function validatePanel() {
+    const yaml = document.getElementById('yamlEditor').value;
+    if (!yaml.trim()) return true;
+    const res = await AdminAPI.post('/admin/api/v1/panels/validate', { yaml });
+    if (!res.ok) {
+        showValidationErrors([{ message: res.error || 'Validation request failed.' }]);
+        return false;
+    }
+    const data = res.data && res.data.data;
+    if (!data || !data.valid) {
+        showValidationErrors(data ? data.issues : [{ message: 'Unknown validation error.' }]);
+        return false;
+    }
+    clearValidationErrors();
+    return true;
+}
+
+// ---- Save ----
+async function savePanel() {
+    if (!activeName) return;
+    const yaml = document.getElementById('yamlEditor').value;
+    if (!yaml.trim()) { showStatus('error', 'YAML cannot be empty.'); return; }
+
+    const btn = document.getElementById('btnSave');
+    btn.disabled = true;
+
+    const valid = await validatePanel();
+    if (!valid) return;
+
+    const encodedName = activeName.split('/').map(encodeURIComponent).join('/');
+    const res = await AdminAPI.put(`/admin/api/v1/panels/${encodedName}`, { yaml });
+    btn.disabled = false;
+
+    if (!res.ok) {
+        showStatus('error', res.error || 'Save failed.');
+        return;
+    }
+
+    // Update local cache.
+    const entry = panelsData.find(p => p.name === activeName);
+    if (entry) entry.yaml = yaml;
+    originalYaml = yaml;
+
+    updateDirtyIndicator();
+    updateResetButton();
+    showStatus('success', `Saved "${activeName}".`);
+}
+
+// ---- Utilities ----
+function showStatus(type, msg) {
+    const bar = document.getElementById('statusBar');
+    bar.className = 'status-bar ' + type;
+    bar.textContent = msg;
+    if (type === 'success') setTimeout(() => { bar.className = 'status-bar'; }, 3000);
+}
+
+function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+function escAttr(s) { return String(s).replace(/"/g,'&quot;'); }
+
+loadPanels();
+</script>
+
+<!-- YAML help modal -->
+<div class="help-overlay" id="helpOverlay" onclick="if(event.target===this)closeHelp()">
+    <div class="help-modal">
+        <div class="help-modal-header">
+            <span class="help-modal-title">Panel Layout YAML Reference</span>
+            <button class="help-modal-close" onclick="closeHelp()">&#215;</button>
+        </div>
+        <div class="help-modal-body">
+            <h3>Top-level fields</h3>
+            <table>
+                <thead><tr><th>Field</th><th>Values / Notes</th></tr></thead>
+                <tbody>
+                <tr><td><code>border</code></td><td>
+                    <code>"full"</code> &mdash; every content row has side borders<br>
+                    <code>"open"</code> &mdash; only first and last rows have side borders<br>
+                    <em>Default: <code>"full"</code></em>
+                </td></tr>
+                <tr><td><code>charset</code></td><td>
+                    <code>"single"</code> &mdash; &#9484;&#9472;&#9488; &#9474; &#9492;&#9472;&#9496; <em>(default)</em><br>
+                    <code>"double"</code> &mdash; &#9556;&#9552;&#9559; &#9553; &#9562;&#9552;&#9565;<br>
+                    <code>"rounded"</code> &mdash; &#9581;&#9472;&#9582; &#9474; &#9584;&#9472;&#9583;<br>
+                    8-rune literal: <code>TopLeft HorizTop TopRight VertLeft VertRight BottomLeft HorizBottom BottomRight</code><br>
+                    Example: <code>"&#9556;&#9552;&#9559;&#9553;&#9553;&#9562;&#9552;&#9565;"</code>
+                </td></tr>
+                <tr><td><code>gap</code></td><td>Spaces between panels side by side and between slots.</td></tr>
+                <tr><td><code>margin</code></td><td>Spaces prepended to every output line. <em>Default: 0</em></td></tr>
+                <tr><td><code>default_color</code></td><td>
+                    Optional ANSI <code>fg</code> color wrapping the entire output.<br>
+                    Numeric code (e.g. <code>"214"</code>) or named alias (e.g. <code>"gold"</code>).<br>
+                    Omit to disable.
+                </td></tr>
+                </tbody>
+            </table>
+
+            <h3>Layout model</h3>
+            <ul>
+                <li><strong>slots</strong> &mdash; top-level horizontal columns, rendered side by side</li>
+                <li><strong>rows</strong> &mdash; within a slot, panel groups stacked vertically</li>
+                <li><strong>panels</strong> &mdash; within a row, panels placed side by side left-to-right</li>
+            </ul>
+
+            <h3>Per-panel fields</h3>
+            <table>
+                <thead><tr><th>Field</th><th>Values / Notes</th></tr></thead>
+                <tbody>
+                <tr><td><code>id</code></td><td>Unique identifier. Used in Go: <code>layout.Panel("id").Add(...)</code>. Required.</td></tr>
+                <tr><td><code>title</code></td><td>Rendered verbatim in the top border. May contain ANSI tags. Omit for a plain border line.</td></tr>
+                <tr><td><code>min_width</code></td><td>Minimum inner content width. Total panel width = <code>min_width + 4</code>.</td></tr>
+                <tr><td><code>columns</code></td><td>Label+value pairs per line. <em>Default: 1</em></td></tr>
+                <tr><td><code>column_gap</code></td><td>Spaces between columns when <code>columns &gt; 1</code>. <em>Default: 2</em></td></tr>
+                <tr><td><code>charset</code></td><td>Per-panel charset override. Falls back to top-level charset when omitted.</td></tr>
+                </tbody>
+            </table>
+
+            <h3>Minimal example</h3>
+            <pre>border: open
+charset: single
+gap: 1
+margin: 1
+
+slots:
+  - rows:
+      - panels:
+          - id: info
+            title: ' Info '
+            min_width: 30
+  - rows:
+      - panels:
+          - id: stats
+            title: ' Stats '
+            min_width: 40
+            columns: 2
+            column_gap: 2</pre>
+        </div>
+    </div>
+</div>
+
+<script>
+function openHelp() {
+    document.getElementById('helpOverlay').classList.add('open');
+}
+function closeHelp() {
+    document.getElementById('helpOverlay').classList.remove('open');
+}
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') closeHelp();
+});
+</script>
+
+{{template "footer" .}}

--- a/_datafiles/html/admin/panels.html
+++ b/_datafiles/html/admin/panels.html
@@ -148,6 +148,7 @@
         font-family: monospace; font-size: 0.8rem; padding: 0.75rem 0.9rem;
         border-radius: 4px; overflow-x: auto; line-height: 1.55; margin: 0;
     }
+    .btn-save {
         padding: 0.45rem 1.2rem; background: var(--color-primary);
         color: var(--color-surface-white); border: none; border-radius: 4px;
         font-size: 0.875rem; font-weight: 600; cursor: pointer;
@@ -557,6 +558,7 @@ loadPanels();
                 <tr><td><code>id</code></td><td>Unique identifier. Used in Go: <code>layout.Panel("id").Add(...)</code>. Required.</td></tr>
                 <tr><td><code>title</code></td><td>Rendered verbatim in the top border. May contain ANSI tags. Omit for a plain border line.</td></tr>
                 <tr><td><code>min_width</code></td><td>Minimum inner content width. Total panel width = <code>min_width + 4</code>.</td></tr>
+                <tr><td><code>max_width</code></td><td>When set, value fields are word-wrapped at this visual width. Continuation lines indent to align with the value column. <em>Default: 0 (no wrap)</em></td></tr>
                 <tr><td><code>columns</code></td><td>Label+value pairs per line. <em>Default: 1</em></td></tr>
                 <tr><td><code>column_gap</code></td><td>Spaces between columns when <code>columns &gt; 1</code>. <em>Default: 2</em></td></tr>
                 <tr><td><code>charset</code></td><td>Per-panel charset override. Falls back to top-level charset when omitted.</td></tr>

--- a/_datafiles/html/admin/static/js/ansitags.js
+++ b/_datafiles/html/admin/static/js/ansitags.js
@@ -1,5 +1,5 @@
 /**
- * ansitags.js - https://github.com/GoMudEngine/ansitags
+ * ansitags.js
  *
  * Parses strings containing <ansi> tags and converts them to HTML <span> tags
  * with inline color styles. This is a JavaScript port of the ansitags Go library,
@@ -128,7 +128,7 @@ const clearMap = {
   'scrollback': 3,
 };
 
-// Mutable state - aliases and position map
+// Mutable state — aliases and position map
 let colorAliases = Object.assign({}, defaultColorAliases);
 let positionMap = Object.assign({}, defaultPositionMap);
 
@@ -522,7 +522,513 @@ function rgb(colorCode) {
   return { r, g, b, hex: colorHex(colorCode) };
 }
 
-const _exports = { parse, setAlias, setAliases, loadAliases, rgb };
+/**
+ * Count visible (non-tag) characters in a string containing <ansi> tags.
+ *
+ * @param {string} input
+ * @returns {number}
+ */
+function visibleLen(input) {
+  let count = 0;
+  const openMatcher = new TagMatcher(TAG_START, TAG_OPEN_MID, TAG_END, true);
+  const closeMatcher = new TagMatcher(TAG_START, TAG_CLOSE_MID, TAG_END, false);
+  let tagLen = 0;
+  let mode = PARSE_MODE_NONE;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (mode === PARSE_MODE_NONE) {
+      if (ch !== TAG_START) {
+        count++;
+        continue;
+      }
+      mode = PARSE_MODE_MATCHING;
+    }
+    if (mode === PARSE_MODE_MATCHING) {
+      const openResult = openMatcher.matchNext(ch);
+      const closeResult = closeMatcher.matchNext(ch);
+      if (openResult.matched) {
+        tagLen++;
+        if (openResult.complete) {
+          tagLen = 0;
+          mode = PARSE_MODE_NONE;
+          openMatcher.reset();
+          closeMatcher.reset();
+        }
+        continue;
+      }
+      openMatcher.reset();
+      if (closeResult.matched) {
+        tagLen++;
+        if (closeResult.complete) {
+          tagLen = 0;
+          mode = PARSE_MODE_NONE;
+          openMatcher.reset();
+          closeMatcher.reset();
+        }
+        continue;
+      }
+      closeMatcher.reset();
+      if (openResult.complete && closeResult.complete) {
+        tagLen++;
+      }
+      mode = PARSE_MODE_NONE;
+      count += tagLen;
+      tagLen = 0;
+      continue;
+    }
+  }
+  if (tagLen > 0) {
+    count += tagLen;
+  }
+  return count;
+}
+
+/**
+ * Split a string containing <ansi> tags into segments of at most maxLen
+ * visible characters. Tags are properly closed at each split point and
+ * reopened in the next segment.
+ *
+ * @param {string} input - Input string with ansi tags.
+ * @param {number} maxLen - Maximum visible characters per segment.
+ * @param {boolean} [trimSpace=true] - Trim leading/trailing spaces from each segment.
+ * @returns {string[]} Array of tagged string segments.
+ */
+function splitString(input, maxLen, trimSpace) {
+  const doTrim = trimSpace === undefined ? true : !!trimSpace;
+
+  if (maxLen <= 0 || input.length === 0) {
+    return [input];
+  }
+
+  const totalVisible = visibleLen(input);
+  if (totalVisible <= maxLen) {
+    return [input];
+  }
+
+  const result = [];
+  const tagStack = [];
+  let current = '';
+  let visCount = 0;
+  let totalConsumed = 0;
+
+  const openMatcher = new TagMatcher(TAG_START, TAG_OPEN_MID, TAG_END, true);
+  const closeMatcher = new TagMatcher(TAG_START, TAG_CLOSE_MID, TAG_END, false);
+
+  const tagBuf = new Array(MAX_TAG_SIZE);
+  let tagBufLen = 0;
+  let mode = PARSE_MODE_NONE;
+
+  function split() {
+    for (let j = tagStack.length - 1; j >= 0; j--) {
+      current += '</ansi>';
+    }
+    result.push(current);
+    current = '';
+    for (let j = 0; j < tagStack.length; j++) {
+      current += tagStack[j];
+    }
+    visCount = 0;
+  }
+
+  function writeVisible(ch) {
+    current += ch;
+    visCount++;
+    totalConsumed++;
+    if (visCount >= maxLen && totalConsumed < totalVisible) {
+      split();
+    }
+  }
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (mode === PARSE_MODE_NONE) {
+      if (ch !== TAG_START) {
+        writeVisible(ch);
+        continue;
+      }
+      mode = PARSE_MODE_MATCHING;
+    }
+
+    if (mode === PARSE_MODE_MATCHING) {
+      const openResult = openMatcher.matchNext(ch);
+      const closeResult = closeMatcher.matchNext(ch);
+
+      if (openResult.matched) {
+        if (tagBufLen < MAX_TAG_SIZE) {
+          tagBuf[tagBufLen++] = ch;
+        }
+        if (!openResult.complete) {
+          continue;
+        }
+        const tagStr = tagBuf.slice(0, tagBufLen).join('');
+        tagStack.push(tagStr);
+        current += tagStr;
+        tagBufLen = 0;
+        mode = PARSE_MODE_NONE;
+        openMatcher.reset();
+        closeMatcher.reset();
+        continue;
+      }
+      openMatcher.reset();
+
+      if (closeResult.matched) {
+        if (tagBufLen < MAX_TAG_SIZE) {
+          tagBuf[tagBufLen++] = ch;
+        }
+        if (!closeResult.complete) {
+          continue;
+        }
+        tagBufLen = 0;
+        if (tagStack.length > 0) {
+          tagStack.pop();
+        }
+        current += '</ansi>';
+        mode = PARSE_MODE_NONE;
+        openMatcher.reset();
+        closeMatcher.reset();
+        continue;
+      }
+      closeMatcher.reset();
+
+      if (openResult.complete && closeResult.complete) {
+        if (tagBufLen < MAX_TAG_SIZE) {
+          tagBuf[tagBufLen++] = ch;
+        }
+      }
+
+      mode = PARSE_MODE_NONE;
+
+      for (let j = 0; j < tagBufLen; j++) {
+        writeVisible(tagBuf[j]);
+      }
+      tagBufLen = 0;
+      continue;
+    }
+  }
+
+  if (tagBufLen > 0) {
+    for (let j = 0; j < tagBufLen; j++) {
+      writeVisible(tagBuf[j]);
+    }
+  }
+
+  if (current.length > 0) {
+    result.push(current);
+  }
+
+  if (result.length === 0) {
+    return [input];
+  }
+
+  if (doTrim) {
+    for (let i = 0; i < result.length; i++) {
+      result[i] = trimTagAwareSpaces(result[i]);
+    }
+  }
+
+  return result;
+}
+
+function trimTagAwareSpaces(input) {
+  const n = input.length;
+  if (n === 0) return input;
+
+  const isVisible = new Uint8Array(n);
+
+  const openMatcher = new TagMatcher(TAG_START, TAG_OPEN_MID, TAG_END, true);
+  const closeMatcher = new TagMatcher(TAG_START, TAG_CLOSE_MID, TAG_END, false);
+  let mode = PARSE_MODE_NONE;
+  let tagBufStart = 0;
+
+  for (let i = 0; i < n; i++) {
+    const ch = input[i];
+    if (mode === PARSE_MODE_NONE) {
+      if (ch !== TAG_START) {
+        isVisible[i] = 1;
+        continue;
+      }
+      mode = PARSE_MODE_MATCHING;
+      tagBufStart = i;
+    }
+    if (mode === PARSE_MODE_MATCHING) {
+      const openResult = openMatcher.matchNext(ch);
+      const closeResult = closeMatcher.matchNext(ch);
+
+      if (openResult.matched) {
+        if (openResult.complete) {
+          mode = PARSE_MODE_NONE;
+          openMatcher.reset();
+          closeMatcher.reset();
+        }
+        continue;
+      }
+      openMatcher.reset();
+
+      if (closeResult.matched) {
+        if (closeResult.complete) {
+          mode = PARSE_MODE_NONE;
+          openMatcher.reset();
+          closeMatcher.reset();
+        }
+        continue;
+      }
+      closeMatcher.reset();
+
+      mode = PARSE_MODE_NONE;
+      for (let j = tagBufStart; j <= i; j++) {
+        isVisible[j] = 1;
+      }
+      continue;
+    }
+  }
+
+  if (mode === PARSE_MODE_MATCHING) {
+    for (let j = tagBufStart; j < n; j++) {
+      isVisible[j] = 1;
+    }
+  }
+
+  let firstNonSpace = -1;
+  let lastNonSpace = -1;
+  for (let i = 0; i < n; i++) {
+    if (isVisible[i] && input[i] !== ' ') {
+      if (firstNonSpace === -1) firstNonSpace = i;
+      lastNonSpace = i;
+    }
+  }
+
+  if (firstNonSpace === -1) {
+    let out = '';
+    for (let i = 0; i < n; i++) {
+      if (!isVisible[i]) out += input[i];
+    }
+    return out;
+  }
+
+  let out = '';
+  for (let i = 0; i < n; i++) {
+    if (isVisible[i] && (i < firstNonSpace || i > lastNonSpace)) {
+      continue;
+    }
+    out += input[i];
+  }
+  return out;
+}
+
+/**
+ * Compute split points (1-based visible-char counts) preferring spaces.
+ * Falls back to character-based split when no space is found.
+ *
+ * @param {string} input
+ * @param {number} maxLen
+ * @returns {number[]}
+ */
+function splitPoints(input, maxLen) {
+  const openMatcher = new TagMatcher(TAG_START, TAG_OPEN_MID, TAG_END, true);
+  const closeMatcher = new TagMatcher(TAG_START, TAG_CLOSE_MID, TAG_END, false);
+  const tagBuf = new Array(MAX_TAG_SIZE);
+  let tagBufLen = 0;
+  let mode = PARSE_MODE_NONE;
+
+  const total = visibleLen(input);
+  const points = [];
+  let consumed = 0;
+  let nextTarget = maxLen;
+  let lastSpaceAt = -1;
+
+  function recordVisible(ch) {
+    consumed++;
+    if (ch === ' ') lastSpaceAt = consumed;
+    while (consumed >= nextTarget && consumed < total) {
+      let splitAt;
+      if (lastSpaceAt > 0) {
+        splitAt = lastSpaceAt;
+        nextTarget = lastSpaceAt + maxLen;
+      } else {
+        splitAt = nextTarget;
+        nextTarget = nextTarget + maxLen;
+      }
+      lastSpaceAt = -1;
+      points.push(splitAt);
+    }
+  }
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (mode === PARSE_MODE_NONE) {
+      if (ch !== TAG_START) {
+        recordVisible(ch);
+        continue;
+      }
+      mode = PARSE_MODE_MATCHING;
+    }
+
+    if (mode === PARSE_MODE_MATCHING) {
+      const openResult = openMatcher.matchNext(ch);
+      const closeResult = closeMatcher.matchNext(ch);
+
+      if (openResult.matched) {
+        if (tagBufLen < MAX_TAG_SIZE) tagBuf[tagBufLen++] = ch;
+        if (!openResult.complete) continue;
+        tagBufLen = 0;
+        mode = PARSE_MODE_NONE;
+        openMatcher.reset();
+        closeMatcher.reset();
+        continue;
+      }
+      openMatcher.reset();
+
+      if (closeResult.matched) {
+        if (tagBufLen < MAX_TAG_SIZE) tagBuf[tagBufLen++] = ch;
+        if (!closeResult.complete) continue;
+        tagBufLen = 0;
+        mode = PARSE_MODE_NONE;
+        openMatcher.reset();
+        closeMatcher.reset();
+        continue;
+      }
+      closeMatcher.reset();
+
+      if (openResult.complete && closeResult.complete) {
+        if (tagBufLen < MAX_TAG_SIZE) tagBuf[tagBufLen++] = ch;
+      }
+      mode = PARSE_MODE_NONE;
+      for (let j = 0; j < tagBufLen; j++) recordVisible(tagBuf[j]);
+      tagBufLen = 0;
+      continue;
+    }
+  }
+
+  return points;
+}
+
+/**
+ * Split a string containing <ansi> tags into segments of at most maxLen
+ * visible characters, preferring to break at a space. Falls back to a
+ * character-based split when no space is found within the limit.
+ *
+ * @param {string} input - Input string with ansi tags.
+ * @param {number} maxLen - Maximum visible characters per segment.
+ * @param {boolean} [trimSpace=true] - Trim leading/trailing spaces from each segment.
+ * @returns {string[]} Array of tagged string segments.
+ */
+function splitStringOnSpaces(input, maxLen, trimSpace) {
+  const doTrim = trimSpace === undefined ? true : !!trimSpace;
+
+  if (maxLen <= 0 || input.length === 0) {
+    return [input];
+  }
+
+  const totalVisible = visibleLen(input);
+  if (totalVisible <= maxLen) {
+    return [input];
+  }
+
+  const points = splitPoints(input, maxLen);
+
+  const result = [];
+  const tagStack = [];
+  let current = '';
+  let totalConsumed = 0;
+  let pointIdx = 0;
+
+  const openMatcher = new TagMatcher(TAG_START, TAG_OPEN_MID, TAG_END, true);
+  const closeMatcher = new TagMatcher(TAG_START, TAG_CLOSE_MID, TAG_END, false);
+
+  const tagBuf = new Array(MAX_TAG_SIZE);
+  let tagBufLen = 0;
+  let mode = PARSE_MODE_NONE;
+
+  function split() {
+    for (let j = tagStack.length - 1; j >= 0; j--) current += '</ansi>';
+    result.push(current);
+    current = '';
+    for (let j = 0; j < tagStack.length; j++) current += tagStack[j];
+  }
+
+  function writeVisible(ch) {
+    current += ch;
+    totalConsumed++;
+    if (pointIdx < points.length && totalConsumed === points[pointIdx] && totalConsumed < totalVisible) {
+      pointIdx++;
+      split();
+    }
+  }
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (mode === PARSE_MODE_NONE) {
+      if (ch !== TAG_START) {
+        writeVisible(ch);
+        continue;
+      }
+      mode = PARSE_MODE_MATCHING;
+    }
+
+    if (mode === PARSE_MODE_MATCHING) {
+      const openResult = openMatcher.matchNext(ch);
+      const closeResult = closeMatcher.matchNext(ch);
+
+      if (openResult.matched) {
+        if (tagBufLen < MAX_TAG_SIZE) tagBuf[tagBufLen++] = ch;
+        if (!openResult.complete) continue;
+        const tagStr = tagBuf.slice(0, tagBufLen).join('');
+        tagStack.push(tagStr);
+        current += tagStr;
+        tagBufLen = 0;
+        mode = PARSE_MODE_NONE;
+        openMatcher.reset();
+        closeMatcher.reset();
+        continue;
+      }
+      openMatcher.reset();
+
+      if (closeResult.matched) {
+        if (tagBufLen < MAX_TAG_SIZE) tagBuf[tagBufLen++] = ch;
+        if (!closeResult.complete) continue;
+        tagBufLen = 0;
+        if (tagStack.length > 0) tagStack.pop();
+        current += '</ansi>';
+        mode = PARSE_MODE_NONE;
+        openMatcher.reset();
+        closeMatcher.reset();
+        continue;
+      }
+      closeMatcher.reset();
+
+      if (openResult.complete && closeResult.complete) {
+        if (tagBufLen < MAX_TAG_SIZE) tagBuf[tagBufLen++] = ch;
+      }
+
+      mode = PARSE_MODE_NONE;
+      for (let j = 0; j < tagBufLen; j++) writeVisible(tagBuf[j]);
+      tagBufLen = 0;
+      continue;
+    }
+  }
+
+  if (tagBufLen > 0) {
+    for (let j = 0; j < tagBufLen; j++) writeVisible(tagBuf[j]);
+  }
+
+  if (current.length > 0) result.push(current);
+
+  if (result.length === 0) return [input];
+
+  if (doTrim) {
+    for (let i = 0; i < result.length; i++) {
+      result[i] = trimTagAwareSpaces(result[i]);
+    }
+  }
+
+  return result;
+}
+
+const _exports = { parse, splitString, splitStringOnSpaces, setAlias, setAliases, loadAliases, rgb };
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = _exports;

--- a/_datafiles/world/default/panel-layouts/character/conditions.yaml
+++ b/_datafiles/world/default/panel-layouts/character/conditions.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the conditions command - active buffs display.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: conditions
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Conditions</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Conditions</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/conditions.yaml
+++ b/_datafiles/world/default/panel-layouts/character/conditions.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the conditions command - active buffs display.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: conditions
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Conditions</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/cooldowns.yaml
+++ b/_datafiles/world/default/panel-layouts/character/cooldowns.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the cooldowns command - active skill cooldowns display.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: cooldowns
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Cooldowns</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Cooldowns</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/cooldowns.yaml
+++ b/_datafiles/world/default/panel-layouts/character/cooldowns.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the cooldowns command - active skill cooldowns display.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: cooldowns
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Cooldowns</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/description.yaml
+++ b/_datafiles/world/default/panel-layouts/character/description.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for looking at a character or corpse - description display.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: desc
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/description.yaml
+++ b/_datafiles/world/default/panel-layouts/character/description.yaml
@@ -11,3 +11,4 @@ slots:
           - id: desc
             title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi>'
             min_width: 74
+            max_width: 74

--- a/_datafiles/world/default/panel-layouts/character/description.yaml
+++ b/_datafiles/world/default/panel-layouts/character/description.yaml
@@ -1,27 +1,4 @@
 # Panel layout for looking at a character or corpse - description display.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: desc
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/equipment-look.yaml
+++ b/_datafiles/world/default/panel-layouts/character/equipment-look.yaml
@@ -1,27 +1,4 @@
 # Panel layout for looking at a character's equipped items (look <target>).
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: equip
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/equipment-look.yaml
+++ b/_datafiles/world/default/panel-layouts/character/equipment-look.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for looking at a character's equipped items (look <target>).
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: equip
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/inventory.yaml
+++ b/_datafiles/world/default/panel-layouts/character/inventory.yaml
@@ -1,14 +1,4 @@
 # Panel layout for the character inventory screen.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
 
 border: open
 charset: single
@@ -19,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: equipment
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/jobs.yaml
+++ b/_datafiles/world/default/panel-layouts/character/jobs.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the jobs command - profession progress display.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: jobs
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Jobs</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/jobs.yaml
+++ b/_datafiles/world/default/panel-layouts/character/jobs.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the jobs command - profession progress display.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: jobs
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Jobs</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Jobs</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/pet.yaml
+++ b/_datafiles/world/default/panel-layouts/character/pet.yaml
@@ -1,27 +1,4 @@
 # Panel layout for looking at a pet's abilities (owner-only view).
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: abilities
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Abilities</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Abilities</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/pet.yaml
+++ b/_datafiles/world/default/panel-layouts/character/pet.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for looking at a pet's abilities (owner-only view).
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: abilities
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Abilities</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/quests.yaml
+++ b/_datafiles/world/default/panel-layouts/character/quests.yaml
@@ -1,29 +1,6 @@
 # Panel layout for the quests command.
 # Note: the panel title is set dynamically in Go code to include quest counts;
 # this file only defines the layout structure.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -34,5 +11,5 @@ slots:
   - rows:
       - panels:
           - id: quests
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Quests</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Quests</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/quests.yaml
+++ b/_datafiles/world/default/panel-layouts/character/quests.yaml
@@ -1,6 +1,6 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the quests command.
+# Note: the panel title is set dynamically in Go code to include quest counts;
+# this file only defines the layout structure.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +33,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: quests
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Quests</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/skills.yaml
+++ b/_datafiles/world/default/panel-layouts/character/skills.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the skills command.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: skills
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Skills</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/skills.yaml
+++ b/_datafiles/world/default/panel-layouts/character/skills.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the skills command.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: skills
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Skills</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Skills</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/character/stat-train.yaml
+++ b/_datafiles/world/default/panel-layouts/character/stat-train.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the train command - stat point allocation display.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: train
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Base Value</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Base Value</ansi>'
             min_width: 38

--- a/_datafiles/world/default/panel-layouts/character/stat-train.yaml
+++ b/_datafiles/world/default/panel-layouts/character/stat-train.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the train command - stat point allocation display.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -28,19 +26,11 @@
 border: open
 charset: single
 gap: 1
-margin: 1
+margin: 2
 
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: train
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Base Value</ansi> '
+            min_width: 38

--- a/_datafiles/world/default/panel-layouts/character/status-lite.yaml
+++ b/_datafiles/world/default/panel-layouts/character/status-lite.yaml
@@ -1,29 +1,6 @@
 # Panel layout for the peep skill status-lite view.
 # Mirrors the structure of character/status but with fewer panels:
 # no zone, XP, bank, or training data.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -34,13 +11,13 @@ slots:
   - rows:
       - panels:
           - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi>'
             min_width: 25
 
   - rows:
       - panels:
           - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi>'
+            min_width: 44
             columns: 2
             column_gap: 2

--- a/_datafiles/world/default/panel-layouts/character/status.yaml
+++ b/_datafiles/world/default/panel-layouts/character/status.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the character status screen.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,20 +9,20 @@ slots:
   - rows:
       - panels:
           - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi>'
             min_width: 25
 
   - rows:
       - panels:
           - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi>'
+            min_width: 44
             columns: 2
             column_gap: 2
       - panels:
           - id: wealth
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Wealth</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Wealth</ansi>'
             min_width: 19
           - id: training
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Training</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Trading</ansi>'
             min_width: 20

--- a/_datafiles/world/default/panel-layouts/inspect/basic.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/basic.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the item inspect - basic info section.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: basic
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Basic Info</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/inspect/basic.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/basic.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the item inspect - basic info section.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: basic
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Basic Info</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Basic Info</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/inspect/basic.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/basic.yaml
@@ -1,13 +1,11 @@
-# Panel layout for the item inspect - basic info section.
-
 border: open
 charset: single
 gap: 1
 margin: 1
-
 slots:
   - rows:
       - panels:
           - id: basic
-            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Basic Info</ansi>'
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Basic Info</ansi> '
             min_width: 74
+            max_width: 60

--- a/_datafiles/world/default/panel-layouts/inspect/magic.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/magic.yaml
@@ -11,3 +11,4 @@ slots:
           - id: magic
             title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Magical Effects</ansi>'
             min_width: 74
+            max_width: 60

--- a/_datafiles/world/default/panel-layouts/inspect/magic.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/magic.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the item inspect - magical effects section.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: magic
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Magical Effects</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/inspect/magic.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/magic.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the item inspect - magical effects section.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: magic
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Magical Effects</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Magical Effects</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/inspect/mods.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/mods.yaml
@@ -11,3 +11,4 @@ slots:
           - id: mods
             title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Modifiers</ansi>'
             min_width: 74
+            max_width: 60

--- a/_datafiles/world/default/panel-layouts/inspect/mods.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/mods.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the item inspect - modifiers section.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: mods
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Modifiers</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Modifiers</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/inspect/mods.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/mods.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the item inspect - modifiers section.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: mods
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Modifiers</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/inspect/stats.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/stats.yaml
@@ -11,3 +11,4 @@ slots:
           - id: stats
             title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Specific Stats</ansi>'
             min_width: 74
+            max_width: 60

--- a/_datafiles/world/default/panel-layouts/inspect/stats.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/stats.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the item inspect - specific stats section.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: stats
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Specific Stats</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Specific Stats</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/inspect/stats.yaml
+++ b/_datafiles/world/default/panel-layouts/inspect/stats.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the item inspect - specific stats section.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: stats
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Specific Stats</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/room/biome.yaml
+++ b/_datafiles/world/default/panel-layouts/room/biome.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the biome command - biome information display.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: biome
-            title: ' <ansi fg="black-bold">.:</ansi> Biome Info '
+            title: '<ansi fg="black-bold">.:</ansi> Biome Info'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/room/biome.yaml
+++ b/_datafiles/world/default/panel-layouts/room/biome.yaml
@@ -3,7 +3,7 @@
 border: open
 charset: single
 gap: 1
-margin: 0
+margin: 1
 
 slots:
   - rows:
@@ -11,3 +11,4 @@ slots:
           - id: biome
             title: '<ansi fg="black-bold">.:</ansi> Biome Info'
             min_width: 74
+            max_width: 60

--- a/_datafiles/world/default/panel-layouts/room/biome.yaml
+++ b/_datafiles/world/default/panel-layouts/room/biome.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the biome command - biome information display.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -28,19 +26,11 @@
 border: open
 charset: single
 gap: 1
-margin: 1
+margin: 0
 
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: biome
+            title: ' <ansi fg="black-bold">.:</ansi> Biome Info '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/room/container-inside.yaml
+++ b/_datafiles/world/default/panel-layouts/room/container-inside.yaml
@@ -1,6 +1,5 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for looking inside a container.
+# No title is set here; the Go code does not assign one.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -28,19 +27,10 @@
 border: open
 charset: single
 gap: 1
-margin: 1
+margin: 0
 
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: inside
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/room/container-inside.yaml
+++ b/_datafiles/world/default/panel-layouts/room/container-inside.yaml
@@ -1,28 +1,5 @@
 # Panel layout for looking inside a container.
 # No title is set here; the Go code does not assign one.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single

--- a/_datafiles/world/default/panel-layouts/room/container-inside.yaml
+++ b/_datafiles/world/default/panel-layouts/room/container-inside.yaml
@@ -4,7 +4,7 @@
 border: open
 charset: single
 gap: 1
-margin: 0
+margin: 1
 
 slots:
   - rows:

--- a/_datafiles/world/default/panel-layouts/room/track.yaml
+++ b/_datafiles/world/default/panel-layouts/room/track.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the track skill - recent room visitors display.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: track
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Recent Visitors</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/room/track.yaml
+++ b/_datafiles/world/default/panel-layouts/room/track.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the track skill - recent room visitors display.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: track
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Recent Visitors</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Recent Visitors</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/room/train.yaml
+++ b/_datafiles/world/default/panel-layouts/room/train.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the train command - skills taught at a trainer.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: train
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Skills Taught Here</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Skills Taught Here</ansi>'
             min_width: 74

--- a/_datafiles/world/default/panel-layouts/room/train.yaml
+++ b/_datafiles/world/default/panel-layouts/room/train.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the train command - skills taught at a trainer.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: train
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Skills Taught Here</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/storage/storage.yaml
+++ b/_datafiles/world/default/panel-layouts/storage/storage.yaml
@@ -1,6 +1,4 @@
-# Panel layout for the peep skill status-lite view.
-# Mirrors the structure of character/status but with fewer panels:
-# no zone, XP, bank, or training data.
+# Panel layout for the storage module - stored items display.
 #
 # border:  "full"    - every content row has side borders  │ label  value │
 #          "open"    - only the first and last content rows have side borders
@@ -33,14 +31,6 @@ margin: 1
 slots:
   - rows:
       - panels:
-          - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
-            min_width: 25
-
-  - rows:
-      - panels:
-          - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
-            min_width: 42
-            columns: 2
-            column_gap: 2
+          - id: storage
+            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">In Storage</ansi> '
+            min_width: 74

--- a/_datafiles/world/default/panel-layouts/storage/storage.yaml
+++ b/_datafiles/world/default/panel-layouts/storage/storage.yaml
@@ -1,27 +1,4 @@
 # Panel layout for the storage module - stored items display.
-#
-# border:  "full"    - every content row has side borders  │ label  value │
-#          "open"    - only the first and last content rows have side borders
-#
-# charset: "single"  - single-line box drawing: ┌─┐ │ └─┘
-#          "double"  - double-line box drawing: ╔═╗ ║ ╚═╝
-#          "rounded" - rounded corners:         ╭─╮ │ ╰─╯
-#
-# gap:    spaces between panels placed side by side, and between top-level slots
-# margin: spaces prepended to every output line (optional, default 0)
-#
-# Layout model:
-#   slots  - top-level horizontal columns, rendered side by side
-#   rows   - within a slot, panels stacked vertically top-to-bottom
-#   panels - within a row, panels placed side by side left-to-right
-#
-# Each panel:
-#   id         - used in Go code: layout.Panel("id").Add(...)
-#   title      - the full title string rendered verbatim into the top border;
-#                may contain ANSI tags - visual width is measured with tags stripped
-#   min_width  - minimum inner content width; expands if content is wider
-#   columns    - optional (default 1): pair rows side by side within the panel
-#   column_gap - optional (default 2): spaces between paired columns
 
 border: open
 charset: single
@@ -32,5 +9,5 @@ slots:
   - rows:
       - panels:
           - id: storage
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">In Storage</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">In Storage</ansi>'
             min_width: 74

--- a/_datafiles/world/empty/panel-layouts/character/inventory.yaml
+++ b/_datafiles/world/empty/panel-layouts/character/inventory.yaml
@@ -19,5 +19,5 @@ slots:
   - rows:
       - panels:
           - id: equipment
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi>'
             min_width: 74

--- a/_datafiles/world/empty/panel-layouts/character/status-lite.yaml
+++ b/_datafiles/world/empty/panel-layouts/character/status-lite.yaml
@@ -11,13 +11,13 @@ slots:
   - rows:
       - panels:
           - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi>'
             min_width: 25
 
   - rows:
       - panels:
           - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi>'
             min_width: 42
             columns: 2
             column_gap: 2

--- a/_datafiles/world/empty/panel-layouts/character/status.yaml
+++ b/_datafiles/world/empty/panel-layouts/character/status.yaml
@@ -32,20 +32,20 @@ slots:
   - rows:
       - panels:
           - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi>'
             min_width: 25
 
   - rows:
       - panels:
           - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi>'
             min_width: 42
             columns: 2
             column_gap: 2
       - panels:
           - id: wealth
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Wealth</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Wealth</ansi>'
             min_width: 19
           - id: training
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Training</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Training</ansi>'
             min_width: 20

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 require (
-	github.com/GoMudEngine/ansitags v1.3.1
+	github.com/GoMudEngine/ansitags v1.3.2
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 require (
-	github.com/GoMudEngine/ansitags v1.3.0
+	github.com/GoMudEngine/ansitags v1.3.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/GoMudEngine/ansitags v1.3.0 h1:f0zZ0VGNmGC1G+qRO+Ers/OMkZU4dAE4Ip+Xo0z9soY=
-github.com/GoMudEngine/ansitags v1.3.0/go.mod h1:McpBTRYx4TE/+aVbK4veo7z6mDNrpi3Lka88FenWa3A=
+github.com/GoMudEngine/ansitags v1.3.1 h1:sltsY2FqdhqTfUHfYCeqru5YrC9kTmprmlunY9YQ3yU=
+github.com/GoMudEngine/ansitags v1.3.1/go.mod h1:McpBTRYx4TE/+aVbK4veo7z6mDNrpi3Lka88FenWa3A=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/GoMudEngine/ansitags v1.3.1 h1:sltsY2FqdhqTfUHfYCeqru5YrC9kTmprmlunY9YQ3yU=
-github.com/GoMudEngine/ansitags v1.3.1/go.mod h1:McpBTRYx4TE/+aVbK4veo7z6mDNrpi3Lka88FenWa3A=
+github.com/GoMudEngine/ansitags v1.3.2 h1:DcxDh0SHlw72120EoWzkwEQ+a3lwi6CsumWwPhdwZ38=
+github.com/GoMudEngine/ansitags v1.3.2/go.mod h1:McpBTRYx4TE/+aVbK4veo7z6mDNrpi3Lka88FenWa3A=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/internal/configs/config_types.go
+++ b/internal/configs/config_types.go
@@ -105,10 +105,7 @@ func (c ConfigBool) String() string {
 }
 
 func (c ConfigSliceString) String() string {
-	if len(c) == 0 {
-		return `[]`
-	}
-	return `["` + strings.Join(c, `", "`) + `"]`
+	return strings.Join(c, `,`)
 }
 
 //

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -173,9 +173,16 @@ func (c *Config) buildDotPaths(v reflect.Value, prefix string, result map[string
 		}
 	default:
 		// For non-struct fields, store the value using the accumulated prefix.
-		// Sanitize to ensure all values are JSON-encodable (YAML unmarshaling
-		// can produce map[interface{}]interface{} inside slices and nested maps).
-		result[prefix] = sanitizeForJSON(v.Interface())
+		// Preserve typed config values so that typeLookups records the correct
+		// type name (e.g. "configs.ConfigSliceString") and SetVal can round-trip
+		// them. Only sanitize values that are not already a known config type.
+		if cs, ok := v.Interface().(ConfigSliceString); ok {
+			result[prefix] = cs
+		} else {
+			// Sanitize to ensure all values are JSON-encodable (YAML unmarshaling
+			// can produce map[interface{}]interface{} inside slices and nested maps).
+			result[prefix] = sanitizeForJSON(v.Interface())
+		}
 	}
 }
 

--- a/internal/configs/configs_test.go
+++ b/internal/configs/configs_test.go
@@ -191,9 +191,9 @@ func TestConfigSliceStringString(t *testing.T) {
 		value    ConfigSliceString
 		expected string
 	}{
-		{name: "EmptySlice", value: ConfigSliceString{}, expected: `[]`},
-		{name: "SingleElement", value: ConfigSliceString{"one"}, expected: `["one"]`},
-		{name: "MultipleElements", value: ConfigSliceString{"one", "two", "three"}, expected: `["one", "two", "three"]`},
+		{name: "EmptySlice", value: ConfigSliceString{}, expected: ``},
+		{name: "SingleElement", value: ConfigSliceString{"one"}, expected: `one`},
+		{name: "MultipleElements", value: ConfigSliceString{"one", "two", "three"}, expected: `one,two,three`},
 	}
 
 	for _, tt := range tests {

--- a/internal/mobcommands/attack.go
+++ b/internal/mobcommands/attack.go
@@ -21,7 +21,10 @@ func Attack(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		// If no argument supplied, attack whoever is attacking the player currently.
 		for _, mId := range room.GetMobs(rooms.FindFightingMob) {
 			m := mobs.GetInstance(mId)
-			if m.Character.Aggro != nil && m.Character.Aggro.MobInstanceId == mob.InstanceId {
+			if m == nil || m.Character.Aggro == nil {
+				continue
+			}
+			if m.Character.Aggro.MobInstanceId == mob.InstanceId {
 				attackMobInstanceId = m.InstanceId
 				break
 			}

--- a/internal/mobcommands/callforhelp.go
+++ b/internal/mobcommands/callforhelp.go
@@ -51,6 +51,9 @@ func CallForHelp(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 	}
 
 	m := mapper.GetMapper(room.RoomId)
+	if m == nil {
+		return true, nil
+	}
 	roomList := m.FindRoomsInDistance(room.RoomId, maxRange, 0)
 
 	for _, roomId := range roomList {

--- a/internal/scripting/panel_func.go
+++ b/internal/scripting/panel_func.go
@@ -119,7 +119,9 @@ func (p *ScriptPanel) SetLabelWidth(w int) *ScriptPanel {
 }
 
 // SetCharset overrides the border character set for this panel.
-// Recognised values: "single", "double", "rounded".
+// Accepts a named preset ("single", "double", "rounded") or an 8-rune literal
+// string in the order: TopLeft, HorizontalTop, TopRight, VerticalLeft, VerticalRight,
+// BottomLeft, HorizontalBottom, BottomRight. Example: "\u2554\u2550\u2557\u2551\u2502\u255a\u2500\u2518".
 // If not called, the panel uses the layout-level charset.
 // Returns the panel for chaining.
 func (p *ScriptPanel) SetCharset(name string) *ScriptPanel {

--- a/internal/scripting/panel_func.go
+++ b/internal/scripting/panel_func.go
@@ -144,6 +144,16 @@ func (p *ScriptPanel) SetMinWidth(w int) *ScriptPanel {
 	return p
 }
 
+// SetMaxWidth sets the panel's value wrap width.
+// When non-zero, values added via Add are wrapped at this visual width using
+// word-boundary splitting. Continuation lines are indented to align with the
+// value column of the first line.
+// Returns the panel for chaining.
+func (p *ScriptPanel) SetMaxWidth(w int) *ScriptPanel {
+	p.panel.SetMaxWidth(w)
+	return p
+}
+
 // SetColumns sets the number of label+value pairs per line (1 or 2).
 // Returns the panel for chaining.
 func (p *ScriptPanel) SetColumns(n int) *ScriptPanel {
@@ -163,6 +173,15 @@ func (p *ScriptPanel) SetColumnGap(n int) *ScriptPanel {
 // Returns the panel for chaining.
 func (p *ScriptPanel) Add(fullLabel, shortLabel, value string) *ScriptPanel {
 	p.panel.Add(fullLabel, shortLabel, value)
+	return p
+}
+
+// AddWithMaxWidth appends a label+value row with a maximum value width.
+// When the value's visual width exceeds maxWidth, it is wrapped onto continuation
+// lines indented to align with the value column of the first line.
+// Returns the panel for chaining.
+func (p *ScriptPanel) AddWithMaxWidth(fullLabel, shortLabel, value string, maxWidth int) *ScriptPanel {
+	p.panel.AddWithMaxWidth(fullLabel, shortLabel, value, maxWidth)
 	return p
 }
 

--- a/internal/templates/PANELS.md
+++ b/internal/templates/PANELS.md
@@ -122,7 +122,7 @@ _datafiles/<world>/panel-layouts/<path>.yaml
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `border` | string | `"full"` | `"full"` or `"open"` — see [Border styles](#border-styles) |
-| `charset` | string | `"single"` | `"single"`, `"double"`, or `"rounded"` — see [Character sets](#character-sets) |
+| `charset` | string | `"single"` | `"single"`, `"double"`, `"rounded"`, or an 8-character literal — see [Character sets](#character-sets) |
 | `gap` | int | `0` | Spaces between panels in the same row and between slots |
 | `margin` | int | `0` | Spaces prepended to every output line |
 | `slots` | list | — | Ordered list of slot definitions |
@@ -140,7 +140,7 @@ Each slot contains a list of rows. Each row contains a list of panels.
 | `panels[].min_width` | int | `0` | Minimum inner content width; expands if content is wider |
 | `panels[].columns` | int | `1` | `1` or `2` — see [Multi-column panels](#multi-column-panels) |
 | `panels[].column_gap` | int | `2` | Spaces between columns when `columns: 2` |
-| `panels[].charset` | string | _(layout charset)_ | Optional per-panel charset override: `"single"`, `"double"`, or `"rounded"` |
+| `panels[].charset` | string | _(layout charset)_ | Optional per-panel charset override: `"single"`, `"double"`, `"rounded"`, or an 8-character literal |
 
 ### Full example
 
@@ -148,9 +148,10 @@ Each slot contains a list of rows. Each row contains a list of panels.
 # border: "full"    - every row has side borders  │ label  value │
 # border: "open"    - only first/last rows have side borders
 #
-# charset: "single"  - ┌─┐ │ └─┘
-# charset: "double"  - ╔═╗ ║ ╚═╝
-# charset: "rounded" - ╭─╮ │ ╰─╯
+# charset: "single"  - ┌─┐ │ │ └─┘
+# charset: "double"  - ╔═╗ ║ ║ ╚═╝
+# charset: "rounded" - ╭─╮ │ │ ╰─╯
+# charset: literal   - 8 chars: TopLeft HorizontalTop TopRight VerticalLeft VerticalRight BottomLeft HorizontalBottom BottomRight
 
 border: open
 charset: single
@@ -230,7 +231,7 @@ build the structure, then `Panel(id)` to configure and populate each panel.
 | Parameter | Description |
 | --- | --- |
 | `border` | `"full"` or `"open"` |
-| `charset` | `"single"`, `"double"`, or `"rounded"` |
+| `charset` | `"single"`, `"double"`, `"rounded"`, or an 8-character literal |
 | `gap` | Spaces between side-by-side panels and between slots |
 | `margin` | Spaces prepended to every output line |
 
@@ -355,12 +356,13 @@ func (p *Panel) SetCharset(name string)
 ```
 
 Overrides the border character set for this panel. When set, this panel uses
-its own charset regardless of the layout-level setting. Recognised values:
-`"single"`, `"double"`, `"rounded"`. An unrecognised value falls back to
-`"single"`.
+its own charset regardless of the layout-level setting. Accepts a named preset
+(`"single"`, `"double"`, `"rounded"`) or an 8-character literal string. An
+unrecognised value falls back to `"single"`.
 
 ```go
 layout.Panel("highlight").SetCharset("double")
+layout.Panel("custom").SetCharset("╔═╗║│╚─┘")
 ```
 
 ---
@@ -469,15 +471,28 @@ default GoMud status screen.
 
 ## Character sets
 
-| Value | Top | Vertical | Bottom |
-| --- | --- | --- | --- |
-| `"single"` (default) | `┌─ title ───┐` | `│` | `└───────────┘` |
-| `"double"` | `╔═ title ═══╗` | `║` | `╚═══════════╝` |
-| `"rounded"` | `╭─ title ───╮` | `│` | `╰───────────╯` |
+| Value | Top-left | Horizontal-top | Top-right | Vertical-left | Vertical-right | Bottom-left | Horizontal-bottom | Bottom-right |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `"single"` (default) | `┌` | `─` | `┐` | `│` | `│` | `└` | `─` | `┘` |
+| `"double"` | `╔` | `═` | `╗` | `║` | `║` | `╚` | `═` | `╝` |
+| `"rounded"` | `╭` | `─` | `╮` | `│` | `│` | `╰` | `─` | `╯` |
 
-The charset applies to all panels in the layout. It is resolved by
-`charsetForName(name string)` which is case-insensitive and defaults to
-`"single"` for any unrecognised value.
+An **8-character literal** can be used instead of a named preset. The characters
+are read in order: TopLeft, HorizontalTop, TopRight, VerticalLeft, VerticalRight,
+BottomLeft, HorizontalBottom, BottomRight. This allows asymmetric left/right and
+top/bottom borders:
+
+```yaml
+charset: "╔═╗║│╚─┘"  # double top/left border, single bottom/right border
+```
+
+```go
+layout.Panel("x").SetCharset("╔═╗║│╚─┘")
+```
+
+The charset applies to all panels in the layout unless overridden per-panel.
+Charset resolution is case-insensitive for named presets and falls back to
+`"single"` for any unrecognised value that is not exactly 8 runes.
 
 ---
 

--- a/internal/templates/PANELS.md
+++ b/internal/templates/PANELS.md
@@ -162,22 +162,22 @@ slots:
   - rows:
       - panels:
           - id: info
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Info</ansi>'
             min_width: 30
 
   - rows:
       - panels:
           - id: attributes
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Attributes</ansi>'
             min_width: 42
             columns: 2
             column_gap: 2
       - panels:
           - id: wealth
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Wealth</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Wealth</ansi>'
             min_width: 19
           - id: training
-            title: ' <ansi fg="black-bold">.:</ansi><ansi fg="20">Training</ansi> '
+            title: '<ansi fg="black-bold">.:</ansi><ansi fg="20">Training</ansi>'
             min_width: 20
 ```
 

--- a/internal/templates/panel.go
+++ b/internal/templates/panel.go
@@ -3,9 +3,11 @@ package templates
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
 	"github.com/GoMudEngine/ansitags"
 	"github.com/mattn/go-runewidth"
 	"gopkg.in/yaml.v2"
@@ -151,20 +153,23 @@ func renderSlot(slot *layoutSlot, gap int) []string {
 
 // PanelLayout is a loaded layout skeleton populated with data and ready to render.
 type PanelLayout struct {
-	border borderStyle
-	chars  borderChars
-	gap    int
-	margin int               // spaces prepended to every output line
-	slots  []*layoutSlot     // top-level horizontal slots (columns)
-	byID   map[string]*Panel // fast lookup by panel id
+	border       borderStyle
+	chars        borderChars
+	gap          int
+	margin       int               // spaces prepended to every output line
+	defaultColor string            // optional ANSI fg color/alias wrapping entire output
+	slots        []*layoutSlot     // top-level horizontal slots (columns)
+	byID         map[string]*Panel // fast lookup by panel id
 }
 
 // Panel returns the named panel for data population.
-// It panics with a descriptive message if the id is not defined in the layout.
+// If the id is not defined in the layout, a no-op panel is returned and an
+// error is logged so the caller continues without panicking.
 func (l *PanelLayout) Panel(id string) *Panel {
 	p, ok := l.byID[id]
 	if !ok {
-		panic(fmt.Sprintf("panel layout: no panel with id %q", id))
+		mudlog.Error("panel layout", "error", fmt.Sprintf("no panel with id %q", id))
+		return &Panel{border: l.border, chars: l.chars, columns: 1, columnGap: defaultColumnGap}
 	}
 	return p
 }
@@ -220,7 +225,11 @@ func (l *PanelLayout) Render() string {
 			out[i] = prefix + line
 		}
 	}
-	return strings.Join(out, "\n")
+	result := strings.Join(out, "\n")
+	if l.defaultColor != "" {
+		result = fmt.Sprintf(`<ansi fg="%s">%s</ansi>`, l.defaultColor, result)
+	}
+	return result
 }
 
 // ---------------------------------------------------------------------------
@@ -250,11 +259,12 @@ type slotDef struct {
 
 // panelLayoutDef is the top-level YAML structure.
 type panelLayoutDef struct {
-	Border  string    `yaml:"border"`
-	Gap     int       `yaml:"gap"`
-	Margin  int       `yaml:"margin"`  // optional left margin applied to every output line
-	Charset string    `yaml:"charset"` // optional: "single" (default), "double", "rounded"
-	Slots   []slotDef `yaml:"slots"`
+	Border       string    `yaml:"border"`
+	Gap          int       `yaml:"gap"`
+	Margin       int       `yaml:"margin"`        // optional left margin applied to every output line
+	Charset      string    `yaml:"charset"`       // optional: "single" (default), "double", "rounded", or 8-rune literal
+	DefaultColor string    `yaml:"default_color"` // optional: ANSI color code or alias to wrap entire output
+	Slots        []slotDef `yaml:"slots"`
 }
 
 // LayoutSlot is the exported handle for a slot, used by the scripting layer.
@@ -340,6 +350,259 @@ func (p *Panel) SetColumnGap(n int) *Panel {
 	return p
 }
 
+// PanelLayoutInfo holds metadata about a discovered panel layout file.
+type PanelLayoutInfo struct {
+	// Name is the relative path under panel-layouts/ without the .yaml extension.
+	// Example: "character/status"
+	Name string
+	// YAML is the raw file content.
+	YAML string
+}
+
+// ListPanelLayouts returns all panel layout files found under the panel-layouts/
+// subdirectory of the data files directory. Each entry's Name is the relative
+// path without the .yaml extension (e.g. "character/status").
+func ListPanelLayouts() ([]PanelLayoutInfo, error) {
+	dataFiles := string(configs.GetFilePathsConfig().DataFiles)
+	root := dataFiles + "/panel-layouts"
+
+	var result []PanelLayoutInfo
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		name := strings.TrimSuffix(rel, ".yaml")
+		// Normalise Windows separators.
+		name = strings.ReplaceAll(name, "\\", "/")
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		result = append(result, PanelLayoutInfo{Name: name, YAML: string(data)})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list panel layouts: %w", err)
+	}
+	return result, nil
+}
+
+// PanelValidationIssue describes a single problem found during layout validation.
+type PanelValidationIssue struct {
+	Message string `json:"message"`
+}
+
+// ValidatePanelLayout parses the given YAML and returns a list of structural
+// issues. An empty slice means the layout is valid. A non-nil error means the
+// YAML itself could not be parsed.
+func ValidatePanelLayout(yamlData string) ([]PanelValidationIssue, error) {
+	var def panelLayoutDef
+	if err := yaml.Unmarshal([]byte(yamlData), &def); err != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", err)
+	}
+
+	var issues []PanelValidationIssue
+	add := func(msg string) { issues = append(issues, PanelValidationIssue{Message: msg}) }
+
+	if def.Border != "" && def.Border != string(borderFull) && def.Border != string(borderOpen) {
+		add(fmt.Sprintf("unknown border style %q (valid: \"full\", \"open\")", def.Border))
+	}
+
+	validCharsets := map[string]bool{"single": true, "double": true, "rounded": true, "": true}
+	if !validCharsets[def.Charset] && len([]rune(def.Charset)) != 8 {
+		add(fmt.Sprintf("unknown charset %q (valid: \"single\", \"double\", \"rounded\", or 8-rune literal)", def.Charset))
+	}
+
+	if def.DefaultColor != "" && strings.TrimSpace(def.DefaultColor) == "" {
+		add("default_color must not be blank whitespace; omit the field to disable it")
+	}
+
+	if len(def.Slots) == 0 {
+		add("layout has no slots defined")
+	}
+
+	seenIDs := make(map[string]bool)
+	for si, sd := range def.Slots {
+		if len(sd.Rows) == 0 {
+			add(fmt.Sprintf("slot %d has no rows", si+1))
+		}
+		for ri, rd := range sd.Rows {
+			if len(rd.Panels) == 0 {
+				add(fmt.Sprintf("slot %d, row %d has no panels", si+1, ri+1))
+			}
+			for pi, pd := range rd.Panels {
+				loc := fmt.Sprintf("slot %d, row %d, panel %d", si+1, ri+1, pi+1)
+				if pd.ID == "" {
+					add(fmt.Sprintf("%s: missing id", loc))
+				} else if seenIDs[pd.ID] {
+					add(fmt.Sprintf("%s: duplicate panel id %q", loc, pd.ID))
+				} else {
+					seenIDs[pd.ID] = true
+				}
+				if pd.Columns < 0 {
+					add(fmt.Sprintf("%s (id=%q): columns must be >= 0", loc, pd.ID))
+				}
+				if pd.MinWidth < 0 {
+					add(fmt.Sprintf("%s (id=%q): min_width must be >= 0", loc, pd.ID))
+				}
+				if pd.Charset != "" && !validCharsets[pd.Charset] && len([]rune(pd.Charset)) != 8 {
+					add(fmt.Sprintf("%s (id=%q): unknown charset %q", loc, pd.ID, pd.Charset))
+				}
+			}
+		}
+	}
+
+	return issues, nil
+}
+
+// PreviewPanelLayout parses the given YAML definition and renders a text
+// preview by filling every panel with at least two dummy rows.
+// When stripAnsi is true the output is plain ASCII (ANSI tags removed from
+// titles). When false, titles are kept verbatim so the caller can render the
+// ANSI tags with a client-side library.
+func PreviewPanelLayout(yamlData string, stripAnsi bool) (string, error) {
+	var def panelLayoutDef
+	if err := yaml.Unmarshal([]byte(yamlData), &def); err != nil {
+		return "", fmt.Errorf("preview panel layout: %w", err)
+	}
+
+	border := borderFull
+	if borderStyle(def.Border) == borderOpen {
+		border = borderOpen
+	}
+	chars := charsetForName(def.Charset)
+	gap := def.Gap
+	if gap < 0 {
+		gap = 0
+	}
+
+	layout := &PanelLayout{
+		border:       border,
+		chars:        chars,
+		gap:          gap,
+		margin:       def.Margin,
+		defaultColor: def.DefaultColor,
+		byID:         make(map[string]*Panel),
+	}
+	if stripAnsi {
+		layout.defaultColor = ""
+	}
+
+	for _, sd := range def.Slots {
+		slot := &layoutSlot{}
+		for _, rd := range sd.Rows {
+			panelCount := len(rd.Panels)
+			var rowPanels []*Panel
+			for _, pd := range rd.Panels {
+				cols := pd.Columns
+				if cols < 1 {
+					cols = 1
+				}
+				colGap := pd.ColumnGap
+				if colGap < 1 {
+					colGap = defaultColumnGap
+				}
+				panelChars := chars
+				if pd.Charset != "" {
+					panelChars = charsetForName(pd.Charset)
+				}
+				title := pd.Title
+				if stripAnsi {
+					title = panelVisualTitle(pd.Title)
+				}
+				p := &Panel{
+					id:        pd.ID,
+					title:     title,
+					minWidth:  pd.MinWidth,
+					border:    border,
+					chars:     panelChars,
+					columns:   cols,
+					columnGap: colGap,
+				}
+				// Sole panel in its row defines its own height; give it more rows
+				// so the preview is representative. Panels with siblings get 2.
+				p.rows = append(p.rows, previewDummyRows(cols, panelCount == 1, !stripAnsi)...)
+				layout.byID[pd.ID] = p
+				rowPanels = append(rowPanels, p)
+			}
+			slot.rows = append(slot.rows, rowPanels)
+		}
+		layout.slots = append(layout.slots, slot)
+	}
+
+	return layout.Render(), nil
+}
+
+// panelVisualTitle strips ANSI tags from a title string and returns the
+// printable text only, suitable for plain-text preview output.
+func panelVisualTitle(title string) string {
+	stripped := ansitags.Parse(title, ansitags.StripTags)
+	return strings.TrimSpace(stripped)
+}
+
+// previewDummyRows returns dummy PanelRows for preview purposes.
+// alone=true means the panel is the sole panel in its row and will define the
+// row height; it gets 4 rows. Panels with horizontal siblings get 2 rows.
+// Multi-column panels double the count so both columns appear populated.
+// When withAnsi is true, labels and values are wrapped in ANSI colour tags.
+func previewDummyRows(columns int, alone bool, withAnsi bool) []PanelRow {
+	base := 2
+	if alone {
+		base = 4
+	}
+	count := base * columns
+	rows := make([]PanelRow, count)
+	for i := range rows {
+		label := fmt.Sprintf("label-%d", i+1)
+		value := fmt.Sprintf("value-%d", i+1)
+		if withAnsi {
+			label = fmt.Sprintf(`<ansi fg="yellow">%s</ansi>`, label)
+			value = fmt.Sprintf(`<ansi fg="green-bold">%s</ansi>`, value)
+		}
+		rows[i] = PanelRow{
+			FullLabel:  label,
+			ShortLabel: label,
+			Value:      value,
+		}
+	}
+	return rows
+}
+
+// SavePanelLayout writes yamlData to the panel layout file for the given name.
+// name is relative to panel-layouts/ without the .yaml extension.
+// The file must already exist; this function does not create new layout files.
+func SavePanelLayout(name, yamlData string) error {
+	dataFiles := string(configs.GetFilePathsConfig().DataFiles)
+	path := dataFiles + "/panel-layouts/" + name + ".yaml"
+
+	// Verify the file exists before overwriting.
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("panel layout %q: %w", name, err)
+	}
+
+	// Validate the YAML parses correctly before writing.
+	var def panelLayoutDef
+	if err := yaml.Unmarshal([]byte(yamlData), &def); err != nil {
+		return fmt.Errorf("panel layout %q: invalid YAML: %w", name, err)
+	}
+
+	if err := os.WriteFile(path, []byte(yamlData), 0644); err != nil {
+		return fmt.Errorf("panel layout %q: %w", name, err)
+	}
+	return nil
+}
+
 // LoadPanelLayout loads a panel layout definition from the datafiles directory.
 // name is relative to the panel-layouts/ subdirectory and has no extension.
 // Example: LoadPanelLayout("character/status")
@@ -370,11 +633,12 @@ func LoadPanelLayout(name string) (*PanelLayout, error) {
 	}
 
 	layout := &PanelLayout{
-		border: border,
-		chars:  chars,
-		gap:    gap,
-		margin: def.Margin,
-		byID:   make(map[string]*Panel),
+		border:       border,
+		chars:        chars,
+		gap:          gap,
+		margin:       def.Margin,
+		defaultColor: def.DefaultColor,
+		byID:         make(map[string]*Panel),
 	}
 
 	for _, sd := range def.Slots {
@@ -506,16 +770,23 @@ func renderPanel(p *Panel) []string {
 
 	var lines []string
 
-	// Top border: TopLeft + Horizontal + " " + title + " " + Horizontal... + TopRight
-	// The title is used verbatim (may contain ANSI tags); its visual width is measured stripped.
-	titleVW := panelVisualWidth(p.title)
-	// visible structure: TL + H + " " + title + " " + H*n + TR
-	// that is 1 + 1 + 1 + titleVW + 1 + n + 1 = inner + 2*panelPad + 2
-	dashCount := inner + 2*panelPad + 2 - 1 - 1 - 1 - titleVW - 1 - 1
-	if dashCount < 0 {
-		dashCount = 0
+	// Top border.
+	// With title:    TopLeft + H + " " + title + " " + H*n + TopRight
+	// Without title: TopLeft + H*(inner + 2*panelPad) + TopRight
+	var topBorder string
+	if p.title == "" {
+		topBorder = c.TopLeft + strings.Repeat(c.Horizontal, inner+2*panelPad) + c.TopRight
+	} else {
+		titleVW := panelVisualWidth(p.title)
+		// visible structure: TL + H + " " + title + " " + H*n + TR
+		// that is 1 + 1 + 1 + titleVW + 1 + n + 1 = inner + 2*panelPad + 2
+		dashCount := inner + 2*panelPad + 2 - 1 - 1 - 1 - titleVW - 1 - 1
+		if dashCount < 0 {
+			dashCount = 0
+		}
+		topBorder = c.TopLeft + c.Horizontal + " " + p.title + " " + strings.Repeat(c.Horizontal, dashCount) + c.TopRight
 	}
-	lines = append(lines, c.TopLeft+c.Horizontal+" "+p.title+" "+strings.Repeat(c.Horizontal, dashCount)+c.TopRight)
+	lines = append(lines, topBorder)
 
 	nRows := len(p.rows)
 

--- a/internal/templates/panel.go
+++ b/internal/templates/panel.go
@@ -82,11 +82,14 @@ func charsetForName(name string) borderChars {
 // PanelRow is one label+value line inside a panel.
 // The renderer uses FullLabel when it fits the panel width, ShortLabel otherwise.
 // Set Blank to true to insert an empty spacer line; label and value are ignored.
+// When MaxWidth > 0, the value is word-wrapped at that visual width; continuation
+// lines are indented to align with the value column of the first line.
 type PanelRow struct {
 	FullLabel  string
 	ShortLabel string
 	Value      string
 	Blank      bool
+	MaxWidth   int
 }
 
 // Panel holds the rows for one titled box. Obtain via PanelLayout.Panel(id).
@@ -94,6 +97,7 @@ type Panel struct {
 	id         string
 	title      string // raw title string, may contain ANSI tags; used verbatim in the top border
 	minWidth   int
+	maxWidth   int // if > 0, value fields are wrapped at this visual width using SplitStringOnSpaces
 	border     borderStyle
 	chars      borderChars
 	columns    int // 1 (default) or 2: how many label+value pairs share a line
@@ -103,11 +107,27 @@ type Panel struct {
 }
 
 // Add appends a label+value row and returns the panel for chaining.
+// If the panel has a non-zero MaxWidth set, the value will be wrapped at that width.
 func (p *Panel) Add(fullLabel, shortLabel, value string) *Panel {
 	p.rows = append(p.rows, PanelRow{
 		FullLabel:  fullLabel,
 		ShortLabel: shortLabel,
 		Value:      value,
+		MaxWidth:   p.maxWidth,
+	})
+	return p
+}
+
+// AddWithMaxWidth appends a label+value row with an explicit maximum value width,
+// overriding the panel-level MaxWidth for this row.
+// When the value's visual width exceeds maxWidth, it is wrapped onto continuation
+// lines indented to align with the value column of the first line.
+func (p *Panel) AddWithMaxWidth(fullLabel, shortLabel, value string, maxWidth int) *Panel {
+	p.rows = append(p.rows, PanelRow{
+		FullLabel:  fullLabel,
+		ShortLabel: shortLabel,
+		Value:      value,
+		MaxWidth:   maxWidth,
 	})
 	return p
 }
@@ -241,6 +261,7 @@ type panelDef struct {
 	ID        string `yaml:"id"`
 	Title     string `yaml:"title"`
 	MinWidth  int    `yaml:"min_width"`
+	MaxWidth  int    `yaml:"max_width"`  // optional; when > 0, value fields are wrapped at this visual width
 	Columns   int    `yaml:"columns"`    // optional, default 1
 	ColumnGap int    `yaml:"column_gap"` // optional, default 2
 	Charset   string `yaml:"charset"`    // optional, overrides layout-level charset
@@ -325,6 +346,12 @@ func (p *Panel) SetTitle(title string) *Panel { p.title = title; return p }
 
 // SetMinWidth sets the panel's minimum inner content width.
 func (p *Panel) SetMinWidth(w int) *Panel { p.minWidth = w; return p }
+
+// SetMaxWidth sets the panel's value wrap width.
+// When non-zero, value fields added via Add are wrapped at this visual width
+// using word-boundary splitting. Continuation lines are indented to align
+// with the value column of the first line.
+func (p *Panel) SetMaxWidth(w int) *Panel { p.maxWidth = w; return p }
 
 // SetLabelWidth sets a fixed visual width that all labels are padded to.
 // When non-zero, every label is right-padded with spaces to this width before
@@ -456,6 +483,9 @@ func ValidatePanelLayout(yamlData string) ([]PanelValidationIssue, error) {
 				if pd.MinWidth < 0 {
 					add(fmt.Sprintf("%s (id=%q): min_width must be >= 0", loc, pd.ID))
 				}
+				if pd.MaxWidth < 0 {
+					add(fmt.Sprintf("%s (id=%q): max_width must be >= 0", loc, pd.ID))
+				}
 				if pd.Charset != "" && !validCharsets[pd.Charset] && len([]rune(pd.Charset)) != 8 {
 					add(fmt.Sprintf("%s (id=%q): unknown charset %q", loc, pd.ID, pd.Charset))
 				}
@@ -525,6 +555,7 @@ func PreviewPanelLayout(yamlData string, stripAnsi bool) (string, error) {
 					id:        pd.ID,
 					title:     title,
 					minWidth:  pd.MinWidth,
+					maxWidth:  pd.MaxWidth,
 					border:    border,
 					chars:     panelChars,
 					columns:   cols,
@@ -662,6 +693,7 @@ func LoadPanelLayout(name string) (*PanelLayout, error) {
 					id:        pd.ID,
 					title:     pd.Title,
 					minWidth:  pd.MinWidth,
+					maxWidth:  pd.MaxWidth,
 					border:    border,
 					chars:     panelChars,
 					columns:   cols,
@@ -703,6 +735,9 @@ func panelInnerWidth(p *Panel) int {
 				lw = p.labelWidth
 			}
 			vw := panelVisualWidth(row.Value)
+			if row.MaxWidth > 0 && vw > row.MaxWidth {
+				vw = row.MaxWidth
+			}
 			needed := lw + 1 + vw
 			if needed > width {
 				width = needed
@@ -795,7 +830,7 @@ func renderPanel(p *Panel) []string {
 		for i, row := range p.rows {
 			isFirst := i == 0
 			isLast := i == nRows-1
-			lines = append(lines, renderSingleColumnLine(p, row, inner, isFirst, isLast))
+			lines = append(lines, renderSingleColumnLines(p, row, inner, isFirst, isLast)...)
 		}
 	} else {
 		// Multi-column layout: pair up rows.
@@ -840,33 +875,83 @@ func renderPanel(p *Panel) []string {
 	return lines
 }
 
-// renderSingleColumnLine renders one content line for a single-column panel.
-func renderSingleColumnLine(p *Panel, row PanelRow, inner int, isFirst, isLast bool) string {
+// renderSingleColumnLines renders one content row for a single-column panel,
+// returning one or more lines. When row.MaxWidth > 0 and the value exceeds that
+// width, the value is split and continuation lines are indented to align with
+// the value column of the first line.
+func renderSingleColumnLines(p *Panel, row PanelRow, inner int, isFirst, isLast bool) []string {
 	c := p.chars
-	var content string
+	borderLine := func(content string) string {
+		if p.border == borderFull || isFirst || isLast {
+			return c.VerticalLeft + content + c.VerticalRight
+		}
+		return " " + content + " "
+	}
+
 	if row.Blank {
-		content = strings.Repeat(" ", inner+2*panelPad)
-	} else {
-		label := chooseLabel(row, inner)
-		lw := panelVisualWidth(label)
-		if p.labelWidth > lw {
-			label = label + strings.Repeat(" ", p.labelWidth-lw)
-			lw = p.labelWidth
-		}
-		vw := panelVisualWidth(row.Value)
-		rightPad := inner - lw - 1 - vw
-		if rightPad < 0 {
-			rightPad = 0
-		}
-		content = strings.Repeat(" ", panelPad) +
-			label + " " + row.Value +
-			strings.Repeat(" ", rightPad) +
-			strings.Repeat(" ", panelPad)
+		return []string{borderLine(strings.Repeat(" ", inner+2*panelPad))}
 	}
-	if p.border == borderFull || isFirst || isLast {
-		return c.VerticalLeft + content + c.VerticalRight
+
+	label := chooseLabel(row, inner)
+	lw := panelVisualWidth(label)
+	if p.labelWidth > lw {
+		label = label + strings.Repeat(" ", p.labelWidth-lw)
+		lw = p.labelWidth
 	}
-	return " " + content + " "
+
+	// valueIndent is the number of spaces to prepend on continuation lines so
+	// that they align with the value column of the first line.
+	// Layout: panelPad + label + " " + value
+	valueIndent := panelPad + lw + 1
+
+	var chunks []string
+	if row.MaxWidth > 0 {
+		for _, chunk := range ansitags.SplitStringOnSpaces(row.Value, row.MaxWidth, true) {
+			if panelVisualWidth(chunk) > 0 {
+				chunks = append(chunks, chunk)
+			}
+		}
+	}
+	if len(chunks) == 0 {
+		chunks = []string{row.Value}
+	}
+
+	var result []string
+	for ci, chunk := range chunks {
+		vw := panelVisualWidth(chunk)
+		var content string
+		if ci == 0 {
+			rightPad := inner - lw - 1 - vw
+			if rightPad < 0 {
+				rightPad = 0
+			}
+			content = strings.Repeat(" ", panelPad) +
+				label + " " + chunk +
+				strings.Repeat(" ", rightPad) +
+				strings.Repeat(" ", panelPad)
+		} else {
+			rightPad := inner + 2*panelPad - valueIndent - vw
+			if rightPad < 0 {
+				rightPad = 0
+			}
+			content = strings.Repeat(" ", valueIndent) +
+				chunk +
+				strings.Repeat(" ", rightPad)
+		}
+		// Only the first and last logical rows of the panel get border treatment
+		// from isFirst/isLast; continuation lines are never first or last.
+		if ci == 0 {
+			result = append(result, borderLine(content))
+		} else {
+			// Continuation lines: open border unless the panel uses full borders.
+			if p.border == borderFull {
+				result = append(result, c.VerticalLeft+content+c.VerticalRight)
+			} else {
+				result = append(result, " "+content+" ")
+			}
+		}
+	}
+	return result
 }
 
 // composePanelGroup renders a group of panels side by side into a slice of lines.

--- a/internal/templates/panel.go
+++ b/internal/templates/panel.go
@@ -21,31 +21,60 @@ const (
 	defaultColumnGap = 2 // spaces between columns when columns > 1
 )
 
-// borderChars holds the six characters used to draw a panel border.
+// borderChars holds the characters used to draw a panel border.
 type borderChars struct {
-	TopLeft     string // e.g. ┌
-	TopRight    string // e.g. ┐
-	BottomLeft  string // e.g. └
-	BottomRight string // e.g. ┘
-	Horizontal  string // e.g. ─
-	Vertical    string // e.g. │
+	TopLeft          string // e.g. ┌
+	TopRight         string // e.g. ┐
+	BottomLeft       string // e.g. └
+	BottomRight      string // e.g. ┘
+	Horizontal       string // e.g. ─  (top border horizontal fill)
+	HorizontalBottom string // e.g. ─  (bottom border horizontal fill)
+	VerticalLeft     string // e.g. │  (left side of content rows)
+	VerticalRight    string // e.g. │  (right side of content rows)
 }
 
 var (
-	charsetSingle  = borderChars{"┌", "┐", "└", "┘", "─", "│"}
-	charsetDouble  = borderChars{"╔", "╗", "╚", "╝", "═", "║"}
-	charsetRounded = borderChars{"╭", "╮", "╰", "╯", "─", "│"}
+	charsetSingle  = borderChars{"┌", "┐", "└", "┘", "─", "─", "│", "│"}
+	charsetDouble  = borderChars{"╔", "╗", "╚", "╝", "═", "═", "║", "║"}
+	charsetRounded = borderChars{"╭", "╮", "╰", "╯", "─", "─", "│", "│"}
 )
 
+// charsetForName returns the borderChars for a named preset or a literal
+// string.
+//
+// Named presets: "single" (default), "double", "rounded".
+//
+// Literal format - exactly 8 Unicode code points in order:
+//
+//	[TopLeft][HorizontalTop][TopRight][VerticalLeft][VerticalRight][BottomLeft][HorizontalBottom][BottomRight]
+//
+// Example: "\u2554\u2550\u2557\u2551\u2502\u255a\u2500\u2518"  (double top/left, single bottom/right)
 func charsetForName(name string) borderChars {
 	switch strings.ToLower(name) {
 	case "double":
 		return charsetDouble
 	case "rounded":
 		return charsetRounded
-	default:
+	case "", "single":
 		return charsetSingle
 	}
+	// Try to parse as an 8-rune literal:
+	// TopLeft, HorizontalTop, TopRight, VerticalLeft, VerticalRight,
+	// BottomLeft, HorizontalBottom, BottomRight.
+	runes := []rune(name)
+	if len(runes) == 8 {
+		return borderChars{
+			TopLeft:          string(runes[0]),
+			Horizontal:       string(runes[1]),
+			TopRight:         string(runes[2]),
+			VerticalLeft:     string(runes[3]),
+			VerticalRight:    string(runes[4]),
+			BottomLeft:       string(runes[5]),
+			HorizontalBottom: string(runes[6]),
+			BottomRight:      string(runes[7]),
+		}
+	}
+	return charsetSingle
 }
 
 // PanelRow is one label+value line inside a panel.
@@ -275,8 +304,10 @@ func (l *PanelLayout) AddPanelsToSlot(slot *LayoutSlot, ids ...string) {
 }
 
 // SetCharset sets the border character set for this panel, overriding the
-// layout-level charset. Recognised values: "single", "double", "rounded".
-// An unrecognised value falls back to "single".
+// layout-level charset. Accepts a named preset ("single", "double", "rounded")
+// or a 7-rune literal string in the order:
+// TopLeft, Horizontal, TopRight, VerticalLeft, VerticalRight, BottomLeft, BottomRight.
+// Example literal: "╔═╗║║╚╝". An unrecognised value falls back to "single".
 func (p *Panel) SetCharset(name string) *Panel { p.chars = charsetForName(name); return p }
 
 // SetTitle sets the panel's title string verbatim.
@@ -525,7 +556,7 @@ func renderPanel(p *Panel) []string {
 			}
 
 			if p.border == borderFull || isFirst || isLast {
-				lines = append(lines, c.Vertical+content+c.Vertical)
+				lines = append(lines, c.VerticalLeft+content+c.VerticalRight)
 			} else {
 				lines = append(lines, " "+content+" ")
 			}
@@ -533,7 +564,7 @@ func renderPanel(p *Panel) []string {
 	}
 
 	// Bottom border
-	lines = append(lines, c.BottomLeft+strings.Repeat(c.Horizontal, inner+2*panelPad)+c.BottomRight)
+	lines = append(lines, c.BottomLeft+strings.Repeat(c.HorizontalBottom, inner+2*panelPad)+c.BottomRight)
 
 	return lines
 }
@@ -562,7 +593,7 @@ func renderSingleColumnLine(p *Panel, row PanelRow, inner int, isFirst, isLast b
 			strings.Repeat(" ", panelPad)
 	}
 	if p.border == borderFull || isFirst || isLast {
-		return c.Vertical + content + c.Vertical
+		return c.VerticalLeft + content + c.VerticalRight
 	}
 	return " " + content + " "
 }
@@ -600,7 +631,7 @@ func composePanelGroup(panels []*Panel, gap int) []string {
 
 		var blankLine string
 		if p.border == borderFull {
-			blankLine = p.chars.Vertical + blankContent + p.chars.Vertical
+			blankLine = p.chars.VerticalLeft + blankContent + p.chars.VerticalRight
 		} else {
 			blankLine = " " + blankContent + " "
 		}

--- a/internal/templates/panel_test.go
+++ b/internal/templates/panel_test.go
@@ -180,7 +180,7 @@ func TestRenderPanel_BlankRow(t *testing.T) {
 	got := renderPanel(p)
 	require.Equal(t, 5, len(got))
 	inner := panelInnerWidth(p)
-	assert.Equal(t, "│"+strings.Repeat(" ", inner+2*panelPad)+"│", got[2])
+	assert.Equal(t, charsetSingle.VerticalLeft+strings.Repeat(" ", inner+2*panelPad)+charsetSingle.VerticalRight, got[2])
 }
 
 func TestRenderPanel_AllLinesEqualVisualWidth(t *testing.T) {
@@ -462,6 +462,26 @@ func TestCharsetForName(t *testing.T) {
 	assert.Equal(t, charsetRounded, charsetForName("rounded"))
 }
 
+func TestCharsetForName_LiteralString(t *testing.T) {
+	// 8-rune literal: TL HTop TR VL VR BL HBottom BR
+	got := charsetForName("╔═╗║│╚─┘")
+	assert.Equal(t, "╔", got.TopLeft)
+	assert.Equal(t, "═", got.Horizontal)
+	assert.Equal(t, "╗", got.TopRight)
+	assert.Equal(t, "║", got.VerticalLeft)
+	assert.Equal(t, "│", got.VerticalRight)
+	assert.Equal(t, "╚", got.BottomLeft)
+	assert.Equal(t, "─", got.HorizontalBottom)
+	assert.Equal(t, "┘", got.BottomRight)
+}
+
+func TestCharsetForName_LiteralString_WrongLength_FallsBackToSingle(t *testing.T) {
+	// 7 runes – not 8 – should fall back to single
+	assert.Equal(t, charsetSingle, charsetForName("╔═╗║│╚┘"))
+	// 9 runes – not 8 – should fall back to single
+	assert.Equal(t, charsetSingle, charsetForName("╔═╗║║╚╝═─"))
+}
+
 func TestRenderPanel_Charset_Double(t *testing.T) {
 	p := makePanel("x", "X", 8, borderFull, []PanelRow{
 		{FullLabel: "A:", ShortLabel: "A:", Value: "1"},
@@ -470,7 +490,8 @@ func TestRenderPanel_Charset_Double(t *testing.T) {
 	got := renderPanel(p)
 	assert.True(t, strings.HasPrefix(got[0], "\u2554"), "double top-left corner")
 	assert.True(t, strings.HasSuffix(got[0], "\u2557"), "double top-right corner")
-	assert.True(t, strings.HasPrefix(got[1], "\u2551"), "double vertical")
+	assert.True(t, strings.HasPrefix(got[1], "\u2551"), "double vertical-left")
+	assert.True(t, strings.HasSuffix(got[1], "\u2551"), "double vertical-right")
 	assert.True(t, strings.HasPrefix(got[len(got)-1], "\u255a"), "double bottom-left corner")
 	assert.True(t, strings.HasSuffix(got[len(got)-1], "\u255d"), "double bottom-right corner")
 }
@@ -487,8 +508,25 @@ func TestRenderPanel_Charset_Rounded(t *testing.T) {
 	assert.True(t, strings.HasSuffix(got[len(got)-1], "\u256f"), "rounded bottom-right corner")
 }
 
+func TestRenderPanel_Charset_Literal_DistinctLeftRight(t *testing.T) {
+	// Use a charset where VerticalLeft (║) != VerticalRight (│) and
+	// HorizontalTop (═) != HorizontalBottom (─) to verify each side uses the
+	// correct character.
+	p := makePanel("x", "X", 8, borderFull, []PanelRow{
+		{FullLabel: "A:", ShortLabel: "A:", Value: "1"},
+	})
+	p.chars = charsetForName("╔═╗║│╚─┘")
+	got := renderPanel(p)
+	assert.True(t, strings.HasPrefix(got[1], "\u2551"), "content row left border is VerticalLeft")
+	assert.True(t, strings.HasSuffix(got[1], "\u2502"), "content row right border is VerticalRight")
+	assert.True(t, strings.HasPrefix(got[0], "\u2554"), "top border uses TopLeft")
+	assert.True(t, strings.Contains(got[0], "\u2550"), "top border uses HorizontalTop")
+	assert.True(t, strings.HasPrefix(got[len(got)-1], "\u255a"), "bottom border uses BottomLeft")
+	assert.True(t, strings.Contains(got[len(got)-1], "\u2500"), "bottom border uses HorizontalBottom")
+	assert.True(t, strings.HasSuffix(got[len(got)-1], "\u2518"), "bottom border uses BottomRight")
+}
+
 func TestRenderPanel_PerPanelCharset_OverridesLayout(t *testing.T) {
-	// Two panels in the same layout: one single (default), one double (override).
 	pSingle := makePanel("a", "A", 8, borderFull, []PanelRow{
 		{FullLabel: "X:", ShortLabel: "X:", Value: "1"},
 	})

--- a/internal/templates/panel_test.go
+++ b/internal/templates/panel_test.go
@@ -557,8 +557,82 @@ func TestRenderPanel_PerPanelCharset_OverridesLayout(t *testing.T) {
 	}
 }
 
+func TestRenderPanel_MaxWidth_WrapsValue(t *testing.T) {
+	// Value "hello world" (11 chars) with MaxWidth=5:
+	// SplitStringOnSpaces produces ["hello", "world"] = 2 non-empty chunks.
+	p := makePanel("x", "X", 20, borderFull, []PanelRow{
+		{FullLabel: "Desc:", ShortLabel: "D:", Value: "hello world", MaxWidth: 5},
+	})
+	got := renderPanel(p)
+	// top border + 2 content lines + bottom border = 4
+	require.Equal(t, 4, len(got), "should have a continuation line")
+	assert.Contains(t, got[1], "Desc:")
+	assert.Contains(t, got[1], "hello")
+	assert.Contains(t, got[2], "world")
+	// Continuation line must NOT contain the label.
+	assert.NotContains(t, got[2], "Desc:")
+}
+
+func TestRenderPanel_MaxWidth_ContinuationAlignsWithValue(t *testing.T) {
+	// Continuation lines must be indented by panelPad + labelWidth + 1 spaces,
+	// which is the same offset as the value column on the first line.
+	// SplitStringOnSpaces("aaa bbb", 3) produces ["aaa", "bbb"] (2 non-empty chunks).
+	p := makePanel("x", "X", 30, borderFull, []PanelRow{
+		{FullLabel: "Label:", ShortLabel: "L:", Value: "aaa bbb", MaxWidth: 3},
+	})
+	got := renderPanel(p)
+	require.Equal(t, 4, len(got), "should have one continuation line")
+
+	// Expected indent: panelPad + visualWidth("Label:") + 1
+	expectedIndent := panelPad + panelVisualWidth("Label:") + 1
+
+	// Strip ANSI and border from the continuation line, then count leading spaces.
+	line2 := ansitags.Parse(got[2], ansitags.StripTags)
+	line2Runes := []rune(line2)
+	line2Body := string(line2Runes[1:]) // remove leading border rune (│)
+	actualIndent := len([]rune(line2Body)) - len([]rune(strings.TrimLeft(line2Body, " ")))
+	assert.Equal(t, expectedIndent, actualIndent, "continuation line should be indented to value column")
+}
+
+func TestRenderPanel_MaxWidth_AllLinesEqualVisualWidth(t *testing.T) {
+	p := makePanel("x", "X", 30, borderFull, []PanelRow{
+		{FullLabel: "Note:", ShortLabel: "N:", Value: "one two three four five", MaxWidth: 9},
+	})
+	got := renderPanel(p)
+	w0 := panelVisualWidth(got[0])
+	for i, line := range got {
+		assert.Equal(t, w0, panelVisualWidth(line), "line %d visual width differs", i)
+	}
+}
+
+func TestRenderPanel_MaxWidth_Zero_NoWrap(t *testing.T) {
+	// MaxWidth=0 means no wrapping; behaves identically to a plain Add row.
+	p := makePanel("x", "X", 20, borderFull, []PanelRow{
+		{FullLabel: "A:", ShortLabel: "A:", Value: "hello world", MaxWidth: 0},
+	})
+	got := renderPanel(p)
+	// top + 1 content + bottom = 3
+	require.Equal(t, 3, len(got))
+	assert.Contains(t, got[1], "hello world")
+}
+
+func TestRenderPanel_MaxWidth_AnsiTagsHandled(t *testing.T) {
+	// ANSI tags must not be mangled across split boundaries.
+	value := `<ansi fg="yellow">hello</ansi> <ansi fg="green">world</ansi>`
+	p := makePanel("x", "X", 30, borderFull, []PanelRow{
+		{FullLabel: "A:", ShortLabel: "A:", Value: value, MaxWidth: 5},
+	})
+	got := renderPanel(p)
+	// Should produce at least 2 content lines.
+	require.GreaterOrEqual(t, len(got), 4)
+	// All lines must have equal visual width.
+	w0 := panelVisualWidth(got[0])
+	for i, line := range got {
+		assert.Equal(t, w0, panelVisualWidth(line), "line %d visual width differs", i)
+	}
+}
+
 func TestRenderPanel_TitleUsedVerbatim(t *testing.T) {
-	// Title is used as-is; no prefix/suffix is added by the renderer.
 	p := makePanel("x", `<ansi fg="20">MyTitle</ansi>`, 15, borderFull, []PanelRow{
 		{FullLabel: "A:", ShortLabel: "A:", Value: "1"},
 	})

--- a/internal/usercommands/admin.grant.go
+++ b/internal/usercommands/admin.grant.go
@@ -34,7 +34,7 @@ func Grant(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 
 	lastWord := args[len(args)-1]
 
-	if len(args) >= 2 && (len(lastWord) >= 3 && lastWord[0:3] == `exp` || lastWord == `xp`) {
+	if len(args) >= 2 && ((len(lastWord) >= 3 && lastWord[0:3] == `exp`) || lastWord == `xp`) {
 
 		expAmt := 0
 

--- a/internal/usercommands/admin.item.go
+++ b/internal/usercommands/admin.item.go
@@ -458,6 +458,10 @@ func item_Create(rest string, user *users.UserRecord, room *rooms.Room, flags ev
 	}
 
 	itemInst := items.GetItemSpec(newItemId)
+	if itemInst == nil {
+		user.SendText("Error: item spec not found after creation.")
+		return true, nil
+	}
 
 	user.SendText(``)
 	user.SendText(`  <ansi bg="red" fg="white-bold">ITEM CREATED</ansi>`)

--- a/internal/usercommands/admin.locate.go
+++ b/internal/usercommands/admin.locate.go
@@ -78,6 +78,9 @@ func Locate(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 	for _, mobId := range mobs.GetAllMobInstanceIds() {
 
 		mob := mobs.GetInstance(mobId)
+		if mob == nil {
+			continue
+		}
 
 		if !listAll {
 			testName := strings.ToLower(mob.Character.Name)

--- a/internal/usercommands/admin.mob.go
+++ b/internal/usercommands/admin.mob.go
@@ -455,6 +455,10 @@ func mob_Create(rest string, user *users.UserRecord, room *rooms.Room, flags eve
 	}
 
 	mobInst := mobs.GetMobSpec(mobId)
+	if mobInst == nil {
+		user.SendText("Error: mob spec not found after creation.")
+		return true, nil
+	}
 
 	user.SendText(``)
 	user.SendText(`  <ansi bg="red" fg="white-bold">MOB CREATED</ansi>`)

--- a/internal/usercommands/admin.room.go
+++ b/internal/usercommands/admin.room.go
@@ -1033,7 +1033,7 @@ func room_Edit_Containers(rest string, user *users.UserRecord, room *rooms.Room,
 					return true, nil
 				}
 
-				if question.Response != `skip` {
+				if question.Response != `skip` && len(question.Response) > 0 {
 
 					removeItem := false
 					if question.Response[0] == '-' {

--- a/internal/usercommands/admin.server.go
+++ b/internal/usercommands/admin.server.go
@@ -40,7 +40,7 @@ func Server(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 
 	args := util.SplitButRespectQuotes(rest)
 	if args[0] == "config" {
-		return server_Config(strings.TrimSpace(rest[7:]), user, room, flags)
+		return server_Config(strings.TrimSpace(rest[6:]), user, room, flags)
 	}
 
 	if args[0] == "set" {

--- a/internal/usercommands/admin.spell.go
+++ b/internal/usercommands/admin.spell.go
@@ -329,6 +329,10 @@ func spell_Create(rest string, user *users.UserRecord, room *rooms.Room, flags e
 	}
 
 	spellSpec := spells.GetSpell(spellId)
+	if spellSpec == nil {
+		user.SendText("Error: spell spec not found after creation.")
+		return true, nil
+	}
 
 	user.SendText(``)
 	user.SendText(`  <ansi bg="red" fg="white-bold">SPELL CREATED</ansi>`)

--- a/internal/usercommands/attack.go
+++ b/internal/usercommands/attack.go
@@ -44,7 +44,7 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 		if attackMobInstanceId == 0 {
 			for _, uId := range room.GetPlayers(rooms.FindFightingPlayer) {
 				u := users.GetByUserId(uId)
-				if u.Character.Aggro == nil {
+				if u == nil || u.Character.Aggro == nil {
 					continue
 				}
 

--- a/internal/usercommands/conditions.panels.go
+++ b/internal/usercommands/conditions.panels.go
@@ -11,13 +11,12 @@ import (
 )
 
 func buildConditionsPanel(user *users.UserRecord) string {
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "conditions")
-
-	layout.Panel("conditions").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Conditions</ansi> `).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("character/conditions")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "conditions")
+		layout.Panel("conditions").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Conditions</ansi> `).SetMinWidth(74)
+	}
 
 	charBuffs := user.Character.GetBuffs()
 	if len(charBuffs) == 0 {

--- a/internal/usercommands/cooldowns.panels.go
+++ b/internal/usercommands/cooldowns.panels.go
@@ -13,13 +13,12 @@ import (
 func buildCooldownsPanel(user *users.UserRecord) string {
 	allCooldowns := user.Character.GetAllCooldowns()
 
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "cooldowns")
-
-	layout.Panel("cooldowns").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Cooldowns</ansi> `).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("character/cooldowns")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "cooldowns")
+		layout.Panel("cooldowns").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Cooldowns</ansi> `).SetMinWidth(74)
+	}
 
 	if len(allCooldowns) == 0 {
 		layout.Panel("cooldowns").Add(``, ``, `<ansi fg="black-bold">None</ansi>`)

--- a/internal/usercommands/descriptions.panels.go
+++ b/internal/usercommands/descriptions.panels.go
@@ -17,12 +17,13 @@ func buildInspectPanel(inspectLevel int, itm *items.Item, iSpec *items.ItemSpec)
 
 	// Basic Info panel
 	{
-		layout := templates.NewPanelLayout("open", "single", 1, 1)
-		slot := layout.AddSlot()
-		layout.AddPanelsToSlot(slot, "basic")
-		layout.Panel("basic").
-			SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Basic Info</ansi> `).
-			SetMinWidth(74).SetLabelWidth(13)
+		layout, err := templates.LoadPanelLayout("inspect/basic")
+		if err != nil {
+			layout = templates.NewPanelLayout("open", "single", 1, 1)
+			layout.AddPanelsToSlot(layout.AddSlot(), "basic")
+			layout.Panel("basic").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Basic Info</ansi> `).SetMinWidth(74)
+		}
+		layout.Panel("basic").SetLabelWidth(13)
 
 		p := layout.Panel("basic")
 		p.Add(`<ansi fg="yellow">Name:</ansi>`, `<ansi fg="yellow">Name:</ansi>`, strings.ToUpper(itm.Name()))
@@ -43,12 +44,13 @@ func buildInspectPanel(inspectLevel int, itm *items.Item, iSpec *items.ItemSpec)
 
 	// Specific Stats panel
 	{
-		layout := templates.NewPanelLayout("open", "single", 1, 1)
-		slot := layout.AddSlot()
-		layout.AddPanelsToSlot(slot, "stats")
-		layout.Panel("stats").
-			SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Specific Stats</ansi> `).
-			SetMinWidth(74).SetLabelWidth(13)
+		layout, err := templates.LoadPanelLayout("inspect/stats")
+		if err != nil {
+			layout = templates.NewPanelLayout("open", "single", 1, 1)
+			layout.AddPanelsToSlot(layout.AddSlot(), "stats")
+			layout.Panel("stats").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Specific Stats</ansi> `).SetMinWidth(74)
+		}
+		layout.Panel("stats").SetLabelWidth(13)
 
 		p := layout.Panel("stats")
 		if inspectLevel > 1 {
@@ -90,12 +92,13 @@ func buildInspectPanel(inspectLevel int, itm *items.Item, iSpec *items.ItemSpec)
 
 	// Modifiers panel
 	{
-		layout := templates.NewPanelLayout("open", "single", 1, 1)
-		slot := layout.AddSlot()
-		layout.AddPanelsToSlot(slot, "mods")
-		layout.Panel("mods").
-			SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Modifiers</ansi> `).
-			SetMinWidth(74).SetLabelWidth(13)
+		layout, err := templates.LoadPanelLayout("inspect/mods")
+		if err != nil {
+			layout = templates.NewPanelLayout("open", "single", 1, 1)
+			layout.AddPanelsToSlot(layout.AddSlot(), "mods")
+			layout.Panel("mods").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Modifiers</ansi> `).SetMinWidth(74)
+		}
+		layout.Panel("mods").SetLabelWidth(13)
 
 		p := layout.Panel("mods")
 		if inspectLevel > 2 {
@@ -188,12 +191,13 @@ func buildInspectPanel(inspectLevel int, itm *items.Item, iSpec *items.ItemSpec)
 
 	// Magical Effects panel
 	{
-		layout := templates.NewPanelLayout("open", "single", 1, 1)
-		slot := layout.AddSlot()
-		layout.AddPanelsToSlot(slot, "magic")
-		layout.Panel("magic").
-			SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Magical Effects</ansi> `).
-			SetMinWidth(74).SetLabelWidth(13)
+		layout, err := templates.LoadPanelLayout("inspect/magic")
+		if err != nil {
+			layout = templates.NewPanelLayout("open", "single", 1, 1)
+			layout.AddPanelsToSlot(layout.AddSlot(), "magic")
+			layout.Panel("magic").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Magical Effects</ansi> `).SetMinWidth(74)
+		}
+		layout.Panel("magic").SetLabelWidth(13)
 
 		p := layout.Panel("magic")
 		if inspectLevel > 3 {
@@ -244,12 +248,12 @@ func buffDurationString(spec *buffs.BuffSpec) string {
 }
 
 func buildTrackPanel(visitors []trackingInfo) string {
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "track")
-	layout.Panel("track").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Recent Visitors</ansi> `).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("room/track")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "track")
+		layout.Panel("track").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Recent Visitors</ansi> `).SetMinWidth(74)
+	}
 
 	p := layout.Panel("track")
 	if len(visitors) == 0 {
@@ -302,10 +306,12 @@ func buildRoomDescPanel(details rooms.RoomTemplateDetails) string {
 }
 
 func buildInsideContainerPanel(itemNames []string, itemNamesFormatted []string) string {
-	layout := templates.NewPanelLayout("open", "single", 1, 0)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "inside")
-	layout.Panel("inside").SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("room/container-inside")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 0)
+		layout.AddPanelsToSlot(layout.AddSlot(), "inside")
+		layout.Panel("inside").SetMinWidth(74)
+	}
 
 	p := layout.Panel("inside")
 	if len(itemNames) == 0 {
@@ -348,12 +354,13 @@ func buildTrainPanel(data TrainingOptions) string {
 	out.WriteString(`Type "<ansi fg="command">help [skill_name]</ansi>" to find out more` + term.CRLFStr)
 	out.WriteString(term.CRLFStr)
 
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "train")
-	layout.Panel("train").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Skills Taught Here</ansi> `).
-		SetMinWidth(74).SetLabelWidth(12)
+	layout, err := templates.LoadPanelLayout("room/train")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "train")
+		layout.Panel("train").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Skills Taught Here</ansi> `).SetMinWidth(74)
+	}
+	layout.Panel("train").SetLabelWidth(12)
 
 	p := layout.Panel("train")
 	for _, opt := range data.Options {
@@ -381,12 +388,13 @@ func buildTrainPanel(data TrainingOptions) string {
 }
 
 func buildBiomePanel(biome *rooms.BiomeInfo) string {
-	layout := templates.NewPanelLayout("open", "single", 1, 0)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "biome")
-	layout.Panel("biome").
-		SetTitle(` <ansi fg="black-bold">.:</ansi> Biome Info `).
-		SetMinWidth(74).SetLabelWidth(13)
+	layout, err := templates.LoadPanelLayout("room/biome")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 0)
+		layout.AddPanelsToSlot(layout.AddSlot(), "biome")
+		layout.Panel("biome").SetTitle(` <ansi fg="black-bold">.:</ansi> Biome Info `).SetMinWidth(74)
+	}
+	layout.Panel("biome").SetLabelWidth(13)
 
 	var lighting string
 	if biome.IsDark() {

--- a/internal/usercommands/descriptions.panels.go
+++ b/internal/usercommands/descriptions.panels.go
@@ -27,14 +27,7 @@ func buildInspectPanel(inspectLevel int, itm *items.Item, iSpec *items.ItemSpec)
 
 		p := layout.Panel("basic")
 		p.Add(`<ansi fg="yellow">Name:</ansi>`, `<ansi fg="yellow">Name:</ansi>`, strings.ToUpper(itm.Name()))
-		descLines := util.SplitString(iSpec.Description, 60)
-		for i, line := range descLines {
-			label := ``
-			if i == 0 {
-				label = `<ansi fg="yellow">Description:</ansi>`
-			}
-			p.Add(label, label, line)
-		}
+		p.Add(`<ansi fg="yellow">Description:</ansi>`, `<ansi fg="yellow">Description:</ansi>`, iSpec.Description)
 		p.Add(`<ansi fg="yellow">Type:</ansi>`, `<ansi fg="yellow">Type:</ansi>`,
 			fmt.Sprintf(`<ansi fg="white">%s</ansi> (<ansi fg="white">%s</ansi>)`, strings.ToUpper(iSpec.Type.String()), strings.ToUpper(iSpec.Subtype.String())))
 		p.Add(`<ansi fg="yellow">Value:</ansi>`, `<ansi fg="yellow">Val:</ansi>`,
@@ -144,7 +137,7 @@ func buildInspectPanel(inspectLevel int, itm *items.Item, iSpec *items.ItemSpec)
 				for _, flag := range spec.Flags {
 					allFlags := buffs.GetAllFlags()
 					if desc, ok := allFlags[flag]; ok {
-						p.Add(``, ``, fmt.Sprintf(`  <ansi fg="cyan">%s</ansi>`, desc))
+						p.Add(``, ``, fmt.Sprintf(`- <ansi fg="cyan">%s</ansi>`, desc))
 					}
 				}
 				added = true
@@ -409,14 +402,7 @@ func buildBiomePanel(biome *rooms.BiomeInfo) string {
 	p.Add(`<ansi fg="yellow">Name:</ansi>`, `<ansi fg="yellow">Name:</ansi>`, biome.Name)
 	p.Add(`<ansi fg="yellow">Symbol:</ansi>`, `<ansi fg="yellow">Sym:</ansi>`, biome.SymbolString())
 	p.Add(`<ansi fg="yellow">Lighting:</ansi>`, `<ansi fg="yellow">Light:</ansi>`, lighting)
-	biomeDescLines := util.SplitString(biome.Description, 60)
-	for i, line := range biomeDescLines {
-		label := ``
-		if i == 0 {
-			label = `<ansi fg="yellow">Description:</ansi>`
-		}
-		p.Add(label, label, line)
-	}
+	p.Add(`<ansi fg="yellow">Description:</ansi>`, `<ansi fg="yellow">Description:</ansi>`, biome.Description)
 
 	return layout.Render() + term.CRLFStr
 }

--- a/internal/usercommands/get.go
+++ b/internal/usercommands/get.go
@@ -135,7 +135,7 @@ func Get(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		container := room.Containers[containerName]
 
 		goldName := `gold`
-		if args[0] == goldName || (len(args[0]) < 5 && goldName[0:len(args[0])-1] == args[0]) {
+		if args[0] == goldName || (len(args[0]) >= 1 && len(args[0]) < 5 && goldName[0:len(args[0])] == args[0]) {
 
 			if container.Gold < 1 {
 				user.SendText("There's no gold to grab.")
@@ -207,7 +207,7 @@ func Get(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 	} else {
 
 		goldName := `gold`
-		if args[0] == goldName || (len(args[0]) < 5 && goldName[0:len(args[0])-1] == args[0]) {
+		if args[0] == goldName || (len(args[0]) >= 1 && len(args[0]) < 5 && goldName[0:len(args[0])] == args[0]) {
 
 			if room.Gold < 1 {
 				user.SendText("There's no gold to grab.")

--- a/internal/usercommands/jobs.panels.go
+++ b/internal/usercommands/jobs.panels.go
@@ -40,13 +40,12 @@ func buildJobsPanel(user *users.UserRecord) string {
 		return strings.Compare(rows[i].name, rows[j].name) == -1
 	})
 
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "jobs")
-
-	layout.Panel("jobs").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Jobs</ansi> `).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("character/jobs")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "jobs")
+		layout.Panel("jobs").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Jobs</ansi> `).SetMinWidth(74)
+	}
 
 	if len(rows) == 0 {
 		layout.Panel("jobs").Add(``, ``, `No jobs. Train skills to unlock professions.`)

--- a/internal/usercommands/look.panels.go
+++ b/internal/usercommands/look.panels.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/items"
 	"github.com/GoMudEngine/GoMud/internal/templates"
 	"github.com/GoMudEngine/GoMud/internal/term"
-	"github.com/GoMudEngine/GoMud/internal/util"
 )
 
 // buildDescriptionPanel renders the character/description template as a panel.
@@ -23,9 +22,7 @@ func buildDescriptionPanel(c *characters.Character) string {
 
 	panel := layout.Panel("desc")
 
-	for _, line := range util.SplitString(c.GetDescription(), 72) {
-		panel.Add(``, ``, line)
-	}
+	panel.Add(``, ``, c.GetDescription())
 	panel.Add(``, ``, c.GetHealthAppearance())
 
 	return layout.Render() + term.CRLFStr
@@ -44,9 +41,7 @@ func buildCorpseDescriptionPanel(c *characters.Character) string {
 
 	panel := layout.Panel("desc")
 	panel.Add(``, ``, skulls)
-	for _, line := range util.SplitString(c.GetDescription(), 72) {
-		panel.Add(``, ``, fmt.Sprintf(`<ansi fg="8">%s</ansi>`, line))
-	}
+	panel.Add(``, ``, fmt.Sprintf(`<ansi fg="8">%s</ansi>`, c.GetDescription()))
 	panel.Add(``, ``, `<ansi fg="8">This is a corpse. They are dead.</ansi>`)
 	panel.Add(``, ``, skulls)
 

--- a/internal/usercommands/look.panels.go
+++ b/internal/usercommands/look.panels.go
@@ -14,13 +14,12 @@ import (
 // buildDescriptionPanel renders the character/description template as a panel.
 // It accepts a *characters.Character and the viewing user's id.
 func buildDescriptionPanel(c *characters.Character) string {
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "desc")
-
-	layout.Panel("desc").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi> `).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("character/description")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "desc")
+		layout.Panel("desc").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi> `).SetMinWidth(74)
+	}
 
 	panel := layout.Panel("desc")
 
@@ -34,13 +33,12 @@ func buildDescriptionPanel(c *characters.Character) string {
 
 // buildCorpseDescriptionPanel renders the character/description-corpse template as a panel.
 func buildCorpseDescriptionPanel(c *characters.Character) string {
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "desc")
-
-	layout.Panel("desc").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi> `).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("character/description")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "desc")
+		layout.Panel("desc").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi> `).SetMinWidth(74)
+	}
 
 	skulls := `<ansi fg="red-bold">☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠ ☠</ansi>`
 
@@ -58,14 +56,13 @@ func buildCorpseDescriptionPanel(c *characters.Character) string {
 // buildInventoryLookPanel renders the character/inventory-look template as a panel.
 // equipment is *characters.Worn, itemNames is the list of carried item display names.
 func buildInventoryLookPanel(equipment *characters.Worn, itemNames []string) string {
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "equip")
-
-	layout.Panel("equip").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi> `).
-		SetMinWidth(74).
-		SetLabelWidth(9)
+	layout, err := templates.LoadPanelLayout("character/equipment-look")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "equip")
+		layout.Panel("equip").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Equipment</ansi> `).SetMinWidth(74)
+	}
+	layout.Panel("equip").SetLabelWidth(9)
 
 	panel := layout.Panel("equip")
 
@@ -122,12 +119,12 @@ func buildPetPanel(c *characters.Character, isOwner bool) string {
 
 	// Description panel
 	{
-		layout := templates.NewPanelLayout("open", "single", 1, 1)
-		slot := layout.AddSlot()
-		layout.AddPanelsToSlot(slot, "desc")
-		layout.Panel("desc").
-			SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi> `).
-			SetMinWidth(74)
+		layout, err := templates.LoadPanelLayout("character/description")
+		if err != nil {
+			layout = templates.NewPanelLayout("open", "single", 1, 1)
+			layout.AddPanelsToSlot(layout.AddSlot(), "desc")
+			layout.Panel("desc").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Description</ansi> `).SetMinWidth(74)
+		}
 
 		panel := layout.Panel("desc")
 		panel.Add(``, ``,
@@ -143,12 +140,12 @@ func buildPetPanel(c *characters.Character, isOwner bool) string {
 	// Abilities panel (owner only)
 	if isOwner {
 		if ab := c.Pet.GetCurrentAbilityDisplay(); ab != nil {
-			layout := templates.NewPanelLayout("open", "single", 1, 1)
-			slot := layout.AddSlot()
-			layout.AddPanelsToSlot(slot, "abilities")
-			layout.Panel("abilities").
-				SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Abilities</ansi> `).
-				SetMinWidth(74)
+			layout, err := templates.LoadPanelLayout("character/pet")
+			if err != nil {
+				layout = templates.NewPanelLayout("open", "single", 1, 1)
+				layout.AddPanelsToSlot(layout.AddSlot(), "abilities")
+				layout.Panel("abilities").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Abilities</ansi> `).SetMinWidth(74)
+			}
 
 			panel := layout.Panel("abilities")
 

--- a/internal/usercommands/party.go
+++ b/internal/usercommands/party.go
@@ -226,12 +226,17 @@ func Party(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 				}
 
 				u := users.GetByUserId(uid)
+				if u == nil {
+					continue
+				}
 				uLevel := fmt.Sprintf(`%d`, u.Character.Level)
 				uRoom := rooms.LoadRoom(u.Character.RoomId)
-				//uHealth := fmt.Sprintf(`%d/%d`, u.Character.Health, u.Character.HealthMax.Value)
+				uLoc := `-`
+				if uRoom != nil {
+					uLoc = uRoom.Title
+				}
 				uHealthPct := int(math.Floor((float64(u.Character.Health) / float64(u.Character.HealthMax.Value)) * 100))
 				uHealthPctStr := fmt.Sprintf(`%d%%`, uHealthPct)
-				uLoc := uRoom.Title
 				rank := currentParty.GetRank(u.UserId)
 				healthClass := util.HealthClass(u.Character.Health, u.Character.HealthMax.Value)
 
@@ -269,7 +274,14 @@ func Party(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 
 			for _, mobInstanceId := range charmedMobInstanceIds {
 				m := mobs.GetInstance(mobInstanceId)
+				if m == nil {
+					continue
+				}
 				mRoom := rooms.LoadRoom(m.Character.RoomId)
+				mLoc := `-`
+				if mRoom != nil {
+					mLoc = mRoom.Title
+				}
 				mHealthPct := int(math.Floor((float64(m.Character.Health) / float64(m.Character.HealthMax.Value)) * 100))
 				rows = append(rows, []string{
 					m.Character.Name,
@@ -277,7 +289,7 @@ func Party(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 					fmt.Sprintf(`%d`, m.Character.Level),
 					//fmt.Sprintf(`%d/%d`, m.Character.Health, m.Character.HealthMax.Value),
 					fmt.Sprintf(`%d%%`, mHealthPct),
-					mRoom.Title,
+					mLoc,
 					`-`,
 				})
 
@@ -294,6 +306,9 @@ func Party(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 
 			for _, uid := range currentParty.InviteUserIds {
 				u := users.GetByUserId(uid)
+				if u == nil {
+					continue
+				}
 				rows = append(rows, []string{
 					u.Character.Name,
 					`Invited`,

--- a/internal/usercommands/picklock.go
+++ b/internal/usercommands/picklock.go
@@ -180,6 +180,10 @@ func Picklock(rest string, user *users.UserRecord, room *rooms.Room, flags event
 	entered += r
 
 	for i := 0; i < len(entered); i++ {
+		if i >= len(sequence) {
+			entered = ``
+			break
+		}
 		if entered[i] == '*' {
 			continue
 		}

--- a/internal/usercommands/quests.panels.go
+++ b/internal/usercommands/quests.panels.go
@@ -23,13 +23,13 @@ func buildQuestsPanel(rows []questRow, questsFound, questsTotal int) string {
 		questsFound, questsTotal,
 	)
 
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "quests")
-
-	layout.Panel("quests").
-		SetTitle(title).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("character/quests")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "quests")
+		layout.Panel("quests").SetMinWidth(74)
+	}
+	layout.Panel("quests").SetTitle(title)
 
 	panel := layout.Panel("quests")
 

--- a/internal/usercommands/set.go
+++ b/internal/usercommands/set.go
@@ -23,12 +23,11 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		user.SendText(`<ansi fg="yellow">` + util.SplitStringNL(user.Character.Description, 80) + `</ansi>`)
 		user.SendText(``)
 
-		user.SendText(`<ansi fg="yellow-bold">ScreenReader:</ansi> `)
+		screenReaderTxt := `<ansi fg="red">OFF</ansi>`
 		if user.ScreenReader {
-			user.SendText(`<ansi fg="green">ON</ansi>`)
-		} else {
-			user.SendText(`<ansi fg="red">OFF</ansi>`)
+			screenReaderTxt = `<ansi fg="green">ON</ansi>`
 		}
+		user.SendText(`<ansi fg="yellow-bold">ScreenReader:</ansi> ` + screenReaderTxt)
 		user.SendText(``)
 
 		on := user.GetConfigOption(`auction`)
@@ -36,8 +35,7 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		if on == nil || on.(bool) {
 			onTxt = `<ansi fg="green">ON</ansi>`
 		}
-		user.SendText(`<ansi fg="yellow-bold">auction:</ansi> `)
-		user.SendText(onTxt)
+		user.SendText(`<ansi fg="yellow-bold">auction:</ansi> ` + onTxt)
 		user.SendText(``)
 
 		on = user.GetConfigOption(`shortadjectives`)
@@ -45,8 +43,7 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		if on == nil || on.(bool) {
 			onTxt = `<ansi fg="green">ON</ansi>`
 		}
-		user.SendText(`<ansi fg="yellow-bold">shortadjectives:</ansi> `)
-		user.SendText(onTxt)
+		user.SendText(`<ansi fg="yellow-bold">shortadjectives:</ansi> ` + onTxt)
 		user.SendText(``)
 
 		on = user.GetConfigOption(`tinymap`)
@@ -54,40 +51,35 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		if on == nil || on.(bool) {
 			onTxt = `<ansi fg="green">ON</ansi>`
 		}
-		user.SendText(`<ansi fg="yellow-bold">tinymap:</ansi> `)
-		user.SendText(onTxt)
+		user.SendText(`<ansi fg="yellow-bold">tinymap:</ansi> ` + onTxt)
 		user.SendText(``)
 
 		currentPrompt := user.GetConfigOption(`prompt`)
 		if currentPrompt == nil {
 			currentPrompt = c.Prompt.String()
 		}
-		user.SendText(`<ansi fg="yellow-bold">prompt: </ansi> `)
-		user.SendText(currentPrompt.(string))
+		user.SendText(`<ansi fg="yellow-bold">prompt:</ansi> ` + currentPrompt.(string))
 		user.SendText(``)
 
 		currentPrompt = user.GetConfigOption(`fprompt`)
 		if currentPrompt == nil {
 			currentPrompt = c.Prompt.String()
 		}
-		user.SendText(`<ansi fg="yellow-bold">fprompt:</ansi> `)
-		user.SendText(currentPrompt.(string))
+		user.SendText(`<ansi fg="yellow-bold">fprompt:</ansi> ` + currentPrompt.(string))
 		user.SendText(``)
 
 		currentWimpy := user.GetConfigOption(`wimpy`)
 		if currentWimpy == nil {
 			currentWimpy = 0
 		}
-		user.SendText(`<ansi fg="yellow-bold">wimpy:</ansi> `)
-		user.SendText(fmt.Sprintf(`%d%%`, currentWimpy.(int)))
+		user.SendText(fmt.Sprintf(`<ansi fg="yellow-bold">wimpy:</ansi> %d%%`, currentWimpy.(int)))
 		user.SendText(``)
 
 		currentStyle := user.GetConfigOption(`shopstyle`)
 		if currentStyle == nil {
 			currentStyle = "default"
 		}
-		user.SendText(`<ansi fg="yellow-bold">shopstyle:</ansi> `)
-		user.SendText(fmt.Sprintf(`%s`, currentStyle))
+		user.SendText(`<ansi fg="yellow-bold">shopstyle:</ansi> ` + currentStyle.(string))
 		user.SendText(``)
 
 		user.SendText(`See: <ansi fg="command">help set</ansi>`)
@@ -123,7 +115,7 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		}
 		if !on.(bool) {
 			on = true
-			user.SendText(`Auctions toggled <ansi fg="red">ON</ansi>.`)
+			user.SendText(`Auctions toggled <ansi fg="green">ON</ansi>.`)
 		} else {
 			on = false
 			user.SendText(`Auctions toggled <ansi fg="red">OFF</ansi>.`)
@@ -147,7 +139,7 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		}
 		if !on.(bool) {
 			on = true
-			user.SendText(`Short Adjectives toggled <ansi fg="red">ON</ansi>.`)
+			user.SendText(`Short Adjectives toggled <ansi fg="green">ON</ansi>.`)
 		} else {
 			on = false
 			user.SendText(`Short Adjectives toggled <ansi fg="red">OFF</ansi>.`)
@@ -171,7 +163,7 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		}
 		if !on.(bool) {
 			on = true
-			user.SendText(`Tinymap toggled <ansi fg="red">ON</ansi>.`)
+			user.SendText(`Tinymap toggled <ansi fg="green">ON</ansi>.`)
 		} else {
 			on = false
 			user.SendText(`Tinymap toggled <ansi fg="red">OFF</ansi>.`)
@@ -204,8 +196,6 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		promptStr := rest[len(setTarget)+1:]
 
 		if promptStr == `default` {
-			user.SetConfigOption(`prompt`, nil)
-			user.SetConfigOption(`prompt-compiled`, nil)
 			user.SetConfigOption(`prompt`, c.Prompt.String())
 			user.SetConfigOption(`prompt-compiled`, util.ConvertColorShortTags(c.Prompt.String()))
 		} else if promptStr == `none` {
@@ -277,13 +267,16 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 			return true, nil
 		}
 
-		wimpyStr := rest[len(setTarget)+1:]
-		wimipyInt, _ := strconv.Atoi(wimpyStr)
+		wimpyStr := args[0]
+		wimpyInt, _ := strconv.Atoi(wimpyStr)
 
-		if wimipyInt == 0 {
+		if wimpyInt <= 0 {
 			user.SetConfigOption(`wimpy`, nil)
 		} else {
-			user.SetConfigOption(`wimpy`, wimipyInt)
+			if wimpyInt > 99 {
+				wimpyInt = 99
+			}
+			user.SetConfigOption(`wimpy`, wimpyInt)
 		}
 
 		user.SendText("wimpy set.")
@@ -337,7 +330,7 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		if user.ScreenReader {
 			user.SendText(`ScreenReader mode toggled <ansi fg="red">OFF</ansi>.`)
 		} else {
-			user.SendText(`ScreenReader mode toggled <ansi fg="red">ON</ansi>.`)
+			user.SendText(`ScreenReader mode toggled <ansi fg="green">ON</ansi>.`)
 		}
 		user.ScreenReader = !user.ScreenReader
 
@@ -384,6 +377,7 @@ func Set(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 
 			for _, cmd := range allComands {
 
+				cmd = strings.TrimSpace(cmd)
 				if len(cmd) > 0 {
 					if cmd[0] == '=' {
 						user.SendText(`You cannot reference macros inside of a macro`)

--- a/internal/usercommands/skill.brawling.throw.go
+++ b/internal/usercommands/skill.brawling.throw.go
@@ -96,6 +96,9 @@ func Throw(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 	} else if targetPlayerId > 0 {
 
 		targetUser := users.GetByUserId(targetPlayerId)
+		if targetUser == nil {
+			return true, nil
+		}
 
 		if pvpErr := room.CanPvp(user, targetUser); pvpErr != nil {
 			user.SendText(pvpErr.Error())
@@ -116,7 +119,7 @@ func Throw(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 		)
 
 		targetUser.SendText(
-			fmt.Sprintf(`<ansi fg="username">%s</ansi> hurls their <ansi fg="itemname">%s</ansi> at you.`, itemMatch.DisplayName(), user.Character.Name),
+			fmt.Sprintf(`<ansi fg="username">%s</ansi> hurls their <ansi fg="itemname">%s</ansi> at you.`, user.Character.Name, itemMatch.DisplayName()),
 		)
 
 		// Tell the old room they are leaving
@@ -161,6 +164,9 @@ func Throw(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 			user.Character.CancelBuffsWithFlag(buffs.Hidden)
 
 			throwToRoom := rooms.LoadRoom(throwRoomId)
+			if throwToRoom == nil {
+				return true, nil
+			}
 			returnExitName := throwToRoom.FindExitTo(user.Character.RoomId)
 
 			if len(returnExitName) < 1 {

--- a/internal/usercommands/skill.portal.go
+++ b/internal/usercommands/skill.portal.go
@@ -105,11 +105,12 @@ func Portal(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> draws a quick symbol in the air, and is sucked into a portal!`, user.Character.Name),
 				user.UserId,
 			)
-			newRoom := rooms.LoadRoom(portalTargetRoomId)
-			newRoom.SendText(
-				fmt.Sprintf(`<ansi fg="username">%s</ansi> suddenly pops into existence!`, user.Character.Name),
-				user.UserId,
-			)
+			if newRoom := rooms.LoadRoom(portalTargetRoomId); newRoom != nil {
+				newRoom.SendText(
+					fmt.Sprintf(`<ansi fg="username">%s</ansi> suddenly pops into existence!`, user.Character.Name),
+					user.UserId,
+				)
+			}
 		} else {
 			user.SendText("Oops, portal sad!")
 		}

--- a/internal/usercommands/skill.skulduggery.bump.go
+++ b/internal/usercommands/skill.skulduggery.bump.go
@@ -47,8 +47,8 @@ func Bump(rest string, user *users.UserRecord, room *rooms.Room, flags events.Ev
 
 	if pickPlayerId > 0 || pickMobInstanceId > 0 {
 
-		if !user.Character.TryCooldown(skills.Brawling.String(`bump`), "1 real minute") {
-			user.SendText(fmt.Sprintf("You need to wait %d rounds before you can do that again!", user.Character.GetCooldown(skills.Brawling.String(`bump`))))
+		if !user.Character.TryCooldown(skills.Skulduggery.String(`bump`), "1 real minute") {
+			user.SendText(fmt.Sprintf("You need to wait %d rounds before you can do that again!", user.Character.GetCooldown(skills.Skulduggery.String(`bump`))))
 			return true, nil
 		}
 

--- a/internal/usercommands/skill.skulduggery.pickpocket.go
+++ b/internal/usercommands/skill.skulduggery.pickpocket.go
@@ -41,6 +41,11 @@ func Pickpocket(rest string, user *users.UserRecord, room *rooms.Room, flags eve
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
+	if len(args) < 1 {
+		user.SendText("Pickpocket who?")
+		return true, nil
+	}
+
 	pickPlayerId, pickMobInstanceId := room.FindByName(args[0])
 
 	if pickPlayerId > 0 || pickMobInstanceId > 0 {

--- a/internal/usercommands/skills.panels.go
+++ b/internal/usercommands/skills.panels.go
@@ -12,13 +12,12 @@ import (
 func buildSkillsPanel(user *users.UserRecord) string {
 	allSkills := user.Character.GetSkills()
 
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "skills")
-
-	layout.Panel("skills").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Skills</ansi> `).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("character/skills")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "skills")
+		layout.Panel("skills").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Skills</ansi> `).SetMinWidth(74)
+	}
 
 	if len(allSkills) == 0 {
 		layout.Panel("skills").Add(``, ``, `No Skills! Visit a guild or training center to train.`)

--- a/internal/usercommands/status.panels.go
+++ b/internal/usercommands/status.panels.go
@@ -86,13 +86,13 @@ func buildStatusPanel(user *users.UserRecord) string {
 func buildStatusTrainPanel(user *users.UserRecord, highlighted string) string {
 	c := user.Character
 
-	layout := templates.NewPanelLayout("open", "single", 1, 2)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "train")
-
-	layout.Panel("train").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Base Value</ansi> `).
-		SetMinWidth(38).SetLabelWidth(12)
+	layout, err := templates.LoadPanelLayout("character/stat-train")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 2)
+		layout.AddPanelsToSlot(layout.AddSlot(), "train")
+		layout.Panel("train").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">Base Value</ansi> `).SetMinWidth(38)
+	}
+	layout.Panel("train").SetLabelWidth(12)
 
 	type statEntry struct {
 		name  string

--- a/internal/usercommands/suicide.go
+++ b/internal/usercommands/suicide.go
@@ -68,9 +68,9 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room, flags events
 
 			if i > 0 {
 				if i < dmgCt-1 {
-					killedBy += ` and `
-				} else {
 					killedBy += `, `
+				} else {
+					killedBy += ` and `
 				}
 			}
 			killedBy += `<ansi fg="username">` + u.Character.Name + `</ansi>`
@@ -197,11 +197,9 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room, flags events
 					var pct float64 = 0.0
 
 					percent, err := strconv.ParseInt(string(config.Death.XPPenalty)[0:len(config.Death.XPPenalty)-1], 10, 64)
-					if err != nil || percent < 0 || percent > 100 {
-						pct = 0.0
+					if err == nil && percent >= 0 && percent <= 100 {
+						pct = float64(percent) / 100.0
 					}
-
-					pct = float64(percent) / 100.0
 
 					loss := int(math.Floor(float64(user.Character.Experience) * pct))
 					user.Character.Experience -= loss

--- a/internal/web/admin_nav.go
+++ b/internal/web/admin_nav.go
@@ -219,6 +219,14 @@ func buildAdminNav() []WebNavItem {
 					},
 				},
 				{
+					Name:   "Panels",
+					Target: "/admin/panels",
+					SubItems: []WebNavSub{
+						{Label: "View / Edit", Target: "/admin/panels"},
+						{Label: "API Docs", Target: "/admin/panels-api"},
+					},
+				},
+				{
 					Name:   "Scripting",
 					Target: "/admin/scripting-api",
 					SubItems: []WebNavSub{

--- a/internal/web/admin_panels.go
+++ b/internal/web/admin_panels.go
@@ -1,0 +1,11 @@
+package web
+
+import "net/http"
+
+func adminPanels(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "panels.html", nil)
+}
+
+func adminPanelsAPI(w http.ResponseWriter, r *http.Request) {
+	serveAdminTemplate(w, r, "panels-api.html", nil)
+}

--- a/internal/web/admin_routes.go
+++ b/internal/web/admin_routes.go
@@ -82,5 +82,8 @@ func registerAdminRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("GET /admin/scripting-api", doBasicAuth(RunWithMUDLocked(adminScriptingAPI)))
 
+	mux.HandleFunc("GET /admin/panels", doBasicAuth(RunWithMUDLocked(adminPanels)))
+	mux.HandleFunc("GET /admin/panels-api", doBasicAuth(RunWithMUDLocked(adminPanelsAPI)))
+
 	registerAdminAPIRoutes(mux)
 }

--- a/internal/web/api_routes.go
+++ b/internal/web/api_routes.go
@@ -156,6 +156,12 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /admin/api/v1/gametime/{calendar}", doBasicAuth(RunWithMUDLocked(apiV1PatchGameTimeCalendar)))
 	mux.HandleFunc("DELETE /admin/api/v1/gametime/{calendar}", doBasicAuth(RunWithMUDLocked(apiV1DeleteGameTimeCalendar)))
 
+	// Panels
+	mux.HandleFunc("GET /admin/api/v1/panels", doBasicAuth(RunWithMUDLocked(apiV1GetPanels)))
+	mux.HandleFunc("POST /admin/api/v1/panels/validate", doBasicAuth(RunWithMUDLocked(apiV1PostPanelValidate)))
+	mux.HandleFunc("POST /admin/api/v1/panels/preview", doBasicAuth(RunWithMUDLocked(apiV1PostPanelPreview)))
+	mux.HandleFunc("PUT /admin/api/v1/panels/{panelname...}", doBasicAuth(RunWithMUDLocked(apiV1PutPanel)))
+
 	// Spells - script sub-route before wildcard {spellId}
 	mux.HandleFunc("GET /admin/api/v2/spells", doBasicAuth(RunWithMUDLocked(apiV2GetSpells)))
 	mux.HandleFunc("POST /admin/api/v2/spells", doBasicAuth(RunWithMUDLocked(apiV2CreateSpell)))

--- a/internal/web/api_v1_panels.go
+++ b/internal/web/api_v1_panels.go
@@ -1,0 +1,134 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/templates"
+)
+
+type panelEntry struct {
+	Name string `json:"name"`
+	YAML string `json:"yaml"`
+}
+
+// GET /admin/api/v1/panels
+// Returns an array of all panel layout files and their YAML content.
+func apiV1GetPanels(w http.ResponseWriter, r *http.Request) {
+	layouts, err := templates.ListPanelLayouts()
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	result := make([]panelEntry, len(layouts))
+	for i, l := range layouts {
+		result[i] = panelEntry{Name: l.Name, YAML: l.YAML}
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[[]panelEntry]{
+		Success: true,
+		Data:    result,
+	})
+}
+
+// POST /admin/api/v1/panels/validate
+// Accepts a panel layout YAML body and returns a list of structural issues.
+// An empty issues array means the layout is valid.
+func apiV1PostPanelValidate(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		YAML string `json:"yaml"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(body.YAML) == "" {
+		writeAPIError(w, http.StatusBadRequest, "yaml is required")
+		return
+	}
+
+	issues, err := templates.ValidatePanelLayout(body.YAML)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[map[string]any]{
+		Success: true,
+		Data: map[string]any{
+			"valid":  len(issues) == 0,
+			"issues": issues,
+		},
+	})
+}
+
+// POST /admin/api/v1/panels/preview
+// Accepts a panel layout YAML body and returns two plain-text previews:
+// "preview" has ANSI tags stripped; "preview_ansi" retains them verbatim.
+func apiV1PostPanelPreview(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		YAML string `json:"yaml"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(body.YAML) == "" {
+		writeAPIError(w, http.StatusBadRequest, "yaml is required")
+		return
+	}
+
+	plain, err := templates.PreviewPanelLayout(body.YAML, true)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ansi, err := templates.PreviewPanelLayout(body.YAML, false)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[map[string]string]{
+		Success: true,
+		Data: map[string]string{
+			"preview":      plain,
+			"preview_ansi": ansi,
+		},
+	})
+}
+
+// PUT /admin/api/v1/panels/{panel-name}
+// Overwrites an existing panel layout file.
+// panel-name uses slashes encoded as %2F (or the path segment may contain
+// a wildcard catch-all so the full sub-path is preserved).
+func apiV1PutPanel(w http.ResponseWriter, r *http.Request) {
+	// The route is registered as /admin/api/v1/panels/{panel-name...} so the
+	// wildcard value already contains the full relative path.
+	name := r.PathValue("panelname")
+	if name == "" {
+		writeAPIError(w, http.StatusBadRequest, "panel name is required")
+		return
+	}
+
+	var body struct {
+		YAML string `json:"yaml"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(body.YAML) == "" {
+		writeAPIError(w, http.StatusBadRequest, "yaml is required")
+		return
+	}
+
+	if err := templates.SavePanelLayout(name, body.YAML); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}

--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -406,13 +406,12 @@ func (m *StorageModule) storageCommand(rest string, user *users.UserRecord, room
 
 // buildStorageText renders the storage listing for the player using a panel.
 func buildStorageText(itemNames []string) string {
-	layout := templates.NewPanelLayout("open", "single", 1, 1)
-	slot := layout.AddSlot()
-	layout.AddPanelsToSlot(slot, "storage")
-
-	layout.Panel("storage").
-		SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">In Storage</ansi> `).
-		SetMinWidth(74)
+	layout, err := templates.LoadPanelLayout("storage/storage")
+	if err != nil {
+		layout = templates.NewPanelLayout("open", "single", 1, 1)
+		layout.AddPanelsToSlot(layout.AddSlot(), "storage")
+		layout.Panel("storage").SetTitle(` <ansi fg="black-bold">.:</ansi><ansi fg="20">In Storage</ansi> `).SetMinWidth(74)
+	}
 
 	panel := layout.Panel("storage")
 	if len(itemNames) == 0 {


### PR DESCRIPTION
# Description

Continues the panel UI system work: converts remaining command layouts to YAML-defined panel files, adds custom border charsets, an admin preview tool, and `max_width` word-wrap support. Also includes a small `set` command reliability fix and an `ansitags` dependency update.

## Changes

- **Panel `max_width` support** — panels now accept a `max_width` field that word-wraps content to fit within the specified column width
- **Custom charsets** — panels support custom border character sets for flexible visual styling
- **Layout YAML migration** — remaining inline panel layouts converted to external YAML layout files
- **Additional panel conversions** — more command outputs migrated from templates to panel-based rendering
- **Admin panel tool** — added admin preview/editor tooling for panel layouts
- **`ansitags` dependency update** — bumped to latest version
- **`set` command bug fixes** — improved reliability of the `set` command for player preferences
