### PR TITLE
Adding fishing module

### DIFF
--- a/internal/statmods/statmods.go
+++ b/internal/statmods/statmods.go
@@ -38,8 +38,14 @@ var (
 	ManaMax    StatName = `manamax`
 )
 
+var extraStatMods = map[StatName]string{}
+
+func RegisterStatMod(name StatName, description string) {
+	extraStatMods[name] = description
+}
+
 func GetStatMods() map[StatName]string {
-	return map[StatName]string{
+	result := map[StatName]string{
 		Picklock:          "Reduces the difficulty of a lock-picking attempt by this many pins.",
 		Tame:              "Increases the chance to successfully tame a creature.",
 		RacialBonusPrefix: "Flat bonus damage against a specific race in combat. Format: `racial-bonus-giant spider`.",
@@ -59,6 +65,10 @@ func GetStatMods() map[StatName]string {
 		HealthMax:         "Directly increases maximum HP (added after stat-based calculation).",
 		ManaMax:           "Directly increases maximum MP (added after stat-based calculation).",
 	}
+	for k, v := range extraStatMods {
+		result[k] = v
+	}
+	return result
 }
 
 func (s StatMods) Get(statName ...string) int {

--- a/modules/all-modules.go
+++ b/modules/all-modules.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/GoMudEngine/GoMud/modules/clibridge"
 	_ "github.com/GoMudEngine/GoMud/modules/elections"
 	_ "github.com/GoMudEngine/GoMud/modules/fasttravel"
+	_ "github.com/GoMudEngine/GoMud/modules/fishing"
 	_ "github.com/GoMudEngine/GoMud/modules/follow"
 	_ "github.com/GoMudEngine/GoMud/modules/gambling"
 	_ "github.com/GoMudEngine/GoMud/modules/gmcp"

--- a/modules/fishing/admin_api.go
+++ b/modules/fishing/admin_api.go
@@ -1,0 +1,121 @@
+package fishing
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+func (m *FishingModule) apiGetConfig(r *http.Request) (int, bool, any) {
+	return http.StatusOK, true, map[string]any{
+		"fishingroditems": m.cfg.FishingRodItemIds,
+	}
+}
+
+func (m *FishingModule) apiPatchConfig(r *http.Request) (int, bool, any) {
+	var body struct {
+		FishingRodItemIds []int `json:"fishingroditems"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return http.StatusBadRequest, false, map[string]string{"error": "malformed request body: " + err.Error()}
+	}
+
+	if body.FishingRodItemIds == nil {
+		body.FishingRodItemIds = []int{}
+	}
+	m.cfg.FishingRodItemIds = body.FishingRodItemIds
+	if err := m.plug.WriteStruct(configKey, m.cfg); err != nil {
+		return http.StatusInternalServerError, false, map[string]string{"error": "failed to save config: " + err.Error()}
+	}
+
+	return http.StatusOK, true, map[string]string{"status": "saved"}
+}
+
+func (m *FishingModule) apiGetCatchables(r *http.Request) (int, bool, any) {
+	catchables := m.cfg.Catchables
+	if catchables == nil {
+		catchables = []CatchableItem{}
+	}
+	return http.StatusOK, true, catchables
+}
+
+func (m *FishingModule) apiAddCatchable(r *http.Request) (int, bool, any) {
+	var body CatchableItem
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return http.StatusBadRequest, false, map[string]string{"error": "malformed request body: " + err.Error()}
+	}
+
+	if body.ItemId < 1 {
+		return http.StatusBadRequest, false, map[string]string{"error": "itemid is required"}
+	}
+	if body.ChanceToCatch < 1 || body.ChanceToCatch > 100 {
+		return http.StatusBadRequest, false, map[string]string{"error": "chancetocatch must be between 1 and 100"}
+	}
+
+	body.ID = m.nextCatchableId()
+	m.cfg.Catchables = append(m.cfg.Catchables, body)
+
+	if err := m.plug.WriteStruct(configKey, m.cfg); err != nil {
+		return http.StatusInternalServerError, false, map[string]string{"error": "failed to save: " + err.Error()}
+	}
+
+	return http.StatusOK, true, body
+}
+
+func (m *FishingModule) apiUpdateCatchable(r *http.Request) (int, bool, any) {
+	idStr := r.PathValue("id")
+	if idStr == "" {
+		idStr = r.URL.Query().Get("id")
+	}
+
+	id, err := strconv.Atoi(idStr)
+	if err != nil || id < 1 {
+		return http.StatusBadRequest, false, map[string]string{"error": "valid id is required"}
+	}
+
+	var body CatchableItem
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return http.StatusBadRequest, false, map[string]string{"error": "malformed request body: " + err.Error()}
+	}
+
+	if body.ChanceToCatch < 1 || body.ChanceToCatch > 100 {
+		return http.StatusBadRequest, false, map[string]string{"error": "chancetocatch must be between 1 and 100"}
+	}
+
+	for i, c := range m.cfg.Catchables {
+		if c.ID == id {
+			body.ID = id
+			m.cfg.Catchables[i] = body
+			if err := m.plug.WriteStruct(configKey, m.cfg); err != nil {
+				return http.StatusInternalServerError, false, map[string]string{"error": "failed to save: " + err.Error()}
+			}
+			return http.StatusOK, true, body
+		}
+	}
+
+	return http.StatusNotFound, false, map[string]string{"error": "catchable not found"}
+}
+
+func (m *FishingModule) apiDeleteCatchable(r *http.Request) (int, bool, any) {
+	idStr := r.PathValue("id")
+	if idStr == "" {
+		idStr = r.URL.Query().Get("id")
+	}
+
+	id, err := strconv.Atoi(idStr)
+	if err != nil || id < 1 {
+		return http.StatusBadRequest, false, map[string]string{"error": "valid id is required"}
+	}
+
+	for i, c := range m.cfg.Catchables {
+		if c.ID == id {
+			m.cfg.Catchables = append(m.cfg.Catchables[:i], m.cfg.Catchables[i+1:]...)
+			if err := m.plug.WriteStruct(configKey, m.cfg); err != nil {
+				return http.StatusInternalServerError, false, map[string]string{"error": "failed to save: " + err.Error()}
+			}
+			return http.StatusOK, true, map[string]string{"status": "deleted"}
+		}
+	}
+
+	return http.StatusNotFound, false, map[string]string{"error": "catchable not found"}
+}

--- a/modules/fishing/files/data-overlays/config.yaml
+++ b/modules/fishing/files/data-overlays/config.yaml
@@ -1,0 +1,1 @@
+FishingRodItemIds: []

--- a/modules/fishing/files/data-overlays/keywords.yaml
+++ b/modules/fishing/files/data-overlays/keywords.yaml
@@ -1,0 +1,1 @@
+fishing: fishing

--- a/modules/fishing/files/datafiles/html/admin/fishing-about.html
+++ b/modules/fishing/files/datafiles/html/admin/fishing-about.html
@@ -1,0 +1,86 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .card { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem; margin-bottom: 1.25rem; }
+    .card h2 { font-size: 1rem; margin: 0 0 0.75rem; }
+    .card p, .card li { font-size: 0.875rem; color: var(--color-text-strong); line-height: 1.6; }
+    .card ul { padding-left: 1.25rem; margin: 0.5rem 0; }
+    code { background: var(--color-surface-alt); border: 1px solid var(--color-border-light); border-radius: 3px; padding: 0.1rem 0.35rem; font-size: 0.82rem; font-family: monospace; color: var(--color-primary); }
+    .tag { display: inline-block; background: var(--color-surface-alt); border: 1px solid var(--color-border-medium); border-radius: 20px; padding: 0.15rem 0.65rem; font-size: 0.8rem; font-family: monospace; color: var(--color-primary); }
+</style>
+
+<h1>fishing - About</h1>
+<p class="subtitle">Fishing module overview and configuration reference.</p>
+
+<div class="card">
+    <h2>Overview</h2>
+    <p>
+        The fishing module lets players cast a line and catch items in specially tagged rooms.
+        Each fishing attempt consumes one use of the chosen bait and lasts up to 15 rounds.
+        Starting at round 3, a catch roll is made each round. The chance decays by 1% per round
+        after round 3, so acting quickly gives the best odds.
+    </p>
+</div>
+
+<div class="card">
+    <h2>Room Setup</h2>
+    <p>To make a room fishable, add the tag <span class="tag">fishing</span> to it via the room editor.</p>
+</div>
+
+<div class="card">
+    <h2>Player Commands</h2>
+    <ul>
+        <li><code>fishing &lt;baitname&gt;</code> &mdash; Begin fishing using the named bait item from your backpack.</li>
+        <li><code>fishing stop</code> / <code>fishing quit</code> / <code>fishing end</code> &mdash; Reel in and stop fishing.</li>
+        <li>Typing <code>fishing</code> with no argument lists available bait in your backpack.</li>
+    </ul>
+</div>
+
+<div class="card">
+    <h2>Requirements</h2>
+    <ul>
+        <li>The room must have the <span class="tag">fishing</span> tag.</li>
+        <li>The player must have a configured fishing rod item equipped in their weapon slot.
+            Configure rod item IDs on the <strong>Config</strong> page. If no rod items are configured, the rod check is skipped.</li>
+        <li>The player must have a food/edible item in their backpack to use as bait. One use is consumed per attempt.</li>
+    </ul>
+</div>
+
+<div class="card">
+    <h2>Catchable Items</h2>
+    <p>Manage catchable items on the <strong>Catchables</strong> page. Each entry has:</p>
+    <ul>
+        <li><strong>Item</strong> &mdash; The item awarded on a successful catch.</li>
+        <li><strong>Catch %</strong> &mdash; Percentage chance (1&ndash;100) that this item is eligible each roll.</li>
+        <li><strong>Required Bait</strong> &mdash; If set, this item only appears when the player uses that specific bait. Leave blank for any bait.</li>
+        <li><strong>Room IDs</strong> &mdash; If set, restricts this item to specific fishing rooms. Leave blank for all fishing rooms.</li>
+    </ul>
+    <p>
+        When a catch roll succeeds, all eligible items whose adjusted chance meets the roll are collected into
+        a pool, and one is chosen at random.
+    </p>
+</div>
+
+<div class="card">
+    <h2>Fishing Statmod</h2>
+    <p>
+        The <code>fishing</code> statmod (available on buffs and equipped items) adds to or subtracts from
+        the catch chance each round. A value of <code>+10</code> gives a 10% bonus; a value of <code>-5</code>
+        makes fishing harder.
+    </p>
+</div>
+
+<div class="card">
+    <h2>Interruptions</h2>
+    <p>Fishing is automatically cancelled when a player:</p>
+    <ul>
+        <li>Moves to a different room.</li>
+        <li>Enters combat (aggro state changes).</li>
+        <li>Is knocked out (drops to 0 HP).</li>
+        <li>Disconnects from the server.</li>
+    </ul>
+</div>
+
+{{template "footer" .}}

--- a/modules/fishing/files/datafiles/html/admin/fishing-catchables.html
+++ b/modules/fishing/files/datafiles/html/admin/fishing-catchables.html
@@ -1,0 +1,351 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .btn { padding: 0.4rem 1rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+    .btn-primary { background: var(--color-primary); color: var(--color-surface-white); }
+    .btn-primary:hover { background: var(--color-primary-hover); }
+    .btn-primary:disabled { background: var(--color-text-secondary); cursor: default; }
+    .btn-sm { padding: 0.25rem 0.6rem; font-size: 0.8rem; }
+    .btn-danger { background: var(--color-danger); color: var(--color-surface-white); }
+    .btn-danger:hover { opacity: 0.85; }
+    .btn-edit { background: var(--color-page-bg); border: 1px solid var(--color-border-medium); color: var(--color-text-strong); }
+    .btn-edit:hover { background: var(--color-hover-tint); }
+
+    #status-bar { display: none; padding: 0.6rem 1rem; border-radius: 4px; font-size: 0.875rem; margin-bottom: 1rem; }
+    #status-bar.success { background: var(--color-success-bg); color: var(--color-success-text); display: block; }
+    #status-bar.error   { background: var(--color-error-bg); color: var(--color-error-text); display: block; }
+
+    .toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+
+    .table-wrap { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; }
+    thead th { background: var(--color-border-faint); text-align: left; padding: 0.6rem 0.9rem; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-text-muted); border-bottom: 1px solid var(--color-border); }
+    tbody tr { border-bottom: 1px solid var(--color-border-light); }
+    tbody tr:last-child { border-bottom: none; }
+    tbody tr:hover:not(.form-row) { background: var(--color-surface-alt); }
+    td { padding: 0.55rem 0.9rem; font-size: 0.875rem; vertical-align: middle; }
+    td.item-cell { font-family: monospace; font-size: 0.82rem; color: var(--color-primary); }
+    td.chance-cell { text-align: center; font-weight: 600; }
+    td.actions-cell { text-align: right; white-space: nowrap; }
+    .empty-row td { padding: 2rem; text-align: center; color: var(--color-text-faint); font-style: italic; }
+
+    .form-row td { background: var(--color-surface-alt); padding: 0.75rem 0.9rem; }
+    .form-row td > .form-inner { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: flex-end; }
+    .field { display: flex; flex-direction: column; gap: 0.25rem; }
+    .field label { font-size: 0.78rem; font-weight: 600; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.03em; }
+    .field input[type="number"], .field input[type="text"] {
+        padding: 0.3rem 0.5rem; border: 1px solid var(--color-border-medium); border-radius: 3px;
+        font-size: 0.875rem; font-family: inherit; width: 100%;
+    }
+    .field-item { min-width: 220px; }
+    .field-chance { width: 90px; }
+    .field-bait { min-width: 200px; }
+    .field-rooms { min-width: 180px; }
+
+    .item-picker-wrap { display: flex; gap: 0.4rem; align-items: center; }
+    .item-picker-display {
+        flex: 1; padding: 0.3rem 0.5rem; border: 1px solid var(--color-border-medium); border-radius: 3px;
+        font-size: 0.875rem; background: var(--color-surface-white); color: var(--color-text-placeholder);
+        font-style: italic; min-height: 1.9rem; display: flex; align-items: center; cursor: pointer;
+    }
+    .item-picker-display.has-value { color: var(--color-primary); font-style: normal; font-family: monospace; }
+    .btn-pick {
+        padding: 0.25rem 0.6rem; border: 1px solid var(--color-border-medium); border-radius: 3px;
+        background: var(--color-page-bg); cursor: pointer; font-size: 0.8rem; font-weight: 600; flex-shrink: 0;
+    }
+    .btn-pick:hover { background: var(--color-hover-tint); }
+    .btn-clear {
+        padding: 0.25rem 0.5rem; border: 1px solid var(--color-border-light); border-radius: 3px;
+        background: none; cursor: pointer; font-size: 0.8rem; color: var(--color-text-faint); flex-shrink: 0;
+    }
+    .btn-clear:hover { color: var(--color-danger); border-color: var(--color-danger); }
+
+    .form-actions { display: flex; gap: 0.5rem; align-self: flex-end; }
+    .badge-any { font-size: 0.75rem; color: var(--color-text-faint); font-style: italic; }
+    .badge-rooms { font-size: 0.75rem; color: var(--color-text-faint); }
+</style>
+
+<h1>fishing - Catchable Items</h1>
+<p class="subtitle">Define what players can catch while fishing. Each entry has a percentage chance to be caught per round (starting round 3, decaying 1% per round thereafter).</p>
+
+<div id="status-bar"></div>
+
+<div class="toolbar">
+    <span id="item-count" style="font-size:0.875rem;color:var(--color-text-muted);"></span>
+    <button class="btn btn-primary" onclick="openAddForm()">+ Add Catchable</button>
+</div>
+
+<div class="table-wrap">
+    <table id="catchables-table">
+        <thead>
+            <tr>
+                <th style="width:30%">Item</th>
+                <th style="width:10%;text-align:center">Catch %</th>
+                <th style="width:22%">Required Bait</th>
+                <th style="width:22%">Room IDs</th>
+                <th style="width:16%;text-align:right">Actions</th>
+            </tr>
+        </thead>
+        <tbody id="catchables-body">
+            <tr><td colspan="5" style="padding:2rem;text-align:center;color:var(--color-text-faint);">Loading...</td></tr>
+        </tbody>
+    </table>
+</div>
+
+<script>
+(function () {
+    'use strict';
+
+    const itemNameCache = {};
+    let catchables = [];
+    let editingId = null;
+
+    // Draft state for add/edit forms
+    let draft = { itemId: 0, itemName: '', chanceToCatch: 10, baitId: 0, baitName: '', roomIds: '' };
+
+    async function init() {
+        const [catchRes, itemsRes] = await AdminAPI.all([
+            AdminAPI.get('/admin/api/v1/fishing-catchables'),
+            AdminAPI.get('/admin/api/v1/items'),
+        ]);
+        if (!catchRes.ok) { showStatus('Failed to load catchables: ' + catchRes.error, false); return; }
+        if (itemsRes.ok) {
+            const arr = Array.isArray(itemsRes.data.data) ? itemsRes.data.data : Object.values(itemsRes.data.data || {});
+            for (const item of arr) {
+                if (item.ItemId != null) itemNameCache[item.ItemId] = item.Name || '';
+            }
+        }
+        catchables = catchRes.data.data || [];
+        renderTable();
+    }
+
+    function itemLabel(id) {
+        if (!id) return '';
+        return itemNameCache[id] ? ('#' + id + ' ' + itemNameCache[id]) : ('#' + id);
+    }
+
+    function renderTable() {
+        const tbody = document.getElementById('catchables-body');
+        tbody.innerHTML = '';
+        document.getElementById('item-count').textContent = catchables.length + ' item' + (catchables.length !== 1 ? 's' : '');
+
+        if (catchables.length === 0 && editingId !== 'new') {
+            tbody.innerHTML = '<tr class="empty-row"><td colspan="5">No catchable items configured. Click "+ Add Catchable" to get started.</td></tr>';
+        }
+
+        if (editingId === 'new') {
+            tbody.appendChild(buildFormRow(null));
+        }
+
+        for (const c of catchables) {
+            if (editingId === c.id) {
+                tbody.appendChild(buildFormRow(c));
+            } else {
+                tbody.appendChild(buildDataRow(c));
+            }
+        }
+    }
+
+    function buildDataRow(c) {
+        const tr = document.createElement('tr');
+        tr.dataset.id = c.id;
+        const roomDisplay = (c.roomids && c.roomids.length > 0)
+            ? '<span class="badge-rooms">' + escHtml(c.roomids.join(', ')) + '</span>'
+            : '<span class="badge-any">All rooms</span>';
+        const baitDisplay = c.requiredbaitid
+            ? '<span style="font-family:monospace;font-size:0.82rem;color:var(--color-primary)">' + escHtml(itemLabel(c.requiredbaitid)) + '</span>'
+            : '<span class="badge-any">Any bait</span>';
+        tr.innerHTML =
+            '<td class="item-cell">' + escHtml(itemLabel(c.itemid)) + '</td>' +
+            '<td class="chance-cell">' + c.chancetocatch + '%</td>' +
+            '<td>' + baitDisplay + '</td>' +
+            '<td>' + roomDisplay + '</td>' +
+            '<td class="actions-cell">' +
+                '<button class="btn btn-sm btn-edit" onclick="startEdit(' + c.id + ')">Edit</button> ' +
+                '<button class="btn btn-sm btn-danger" onclick="deleteCatchable(' + c.id + ')">Delete</button>' +
+            '</td>';
+        return tr;
+    }
+
+    function buildFormRow(c) {
+        const isNew = !c;
+        if (isNew) {
+            draft = { itemId: 0, itemName: '', chanceToCatch: 10, baitId: 0, baitName: '', roomIds: '' };
+        } else {
+            draft = {
+                itemId: c.itemid || 0,
+                itemName: itemNameCache[c.itemid] || '',
+                chanceToCatch: c.chancetocatch || 10,
+                baitId: c.requiredbaitid || 0,
+                baitName: itemNameCache[c.requiredbaitid] || '',
+                roomIds: (c.roomids || []).join(', '),
+            };
+        }
+
+        const tr = document.createElement('tr');
+        tr.className = 'form-row';
+        tr.id = 'form-row';
+
+        const itemDisplay = draft.itemId ? itemLabel(draft.itemId) : 'none selected';
+        const itemHasValue = draft.itemId > 0;
+        const baitDisplay = draft.baitId ? itemLabel(draft.baitId) : 'any bait';
+        const baitHasValue = draft.baitId > 0;
+
+        tr.innerHTML = '<td colspan="5"><div class="form-inner">' +
+            '<div class="field field-item">' +
+                '<label>Item *</label>' +
+                '<div class="item-picker-wrap">' +
+                    '<span id="form-item-display" class="item-picker-display' + (itemHasValue ? ' has-value' : '') + '">' + escHtml(itemDisplay) + '</span>' +
+                    '<button type="button" class="btn-pick" onclick="pickFormItem()">Pick&hellip;</button>' +
+                '</div>' +
+            '</div>' +
+            '<div class="field field-chance">' +
+                '<label>Catch %</label>' +
+                '<input type="number" id="form-chance" min="1" max="100" value="' + draft.chanceToCatch + '" />' +
+            '</div>' +
+            '<div class="field field-bait">' +
+                '<label>Required Bait</label>' +
+                '<div class="item-picker-wrap">' +
+                    '<span id="form-bait-display" class="item-picker-display' + (baitHasValue ? ' has-value' : '') + '">' + escHtml(baitDisplay) + '</span>' +
+                    '<button type="button" class="btn-pick" onclick="pickFormBait()">Pick&hellip;</button>' +
+                    '<button type="button" class="btn-clear" title="Clear (any bait)" onclick="clearFormBait()">&#10005;</button>' +
+                '</div>' +
+            '</div>' +
+            '<div class="field field-rooms">' +
+                '<label>Room IDs <small style="font-weight:400;text-transform:none">(comma-separated, empty = all)</small></label>' +
+                '<input type="text" id="form-rooms" placeholder="e.g. 101, 204" value="' + escAttr(draft.roomIds) + '" />' +
+            '</div>' +
+            '<div class="form-actions">' +
+                '<button class="btn btn-primary btn-sm" onclick="saveForm(' + (isNew ? 'true' : 'false') + ',' + (isNew ? 0 : c.id) + ')">Save</button>' +
+                '<button class="btn btn-sm btn-edit" onclick="cancelForm()">Cancel</button>' +
+            '</div>' +
+        '</div></td>';
+
+        return tr;
+    }
+
+    window.pickFormItem = function () {
+        Picker.open({
+            ...PickerConfigs.items,
+            title: 'Select Catchable Item',
+            onSelect: (item) => {
+                itemNameCache[item.ItemId] = item.Name;
+                draft.itemId = item.ItemId;
+                draft.itemName = item.Name;
+                const el = document.getElementById('form-item-display');
+                if (el) { el.textContent = itemLabel(item.ItemId); el.className = 'item-picker-display has-value'; }
+            },
+        });
+    };
+
+    window.pickFormBait = function () {
+        Picker.open({
+            ...PickerConfigs.items,
+            title: 'Select Required Bait Item (food/edible only)',
+            filter: (item) => item.Type === 'food' && item.Subtype === 'edible',
+            onSelect: (item) => {
+                itemNameCache[item.ItemId] = item.Name;
+                draft.baitId = item.ItemId;
+                draft.baitName = item.Name;
+                const el = document.getElementById('form-bait-display');
+                if (el) { el.textContent = itemLabel(item.ItemId); el.className = 'item-picker-display has-value'; }
+            },
+        });
+    };
+
+    window.clearFormBait = function () {
+        draft.baitId = 0;
+        draft.baitName = '';
+        const el = document.getElementById('form-bait-display');
+        if (el) { el.textContent = 'any bait'; el.className = 'item-picker-display'; }
+    };
+
+    window.openAddForm = function () {
+        editingId = 'new';
+        renderTable();
+        const row = document.getElementById('form-row');
+        if (row) row.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    };
+
+    window.startEdit = function (id) {
+        editingId = id;
+        renderTable();
+        const row = document.getElementById('form-row');
+        if (row) row.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    };
+
+    window.cancelForm = function () {
+        editingId = null;
+        renderTable();
+    };
+
+    window.saveForm = async function (isNew, id) {
+        const chance = parseInt(document.getElementById('form-chance').value, 10);
+        const roomsRaw = document.getElementById('form-rooms').value.trim();
+
+        if (!draft.itemId) { showStatus('Please select an item.', false); return; }
+        if (isNaN(chance) || chance < 1 || chance > 100) { showStatus('Catch % must be between 1 and 100.', false); return; }
+
+        const roomIds = roomsRaw
+            ? roomsRaw.split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n) && n > 0)
+            : [];
+
+        const payload = {
+            itemid: draft.itemId,
+            chancetocatch: chance,
+            requiredbaitid: draft.baitId || 0,
+            roomids: roomIds,
+        };
+
+        let res;
+        if (isNew) {
+            res = await AdminAPI.post('/admin/api/v1/fishing-catchables', payload);
+        } else {
+            payload.id = id;
+            res = await AdminAPI.patch('/admin/api/v1/fishing-catchables/' + id, payload);
+        }
+
+        if (!res.ok) { showStatus('Error: ' + res.error, false); return; }
+
+        const saved = res.data.data;
+        if (isNew) {
+            catchables.push(saved);
+        } else {
+            catchables = catchables.map(c => c.id === id ? saved : c);
+        }
+
+        editingId = null;
+        renderTable();
+        showStatus(isNew ? 'Catchable item added.' : 'Catchable item updated.', true);
+    };
+
+    window.deleteCatchable = async function (id) {
+        const c = catchables.find(x => x.id === id);
+        const name = c ? itemLabel(c.itemid) : '#' + id;
+        if (!confirm('Delete catchable item ' + name + '?')) return;
+
+        const res = await AdminAPI.delete('/admin/api/v1/fishing-catchables/' + id);
+        if (!res.ok) { showStatus('Error: ' + res.error, false); return; }
+
+        catchables = catchables.filter(c => c.id !== id);
+        if (editingId === id) editingId = null;
+        renderTable();
+        showStatus('Deleted.', true);
+    };
+
+    function showStatus(msg, success) {
+        const bar = document.getElementById('status-bar');
+        bar.textContent = msg; bar.className = success ? 'success' : 'error';
+        clearTimeout(bar._t); bar._t = setTimeout(() => { bar.className = ''; bar.style.display = 'none'; }, 5000);
+    }
+    function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+    function escAttr(s) { return String(s).replace(/'/g, "\\'").replace(/"/g, '&quot;'); }
+
+    init();
+})();
+</script>
+
+{{template "footer" .}}

--- a/modules/fishing/files/datafiles/html/admin/fishing-config.html
+++ b/modules/fishing/files/datafiles/html/admin/fishing-config.html
@@ -1,0 +1,131 @@
+{{template "header" .}}
+
+<style>
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
+
+    .btn { padding: 0.4rem 1rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+    .btn-primary { background: var(--color-primary); color: var(--color-surface-white); }
+    .btn-primary:hover { background: var(--color-primary-hover); }
+    .btn-primary:disabled { background: var(--color-text-secondary); cursor: default; }
+    .btn-danger { background: var(--color-danger); color: var(--color-surface-white); }
+    .btn-danger:hover { opacity: 0.85; }
+
+    #status-bar { display: none; padding: 0.6rem 1rem; border-radius: 4px; font-size: 0.875rem; margin-bottom: 1rem; }
+    #status-bar.success { background: var(--color-success-bg); color: var(--color-success-text); display: block; }
+    #status-bar.error   { background: var(--color-error-bg); color: var(--color-error-text); display: block; }
+
+    .section { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem; margin-bottom: 1.5rem; }
+    .section h2 { font-size: 1rem; margin: 0 0 0.25rem; }
+    .section-desc { font-size: 0.82rem; color: var(--color-text-faint); margin-bottom: 1rem; font-style: italic; }
+
+    .rod-chips { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem; min-height: 2rem; align-items: center; }
+    .rod-chip {
+        display: inline-flex; align-items: center; gap: 0.35rem;
+        background: var(--color-surface-alt); border: 1px solid var(--color-border-medium);
+        border-radius: 20px; padding: 0.2rem 0.6rem 0.2rem 0.75rem;
+        font-size: 0.82rem; font-family: monospace; color: var(--color-primary);
+    }
+    .rod-chip-remove {
+        background: none; border: none; cursor: pointer; color: var(--color-text-faint);
+        font-size: 1rem; line-height: 1; padding: 0; margin-left: 0.1rem;
+    }
+    .rod-chip-remove:hover { color: var(--color-danger); }
+    .no-rods { color: var(--color-text-faint); font-size: 0.875rem; font-style: italic; }
+</style>
+
+<h1>fishing - Module Config</h1>
+<p class="subtitle">Configure fishing rod items. Rooms must have the <strong>fishing</strong> tag to be usable as fishing spots.</p>
+
+<div id="status-bar"></div>
+
+<div class="section">
+    <h2>Fishing Rod Items</h2>
+    <p class="section-desc">
+        Players must have one of these items equipped in their weapon slot to fish.
+        If this list is empty, no rod check is performed.
+    </p>
+    <div id="rod-chips" class="rod-chips">
+        <span class="no-rods">Loading...</span>
+    </div>
+    <button class="btn btn-primary" onclick="addRod()">+ Add Rod Item</button>
+</div>
+
+<script>
+(function () {
+    'use strict';
+    let rodItemIds = [];
+    const itemNameCache = {};
+
+    async function init() {
+        const [cfgRes, itemsRes] = await AdminAPI.all([
+            AdminAPI.get('/admin/api/v1/fishing-config'),
+            AdminAPI.get('/admin/api/v1/items'),
+        ]);
+        if (!cfgRes.ok) { showStatus('Failed to load config: ' + cfgRes.error, false); return; }
+        if (itemsRes.ok) {
+            const itemList = (itemsRes.data && itemsRes.data.data) || [];
+            const arr = Array.isArray(itemList) ? itemList : Object.values(itemList);
+            for (const item of arr) {
+                if (item.ItemId != null) itemNameCache[item.ItemId] = item.Name || '';
+            }
+        }
+        rodItemIds = (cfgRes.data && cfgRes.data.data && cfgRes.data.data.fishingroditems) || [];
+        renderChips();
+    }
+
+    function renderChips() {
+        const container = document.getElementById('rod-chips');
+        container.innerHTML = '';
+        if (rodItemIds.length === 0) {
+            container.innerHTML = '<span class="no-rods">No rod items configured &mdash; rod check is disabled.</span>';
+            return;
+        }
+        for (const id of rodItemIds) {
+            const name = itemNameCache[id] ? ('#' + id + ' ' + itemNameCache[id]) : ('#' + id);
+            const chip = document.createElement('span');
+            chip.className = 'rod-chip';
+            chip.innerHTML = escHtml(name) +
+                '<button class="rod-chip-remove" title="Remove" onclick="removeRod(' + id + ')">&times;</button>';
+            container.appendChild(chip);
+        }
+    }
+
+    window.addRod = function () {
+        Picker.open({
+            ...PickerConfigs.items,
+            title: 'Select Fishing Rod Item',
+            onSelect: async (item) => {
+                if (rodItemIds.includes(item.ItemId)) return;
+                itemNameCache[item.ItemId] = item.Name;
+                rodItemIds.push(item.ItemId);
+                renderChips();
+                await saveRods();
+            },
+        });
+    };
+
+    window.removeRod = async function (id) {
+        rodItemIds = rodItemIds.filter(x => x !== id);
+        renderChips();
+        await saveRods();
+    };
+
+    async function saveRods() {
+        const res = await AdminAPI.patch('/admin/api/v1/fishing-config', { fishingroditems: rodItemIds });
+        if (!res.ok) { showStatus('Failed to save: ' + res.error, false); }
+        else { showStatus('Saved.', true); }
+    }
+
+    function showStatus(msg, success) {
+        const bar = document.getElementById('status-bar');
+        bar.textContent = msg; bar.className = success ? 'success' : 'error';
+        clearTimeout(bar._t); bar._t = setTimeout(() => { bar.className = ''; bar.style.display = 'none'; }, 4000);
+    }
+    function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+    init();
+})();
+</script>
+
+{{template "footer" .}}

--- a/modules/fishing/files/datafiles/templates/help/fishing.template
+++ b/modules/fishing/files/datafiles/templates/help/fishing.template
@@ -1,0 +1,31 @@
+<ansi fg="yellow">fishing</ansi>
+
+  Cast a line and try your luck.
+
+  <ansi fg="yellow">Usage:</ansi>
+    <ansi fg="command">fishing <baitname></ansi> - Begin fishing using the named bait item.
+    <ansi fg="command">fishing stop</ansi>       - Reel in your line and stop fishing.
+    <ansi fg="command">fishing quit</ansi>       - Alias for <ansi fg="command">fishing stop</ansi>.
+    <ansi fg="command">fishing end</ansi>        - Alias for <ansi fg="command">fishing stop</ansi>.
+
+  <ansi fg="yellow">Requirements:</ansi>
+    - You must be in a room with a <ansi fg="cyan">fishing</ansi> tag.
+    - You must have a fishing rod equipped in your weapon slot.
+    - You must have a food item in your backpack to use as bait.
+
+  <ansi fg="yellow">How it works:</ansi>
+    When you cast your line, one use of your chosen bait is consumed. You
+    will receive flavor text each round while you wait. Starting at round 3,
+    there is a chance to catch something based on each catchable item's
+    configured chance. That chance decreases by 1% per round after round 3.
+
+    The <ansi fg="cyan">fishing</ansi> statmod (from buffs or equipped items) adds to or subtracts
+    from your catch chance each round.
+
+    A fishing attempt lasts up to 15 rounds. If nothing is caught by then,
+    the attempt ends with a disappointing message.
+
+    Certain rare catches may only appear when using a specific type of bait.
+
+    Fishing is interrupted by: moving to another room, entering combat,
+    being knocked out, or disconnecting.

--- a/modules/fishing/fishing.go
+++ b/modules/fishing/fishing.go
@@ -1,0 +1,536 @@
+package fishing
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+
+	"github.com/GoMudEngine/GoMud/internal/events"
+	"github.com/GoMudEngine/GoMud/internal/items"
+	"github.com/GoMudEngine/GoMud/internal/plugins"
+	"github.com/GoMudEngine/GoMud/internal/rooms"
+	"github.com/GoMudEngine/GoMud/internal/statmods"
+	"github.com/GoMudEngine/GoMud/internal/users"
+	"github.com/GoMudEngine/GoMud/internal/util"
+)
+
+var (
+	//go:embed files/*
+	files embed.FS
+)
+
+const (
+	maxFishingRounds = 15
+	catchStartRound  = 3
+	configKey        = `fishing-config`
+
+	fishingStatMod statmods.StatName = `fishing`
+)
+
+var flavorMessages = []string{
+	`Something stirs on the water's surface...`,
+	`Ripples appear near your line.`,
+	`Your line bobs slightly.`,
+	`A fish jumps in the distance.`,
+	`The water is still and quiet.`,
+	`You feel a faint tug... but nothing.`,
+	`A small wave laps at the bank.`,
+	`The current gently pulls your line.`,
+	`You hear a splash nearby.`,
+	`Bubbles rise near your hook.`,
+	`A shadow passes beneath the surface.`,
+	`The water shimmers in the light.`,
+	`Your line drifts lazily in the current.`,
+	`A dragonfly lands on your line briefly.`,
+	`The water is calm and peaceful.`,
+	`You notice movement beneath the surface.`,
+	`A frog croaks somewhere nearby.`,
+	`The water ripples gently around your hook.`,
+	`You feel the weight of the line in your hands.`,
+	`Something brushes past your hook...`,
+	`The surface of the water glitters like glass.`,
+	`A cool breeze drifts across the water.`,
+	`You watch a leaf drift past your line.`,
+	`The water is deep and dark beneath you.`,
+	`A heron stands motionless at the water's edge.`,
+	`The smell of mud and algae drifts up from the bank.`,
+	`A turtle surfaces briefly, then disappears.`,
+	`You hear the distant call of a bird across the water.`,
+	`The water is murky today - hard to see what lurks below.`,
+	`A gentle mist hangs just above the surface.`,
+	`Your reflection stares back at you from the still water.`,
+	`A water strider skates across the surface near your line.`,
+	`Something large moves beneath you, then is gone.`,
+	`The current shifts, pulling your line to one side.`,
+	`A cloud passes overhead, casting the water in shadow.`,
+	`You hear a plop as something drops into the water nearby.`,
+	`The line goes taut for just a moment, then relaxes.`,
+	`A school of tiny fish darts beneath the surface.`,
+	`The water here smells faintly of moss and earth.`,
+	`You adjust your grip and wait patiently.`,
+	`A kingfisher dives into the water downstream and comes up empty.`,
+	`The bobber dips slightly, then steadies itself.`,
+	`An eddy forms around your line and slowly unwinds.`,
+	`The light plays tricks on the water - is that movement?`,
+	`You hear the soft burble of water moving over stones.`,
+	`A water snake glides silently past, ignoring you.`,
+	`The surface breaks for just a moment, then seals over.`,
+	`Your arms are getting tired. You shift your stance.`,
+	`A faint ring spreads outward from somewhere near your hook.`,
+	`The water feels alive today.`,
+	`Clouds of silt drift up from the bottom, disturbed by something.`,
+	`A large bubble rises and pops at the surface.`,
+	`You catch a glimpse of silver beneath the water.`,
+	`The wind picks up briefly, sending tiny waves across the surface.`,
+	`A log drifts slowly past your position.`,
+	`You hear the creak of reeds bending in the breeze.`,
+	`The water grows darker near the far bank.`,
+	`Something nudges your line from below, then retreats.`,
+	`A splash erupts a few feet away - something feeding.`,
+	`The sun warms your back as you wait.`,
+	`You notice the water is clearer here than it looked.`,
+	`A crayfish scuttles across the bottom near your hook.`,
+	`The line trembles almost imperceptibly.`,
+	`Insects buzz lazily above the water's surface.`,
+	`A fallen branch bobs gently in the shallows.`,
+	`The water makes a soft lapping sound against the bank.`,
+	`You feel a subtle vibration travel up the line.`,
+	`A pair of ducks paddle past without a second glance.`,
+	`The light beneath the surface shifts as something moves.`,
+	`You hold your breath for a moment, then let it out slowly.`,
+	`A carp rolls lazily near the surface a short distance away.`,
+	`The bottom is barely visible through the green-tinted water.`,
+	`Something investigates your bait, then thinks better of it.`,
+}
+
+func init() {
+	m := &FishingModule{
+		plug:     plugins.New(`fishing`, `1.0`),
+		sessions: make(map[int]*FishingSession),
+	}
+
+	if err := m.plug.AttachFileSystem(files); err != nil {
+		panic(err)
+	}
+
+	statmods.RegisterStatMod(fishingStatMod, `Modifies the percentage chance to catch something while fishing. Can be negative.`)
+
+	m.plug.ReserveTags(`fishing`)
+
+	rooms.OnRoomLook.Register(m.onRoomLook)
+
+	m.plug.Web.AdminPage("Config", "fishing-config", "html/admin/fishing-config.html", true, "Modules", "Fishing", nil)
+	m.plug.Web.AdminPage("Catchables", "fishing-catchables", "html/admin/fishing-catchables.html", true, "Modules", "Fishing", nil)
+	m.plug.Web.AdminPage("About", "fishing-about", "html/admin/fishing-about.html", true, "Modules", "Fishing", nil)
+
+	m.plug.Web.RegisterPermissions(plugins.ModulePermission{
+		Key:         `fishing.write`,
+		Description: `Manage fishing module configuration and catchable items.`,
+		Category:    `Modules`,
+	})
+
+	m.plug.Web.AdminAPIEndpoint("GET", "fishing-config", m.apiGetConfig)
+	m.plug.Web.AdminAPIEndpoint("PATCH", "fishing-config", m.apiPatchConfig, `fishing.write`)
+	m.plug.Web.AdminAPIEndpoint("GET", "fishing-catchables", m.apiGetCatchables)
+	m.plug.Web.AdminAPIEndpoint("POST", "fishing-catchables", m.apiAddCatchable, `fishing.write`)
+	m.plug.Web.AdminAPIEndpoint("PATCH", "fishing-catchables/{id}", m.apiUpdateCatchable, `fishing.write`)
+	m.plug.Web.AdminAPIEndpoint("DELETE", "fishing-catchables/{id}", m.apiDeleteCatchable, `fishing.write`)
+
+	m.plug.AddUserCommand(`fishing`, m.fishingCommand, false, false)
+
+	m.plug.Callbacks.SetOnLoad(m.load)
+	m.plug.Callbacks.SetOnSave(m.save)
+
+	events.RegisterListener(events.NewRound{}, m.onNewRound)
+	events.RegisterListener(events.RoomChange{}, m.onRoomChange)
+	events.RegisterListener(events.AggroChanged{}, m.onAggroChanged)
+	events.RegisterListener(events.PlayerDrop{}, m.onPlayerDrop)
+	events.RegisterListener(events.PlayerDespawn{}, m.onPlayerDespawn)
+}
+
+type CatchableItem struct {
+	ID             int   `yaml:"id" json:"id"`
+	ItemId         int   `yaml:"itemid" json:"itemid"`
+	ChanceToCatch  int   `yaml:"chancetocatch" json:"chancetocatch"`
+	RequiredBaitId int   `yaml:"requiredbaitid,omitempty" json:"requiredbaitid"`
+	RoomIds        []int `yaml:"roomids,omitempty" json:"roomids"`
+}
+
+type FishingConfig struct {
+	FishingRodItemIds []int           `yaml:"fishingroditems"`
+	Catchables        []CatchableItem `yaml:"catchables"`
+}
+
+type FishingSession struct {
+	UserId     int
+	BaitItem   items.Item
+	StartRound uint64
+}
+
+type FishingModule struct {
+	plug     *plugins.Plugin
+	cfg      FishingConfig
+	sessions map[int]*FishingSession
+}
+
+func (m *FishingModule) load() {
+	m.plug.ReadIntoStruct(configKey, &m.cfg)
+}
+
+func (m *FishingModule) save() {
+	m.plug.WriteStruct(configKey, m.cfg)
+}
+
+func (m *FishingModule) nextCatchableId() int {
+	maxId := 0
+	for _, c := range m.cfg.Catchables {
+		if c.ID > maxId {
+			maxId = c.ID
+		}
+	}
+	return maxId + 1
+}
+
+func (m *FishingModule) cancelFishing(userId int, msg string) {
+	session, ok := m.sessions[userId]
+	if !ok {
+		return
+	}
+	delete(m.sessions, userId)
+
+	user := users.GetByUserId(userId)
+	if user == nil {
+		return
+	}
+	user.Character.SetAdjective(`fishing`, false)
+
+	if msg != `` {
+		user.SendText(msg)
+	}
+	_ = session
+}
+
+func (m *FishingModule) fishingCommand(rest string, user *users.UserRecord, room *rooms.Room, flags events.EventFlag) (bool, error) {
+
+	rest = strings.TrimSpace(rest)
+	restLower := strings.ToLower(rest)
+
+	if restLower == `stop` || restLower == `quit` || restLower == `end` {
+		if _, ok := m.sessions[user.UserId]; ok {
+			m.cancelFishing(user.UserId, `You reel in your line.`)
+			room.SendText(
+				fmt.Sprintf(`<ansi fg="username">%s</ansi> reels in their fishing line.`, user.Character.Name),
+				user.UserId,
+			)
+		} else {
+			user.SendText(`You are not currently fishing.`)
+		}
+		return true, nil
+	}
+
+	if !room.HasTag(`fishing`) {
+		user.SendText(`There is no suitable fishing spot here.`)
+		return true, nil
+	}
+
+	if _, alreadyFishing := m.sessions[user.UserId]; alreadyFishing {
+		user.SendText(`You are already fishing. Use <ansi fg="command">fishing stop</ansi> to reel in.`)
+		return true, nil
+	}
+
+	if len(m.cfg.FishingRodItemIds) > 0 {
+		equippedWeaponId := user.Character.Equipment.Weapon.ItemId
+		hasRod := false
+		for _, rodId := range m.cfg.FishingRodItemIds {
+			if equippedWeaponId == rodId {
+				hasRod = true
+				break
+			}
+		}
+		if !hasRod {
+			user.SendText(`You need a fishing rod equipped to fish.`)
+			return true, nil
+		}
+	}
+
+	if rest == `` {
+		m.listBait(user)
+		return true, nil
+	}
+
+	baitItem, found := user.Character.FindInBackpack(rest)
+	if !found {
+		user.SendText(fmt.Sprintf(`You don't have any <ansi fg="itemname">%s</ansi> to use as bait.`, rest))
+		m.listBait(user)
+		return true, nil
+	}
+
+	baitSpec := baitItem.GetSpec()
+	if baitSpec.Type != items.Food || baitSpec.Subtype != items.Edible {
+		user.SendText(fmt.Sprintf(`<ansi fg="itemname">%s</ansi> doesn't make good bait.`, baitItem.DisplayName()))
+		return true, nil
+	}
+
+	if usesLeft := user.Character.UseItem(baitItem); usesLeft < 1 {
+		events.AddToQueue(events.ItemOwnership{
+			UserId: user.UserId,
+			Item:   baitItem,
+			Gained: false,
+		})
+	}
+
+	user.Character.SetAdjective(`fishing`, true)
+
+	m.sessions[user.UserId] = &FishingSession{
+		UserId:     user.UserId,
+		BaitItem:   baitItem,
+		StartRound: util.GetRoundCount(),
+	}
+
+	user.SendText(`You bait your hook and cast your line into the water...`)
+	room.SendText(
+		fmt.Sprintf(`<ansi fg="username">%s</ansi> casts a fishing line into the water.`, user.Character.Name),
+		user.UserId,
+	)
+
+	return true, nil
+}
+
+func (m *FishingModule) listBait(user *users.UserRecord) {
+	baitItems := []string{}
+	for _, itm := range user.Character.GetAllBackpackItems() {
+		spec := itm.GetSpec()
+		if spec.Type == items.Food && spec.Subtype == items.Edible {
+			baitItems = append(baitItems, itm.DisplayName())
+		}
+	}
+
+	if len(baitItems) == 0 {
+		user.SendText(`You have no bait in your backpack. Find some food items to use as bait.`)
+		user.SendText(`Usage: <ansi fg="command">fishing <baitname></ansi>`)
+		return
+	}
+
+	user.SendText(`You have the following bait available:`)
+	for _, name := range baitItems {
+		user.SendText(fmt.Sprintf(`  <ansi fg="itemname">%s</ansi>`, name))
+	}
+	user.SendText(`Usage: <ansi fg="command">fishing <baitname></ansi>`)
+}
+
+func (m *FishingModule) onNewRound(e events.Event) events.ListenerReturn {
+	evt := e.(events.NewRound)
+	currentRound := evt.RoundNumber
+
+	for userId, session := range m.sessions {
+		roundNumber := int(currentRound-session.StartRound) + 1
+
+		if roundNumber > maxFishingRounds {
+			user := users.GetByUserId(userId)
+			if user != nil {
+				room := rooms.LoadRoom(user.Character.RoomId)
+				if room != nil {
+					room.SendText(
+						fmt.Sprintf(`<ansi fg="username">%s</ansi> reels in their line, empty-handed.`, user.Character.Name),
+						userId,
+					)
+				}
+			}
+			m.cancelFishing(userId, `Your line sits motionless. Nothing is biting today.`)
+			continue
+		}
+
+		user := users.GetByUserId(userId)
+		if user == nil {
+			delete(m.sessions, userId)
+			continue
+		}
+
+		if util.Rand(2) == 0 {
+			flavor := flavorMessages[util.Rand(len(flavorMessages))]
+			user.SendText(fmt.Sprintf(`<ansi fg="cyan">%s</ansi>`, flavor))
+		}
+
+		if roundNumber < catchStartRound {
+			continue
+		}
+
+		room := rooms.LoadRoom(user.Character.RoomId)
+		if room == nil {
+			continue
+		}
+
+		roundDecay := roundNumber - catchStartRound
+		statBonus := user.Character.StatMod(string(fishingStatMod))
+
+		eligible := m.buildEligiblePool(session.BaitItem.ItemId, room.RoomId)
+		if len(eligible) == 0 {
+			continue
+		}
+
+		// Build adjusted weights, clamping each to [0, 100].
+		type weightedEntry struct {
+			item   CatchableItem
+			weight int
+		}
+		var pool []weightedEntry
+		totalWeight := 0
+		for _, c := range eligible {
+			w := c.ChanceToCatch - roundDecay + statBonus
+			if w <= 0 {
+				continue
+			}
+			if w > 100 {
+				w = 100
+			}
+			pool = append(pool, weightedEntry{item: c, weight: w})
+			totalWeight += w
+		}
+
+		if totalWeight == 0 {
+			continue
+		}
+
+		// Single roll in [0, totalWeight). Walk the pool until the
+		// cumulative weight exceeds the roll — each item gets exactly
+		// its proportional share of outcomes.
+		roll := util.Rand(totalWeight)
+		var caught *CatchableItem
+		running := 0
+		for _, entry := range pool {
+			running += entry.weight
+			if roll < running {
+				c := entry.item
+				caught = &c
+				break
+			}
+		}
+
+		if caught == nil {
+			continue
+		}
+
+		caughtItemSpec := items.GetItemSpec(caught.ItemId)
+		if caughtItemSpec == nil {
+			continue
+		}
+
+		caughtItem := items.New(caught.ItemId)
+		if caughtItem.ItemId == 0 {
+			continue
+		}
+
+		if user.Character.StoreItem(caughtItem) {
+			events.AddToQueue(events.ItemOwnership{
+				UserId: userId,
+				Item:   caughtItem,
+				Gained: true,
+			})
+
+			user.SendText(fmt.Sprintf(
+				`<ansi fg="yellow-bold">You reel in a <ansi fg="itemname">%s</ansi>!</ansi>`,
+				caughtItem.DisplayName(),
+			))
+			room.SendText(
+				fmt.Sprintf(`<ansi fg="username">%s</ansi> reels in a <ansi fg="itemname">%s</ansi>!`,
+					user.Character.Name, caughtItem.DisplayName()),
+				userId,
+			)
+		}
+
+		m.cancelFishing(userId, ``)
+	}
+
+	return events.Continue
+}
+
+func (m *FishingModule) buildEligiblePool(baitItemId int, roomId int) []CatchableItem {
+	var pool []CatchableItem
+	for _, c := range m.cfg.Catchables {
+		if c.RequiredBaitId != 0 && c.RequiredBaitId != baitItemId {
+			continue
+		}
+		if len(c.RoomIds) > 0 {
+			inRoom := false
+			for _, rid := range c.RoomIds {
+				if rid == roomId {
+					inRoom = true
+					break
+				}
+			}
+			if !inRoom {
+				continue
+			}
+		}
+		pool = append(pool, c)
+	}
+	return pool
+}
+
+func (m *FishingModule) onRoomChange(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.RoomChange)
+	if !ok || evt.UserId == 0 {
+		return events.Continue
+	}
+	if _, fishing := m.sessions[evt.UserId]; fishing {
+		m.cancelFishing(evt.UserId, `You reel in your line as you move away.`)
+	}
+	return events.Continue
+}
+
+func (m *FishingModule) onAggroChanged(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.AggroChanged)
+	if !ok || evt.UserId == 0 {
+		return events.Continue
+	}
+	user := users.GetByUserId(evt.UserId)
+	if user == nil {
+		return events.Continue
+	}
+	if user.Character.Aggro == nil {
+		return events.Continue
+	}
+	if _, fishing := m.sessions[evt.UserId]; fishing {
+		m.cancelFishing(evt.UserId, `Combat interrupts your fishing!`)
+	}
+	return events.Continue
+}
+
+func (m *FishingModule) onPlayerDrop(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerDrop)
+	if !ok {
+		return events.Continue
+	}
+	if _, fishing := m.sessions[evt.UserId]; fishing {
+		m.cancelFishing(evt.UserId, ``)
+	}
+	return events.Continue
+}
+
+func (m *FishingModule) onPlayerDespawn(e events.Event) events.ListenerReturn {
+	evt, ok := e.(events.PlayerDespawn)
+	if !ok {
+		return events.Continue
+	}
+	if _, fishing := m.sessions[evt.UserId]; fishing {
+		user := users.GetByUserId(evt.UserId)
+		if user != nil {
+			user.Character.SetAdjective(`fishing`, false)
+		}
+		delete(m.sessions, evt.UserId)
+	}
+	return events.Continue
+}
+
+func (m *FishingModule) onRoomLook(d rooms.RoomTemplateDetails) rooms.RoomTemplateDetails {
+	if len(m.cfg.FishingRodItemIds) == 0 || len(m.cfg.Catchables) == 0 {
+		return d
+	}
+	for _, t := range d.Tags {
+		if strings.EqualFold(t, `fishing`) {
+			d.Alert(`This is a <ansi fg="cyan-bold">fishing spot</ansi>! Equip a rod, bring bait, and use <ansi fg="command">fishing <baitname></ansi> to cast your line.`)
+			return d
+		}
+	}
+	return d
+}


### PR DESCRIPTION
# Description

Adds a new configurable module `fishing`

## Changes

- `fishing` command added
- admin page for managing the module
- You can add any item that can be used as a fishing rod
- You can add any item to be caught (guppy, leather boot, etc)
- `fishing` tag on rooms makes the room fishable (with an alert to visitors)
- Certain rooms can have different catchable items
- Certain catchable items can have specific bait requirements