### PR TITLE
Improving room alert api

### DIFF
--- a/internal/rooms/roomdetails.go
+++ b/internal/rooms/roomdetails.go
@@ -25,7 +25,7 @@ import (
 // Example registration from a module:
 //
 //	rooms.OnRoomLook.Register(func(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
-//	    d.RoomAlerts = append(d.RoomAlerts, "You can fish here!")
+//	    d.Alert("You can fish here!")
 //	    return d
 //	})
 var OnRoomLook util.Hook[RoomTemplateDetails]
@@ -47,9 +47,20 @@ type RoomTemplateDetails struct {
 	IsDark         bool
 	IsNight        bool
 	TrackingString string
-	RoomAlerts     []string // Messages to show below room description as a special alert
-	ShowPvp        bool     // Whether to display that the room is PVP
-	Tags           []string // Tags applied to the room
+	RoomAlerts     [][]string // Messages to show below room description as a special alert
+	ShowPvp        bool       // Whether to display that the room is PVP
+	Tags           []string   // Tags applied to the room
+}
+
+// Alert appends one alert group to RoomAlerts. Each argument becomes one line
+// within the same header/footer bracket when rendered. A single string
+// containing "\n" is automatically split into multiple lines of the same group.
+func (d *RoomTemplateDetails) Alert(lines ...string) {
+	var group []string
+	for _, line := range lines {
+		group = append(group, strings.Split(line, "\n")...)
+	}
+	d.RoomAlerts = append(d.RoomAlerts, group)
 }
 
 func GetDetails(r *Room, user *users.UserRecord, tinymap ...[]string) RoomTemplateDetails {
@@ -99,15 +110,15 @@ func GetDetails(r *Room, user *users.UserRecord, tinymap ...[]string) RoomTempla
 	//
 
 	if len(r.SkillTraining) > 0 {
-		details.RoomAlerts = append(details.RoomAlerts, `<ansi fg="yellow-bold">You can train here!</ansi> Type <ansi fg="command">train</ansi> to see what training is available.`)
+		details.Alert(`<ansi fg="yellow-bold">You can train here!</ansi> Type <ansi fg="command">train</ansi> to see what training is available.`)
 	}
 
 	if r.IsBank {
-		details.RoomAlerts = append(details.RoomAlerts, `          <ansi fg="yellow-bold">This is a bank!</ansi> Type <ansi fg="command">bank</ansi> to deposit/withdraw.`)
+		details.Alert(`<ansi fg="yellow-bold">This is a bank!</ansi> Type <ansi fg="command">bank</ansi> to deposit/withdraw.`)
 	}
 
 	if r.RoomId == -1 {
-		details.RoomAlerts = append(details.RoomAlerts, `      <ansi fg="yellow-bold">Type <ansi fg="command">start</ansi> to begin playing.</ansi>`)
+		details.Alert(`<ansi fg="yellow-bold">Type <ansi fg="command">start</ansi> to begin playing.</ansi>`)
 	}
 
 	//
@@ -222,15 +233,7 @@ func GetDetails(r *Room, user *users.UserRecord, tinymap ...[]string) RoomTempla
 		// No current plans to allow them to overwrite existing alerts.
 		if mutSpec.AlertModifier != nil {
 
-			alertText := mutSpec.AlertModifier.Text
-
-			// center the text
-			if len(mutSpec.AlertModifier.Text) < 65 {
-				padding := (65 - len(mutSpec.AlertModifier.Text)) >> 1
-				alertText = strings.Repeat(` `, padding) + alertText
-			}
-
-			details.RoomAlerts = append(details.RoomAlerts, colorpatterns.ApplyColorPattern(alertText, mutSpec.AlertModifier.ColorPattern))
+			details.Alert(colorpatterns.ApplyColorPattern(mutSpec.AlertModifier.Text, mutSpec.AlertModifier.ColorPattern))
 
 		}
 	}

--- a/internal/usercommands/descriptions.panels.go
+++ b/internal/usercommands/descriptions.panels.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/templates"
 	"github.com/GoMudEngine/GoMud/internal/term"
 	"github.com/GoMudEngine/GoMud/internal/util"
+	"github.com/GoMudEngine/ansitags"
 )
 
 func buildInspectPanel(inspectLevel int, itm *items.Item, iSpec *items.ItemSpec) string {
@@ -270,6 +271,34 @@ func buildTrackPanel(visitors []trackingInfo) string {
 	return layout.Render() + term.CRLFStr
 }
 
+const (
+	alertBorderDashes = 69
+	alertContentWidth = alertBorderDashes - 2 // one space padding on each side inside the border
+)
+
+var (
+	alertBorderTop     = `    <ansi fg="red">┌` + strings.Repeat(`─`, alertBorderDashes) + `┐</ansi>`
+	alertBorderBottom  = `    <ansi fg="red">└` + strings.Repeat(`─`, alertBorderDashes) + `┘</ansi>`
+	alertContentPrefix = `    <ansi fg="red">│</ansi> `
+)
+
+// wrapAlertLine splits a single alert line into visual chunks that each fit
+// within alertContentWidth visible characters, respecting ANSI tags.
+// Blank input produces a single empty string so blank lines are preserved.
+func wrapAlertLine(line string) []string {
+	chunks := ansitags.SplitStringOnSpaces(line, alertContentWidth, true)
+	var result []string
+	for _, chunk := range chunks {
+		if len(strings.TrimSpace(ansitags.Parse(chunk, ansitags.StripTags))) > 0 {
+			result = append(result, chunk)
+		}
+	}
+	if len(result) == 0 {
+		return []string{``}
+	}
+	return result
+}
+
 func buildRoomDescPanel(details rooms.RoomTemplateDetails) string {
 	var out strings.Builder
 
@@ -279,14 +308,18 @@ func buildRoomDescPanel(details rooms.RoomTemplateDetails) string {
 	}
 	out.WriteString(fmt.Sprintf(`<ansi fg="%s">%s</ansi>`, descColor, details.Description))
 
-	for _, alert := range details.RoomAlerts {
+	for _, group := range details.RoomAlerts {
 		out.WriteString(term.CRLFStr)
 		out.WriteString(term.CRLFStr)
-		out.WriteString(`    <ansi fg="red">┌───────────────────────────────────────────────────────────────────┐</ansi>`)
+		out.WriteString(alertBorderTop)
+		for _, line := range group {
+			for _, wline := range wrapAlertLine(line) {
+				out.WriteString(term.CRLFStr)
+				out.WriteString(alertContentPrefix + wline)
+			}
+		}
 		out.WriteString(term.CRLFStr)
-		out.WriteString(`      ` + alert)
-		out.WriteString(term.CRLFStr)
-		out.WriteString(`    <ansi fg="red">└───────────────────────────────────────────────────────────────────┘</ansi>`)
+		out.WriteString(alertBorderBottom)
 	}
 
 	if details.TrackingString != `` {

--- a/internal/util/hook.go
+++ b/internal/util/hook.go
@@ -16,7 +16,7 @@ import "sync"
 // Example – registering a handler from a module:
 //
 //	rooms.OnRoomLook.Register(func(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
-//	    d.RoomAlerts = append(d.RoomAlerts, "You can fish here!")
+//	    d.Alert("You can fish here!")
 //	    return d
 //	})
 //

--- a/modules/alt-characters/alt_characters.go
+++ b/modules/alt-characters/alt_characters.go
@@ -250,9 +250,7 @@ func swapToAlt(u *users.UserRecord, targetAltName string) bool {
 func (m *AltCharactersModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
 	for _, t := range d.Tags {
 		if strings.EqualFold(t, characterTag) {
-			d.RoomAlerts = append(d.RoomAlerts,
-				`      <ansi fg="yellow-bold">This is a character room!</ansi> Type <ansi fg="command">character</ansi> to interact.`,
-			)
+			d.Alert(`<ansi fg="yellow-bold">This is a character room!</ansi> Type <ansi fg="command">character</ansi> to interact.`)
 			return d
 		}
 	}

--- a/modules/automission/automission.go
+++ b/modules/automission/automission.go
@@ -107,9 +107,7 @@ func (m *AutoMissionModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTe
 	for _, tag := range allBoardTags {
 		for _, t := range d.Tags {
 			if strings.EqualFold(t, tag) {
-				d.RoomAlerts = append(d.RoomAlerts,
-					`<ansi fg="yellow-bold">There's a mission board here!</ansi> <ansi fg="command">mission list</ansi> lists missions.`,
-				)
+				d.Alert(`<ansi fg="yellow-bold">There's a mission board here!</ansi> <ansi fg="command">mission list</ansi> lists missions.`)
 				return d
 			}
 		}

--- a/modules/elections/elections.go
+++ b/modules/elections/elections.go
@@ -890,31 +890,21 @@ func (m *ElectionsModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemp
 	for _, t := range d.Tags {
 		if strings.EqualFold(t, pollTag) {
 			if m.state.ActiveElection != nil {
-				d.RoomAlerts = append(d.RoomAlerts,
-					`<ansi fg="yellow-bold">This is a polling location!</ansi> <ansi fg="command">vote</ansi> for or <ansi fg="command">nominate</ansi> someone.`,
-				)
+				d.Alert(`<ansi fg="yellow-bold">This is a polling location!</ansi> <ansi fg="command">vote</ansi> for or <ansi fg="command">nominate</ansi> someone.`)
 			}
 		} else if strings.EqualFold(t, cofferTag) {
-			d.RoomAlerts = append(d.RoomAlerts,
-				`<ansi fg="yellow-bold">This room holds the local coffer.</ansi> Type <ansi fg="command">coffer</ansi> to manage it.`,
-			)
+			d.Alert(`<ansi fg="yellow-bold">This room holds the local coffer.</ansi> Type <ansi fg="command">coffer</ansi> to manage it.`)
 			zoneKey := strings.ToLower(d.Zone)
 			if winner, hasWinner := m.state.Winners[zoneKey]; hasWinner && winner.UserId == d.UserId {
 				rate := m.zoneTaxRate(zoneKey)
-				d.RoomAlerts = append(d.RoomAlerts,
-					fmt.Sprintf(`<ansi fg="yellow-bold">Set the zone tax rate (currently <ansi fg="white-bold">%d%%</ansi>) with <ansi fg="command">taxrate <0-100></ansi>.</ansi></ansi>`, rate),
-				)
+				d.Alert(fmt.Sprintf(`<ansi fg="yellow-bold">Set the zone tax rate (currently <ansi fg="white-bold">%d%%</ansi>) with <ansi fg="command">taxrate <0-100></ansi>.</ansi></ansi>`, rate))
 			}
 		} else if strings.EqualFold(t, officialOnlyTag) {
 			zoneKey := strings.ToLower(d.Zone)
 			if winner, hasWinner := m.state.Winners[zoneKey]; hasWinner {
-				d.RoomAlerts = append(d.RoomAlerts,
-					fmt.Sprintf(`<ansi fg="yellow-bold">This area is restricted to the <ansi fg="white-bold">%s</ansi> and their party.</ansi>`, winner.Title),
-				)
+				d.Alert(fmt.Sprintf(`<ansi fg="yellow-bold">This area is restricted to the <ansi fg="white-bold">%s</ansi> and their party.</ansi>`, winner.Title))
 			} else {
-				d.RoomAlerts = append(d.RoomAlerts,
-					`<ansi fg="yellow-bold">This area is restricted to elected officials only.</ansi>`,
-				)
+				d.Alert(`<ansi fg="yellow-bold">This area is restricted to elected officials only.</ansi>`)
 			}
 		}
 	}

--- a/modules/fasttravel/fasttravel.go
+++ b/modules/fasttravel/fasttravel.go
@@ -108,10 +108,9 @@ func (m *FastTravelModule) onPlayerDespawn(e events.Event) events.ListenerReturn
 func (m *FastTravelModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
 	for _, t := range d.Tags {
 		if strings.EqualFold(t, fastTravelTag) {
-			d.RoomAlerts = append(d.RoomAlerts,
-				`<ansi fg="yellow-bold">This is a fast travel station!</ansi>`+
-					"\n"+
-					`      <ansi fg="command">fasttravel</ansi> lists destinations, or <ansi fg="command">look fast travel</ansi> to examine it.`,
+			d.Alert(
+				`<ansi fg="yellow-bold">This is a fast travel station!</ansi>`,
+				`<ansi fg="command">fasttravel</ansi> lists destinations, or <ansi fg="command">look fast travel</ansi> to examine it.`,
 			)
 			return d
 		}

--- a/modules/gambling/claw.go
+++ b/modules/gambling/claw.go
@@ -117,9 +117,7 @@ func (g *GamblingModule) pickClawPrize() *clawPrize {
 func (g *GamblingModule) onRoomLookClaw(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
 	for _, t := range d.Tags {
 		if strings.ToLower(t) == `claw machine` {
-			d.RoomAlerts = append(d.RoomAlerts,
-				`There is a <ansi fg="cyan-bold">claw machine</ansi> here! You can <ansi fg="command">look</ansi> at or <ansi fg="command">play</ansi> it.`,
-			)
+			d.Alert(`There is a <ansi fg="cyan-bold">claw machine</ansi> here! You can <ansi fg="command">look</ansi> at or <ansi fg="command">play</ansi> it.`)
 			return d
 		}
 	}

--- a/modules/gambling/gambling.go
+++ b/modules/gambling/gambling.go
@@ -165,9 +165,7 @@ func (g *GamblingModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTempl
 	for _, t := range d.Tags {
 		tl := strings.ToLower(t)
 		if tl == `slots` || tl == `slot machine` {
-			d.RoomAlerts = append(d.RoomAlerts,
-				`There is a <ansi fg="cyan-bold">slot machine</ansi> here! You can <ansi fg="command">look</ansi> at or <ansi fg="command">play</ansi> it.`,
-			)
+			d.Alert(`There is a <ansi fg="cyan-bold">slot machine</ansi> here! You can <ansi fg="command">look</ansi> at or <ansi fg="command">play</ansi> it.`)
 			return d
 		}
 	}

--- a/modules/storage/storage.go
+++ b/modules/storage/storage.go
@@ -225,9 +225,7 @@ func (m *StorageModule) onAutoComplete(req suggestions.AutoCompleteRequest) sugg
 func (m *StorageModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
 	for _, t := range d.Tags {
 		if strings.EqualFold(t, storageTag) {
-			d.RoomAlerts = append(d.RoomAlerts,
-				` <ansi fg="yellow-bold">This is an item storage location!</ansi> Type <ansi fg="command">storage</ansi> to store/unstore.`,
-			)
+			d.Alert(`<ansi fg="yellow-bold">This is an item storage location!</ansi> Type <ansi fg="command">storage</ansi> to store/unstore.`)
 			return d
 		}
 	}


### PR DESCRIPTION
# Description

This change consolidates the room alerts in a more repeatable fashion and centralizes via an interface of `roomDetails.Alert()`

## Changes

- Added `Alert()` to room details
- Automatic padding and wrapping of alert text
- Multi-line alerts better supported.
- Updated all code everywhere that used room alerts
