### PR TITLE
Permanently bound items

### DIFF
--- a/_datafiles/html/admin/mobs.html
+++ b/_datafiles/html/admin/mobs.html
@@ -133,6 +133,23 @@
     }
     .btn-icon:hover { color: var(--color-danger); }
 
+    /* equipment lock button */
+    .eq-lock-btn {
+        background: none; border: none; cursor: pointer; font-size: 1rem;
+        line-height: 1; padding: 0 0.15rem; transition: color 0.15s;
+        flex-shrink: 0;
+    }
+    .eq-lock-btn[data-locked="true"]  { color: #e53e3e; }
+    .eq-lock-btn[data-locked="false"] { color: var(--color-text-faint); }
+    .eq-lock-btn[data-locked="true"]:hover  { color: #c53030; }
+    .eq-lock-btn[data-locked="false"]:hover { color: #e53e3e; }
+    .shop-picker-wrap.item-locked {
+        border: 1px solid #e53e3e;
+        background: #fff5f5;
+        border-radius: 4px;
+        padding: 0.2rem 0.4rem;
+    }
+
     /* shop picker display */
     .shop-picker-wrap { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
     .shop-picker-display { font-size: 0.82rem; color: var(--color-text-strong); font-family: monospace; }
@@ -572,6 +589,7 @@
                     '<span class="shop-picker-display empty">nothing</span>' +
                     '<button type="button" class="btn-add-sm" style="margin-top:0" onclick="pickEquip(\'' + id + '\')">Pick&hellip;</button>' +
                     '<button type="button" class="btn-icon" title="Clear" onclick="clearEquip(\'' + id + '\')">\u00d7</button>' +
+                    '<button type="button" class="eq-lock-btn" data-locked="false" title="Item is removable. Click to permanently bind it to this mob." onclick="toggleEquipLock(\'' + id + '\')">\uD83D\uDD13</button>' +
                 '</div>';
             grid.appendChild(field);
         }
@@ -599,7 +617,7 @@
         }
     }
 
-    function setEquipSlot(slotId, itemId) {
+    function setEquipSlot(slotId, itemId, locked) {
         const wrap = document.getElementById(slotId);
         if (!wrap) return;
         wrap.dataset.value = itemId || 0;
@@ -608,11 +626,44 @@
         if (!itemId || itemId === 0) {
             display.textContent = 'nothing';
             display.className = 'shop-picker-display empty';
+            // Reset lock when slot is cleared
+            const lockBtn = wrap.querySelector('.eq-lock-btn');
+            if (lockBtn) {
+                lockBtn.dataset.locked = 'false';
+                lockBtn.textContent = '\uD83D\uDD13';
+                lockBtn.title = 'Item is removable. Click to permanently bind it to this mob.';
+            }
+            wrap.classList.remove('item-locked');
         } else {
             display.textContent = '#' + itemId + ' ' + itemName(itemId);
             display.className = 'shop-picker-display';
+            // Apply lock state if provided
+            const lockBtn = wrap.querySelector('.eq-lock-btn');
+            if (lockBtn && locked !== undefined) {
+                const isLocked = !!locked;
+                lockBtn.dataset.locked = isLocked ? 'true' : 'false';
+                lockBtn.textContent = isLocked ? '\uD83D\uDD12' : '\uD83D\uDD13';
+                lockBtn.title = isLocked
+                    ? 'Item is permanently bound. This item will NEVER be removed from this mob (not even on death). Click to unlock.'
+                    : 'Item is removable. Click to permanently bind it to this mob.';
+                wrap.classList.toggle('item-locked', isLocked);
+            }
         }
     }
+
+    window.toggleEquipLock = function (slotId) {
+        const wrap = document.getElementById(slotId);
+        if (!wrap || !wrap.dataset.value || wrap.dataset.value === '0') return;
+        const lockBtn = wrap.querySelector('.eq-lock-btn');
+        if (!lockBtn) return;
+        const nowLocked = lockBtn.dataset.locked !== 'true';
+        lockBtn.dataset.locked = nowLocked ? 'true' : 'false';
+        lockBtn.textContent = nowLocked ? '\uD83D\uDD12' : '\uD83D\uDD13';
+        lockBtn.title = nowLocked
+            ? 'Item is permanently bound. This item will NEVER be removed from this mob (not even on death). Click to unlock.'
+            : 'Item is removable. Click to permanently bind it to this mob.';
+        wrap.classList.toggle('item-locked', nowLocked);
+    };
 
     window.pickEquip = function (slotId) {
         Picker.open({
@@ -804,7 +855,8 @@
         const eq = ch.Equipment || {};
         for (const slot of EQ_SLOTS) {
             const key = slot.charAt(0).toUpperCase() + slot.slice(1);
-            setEquipSlot('f-eq-' + slot, eqItemId(eq[key]));
+            const slotData = eq[key] || {};
+            setEquipSlot('f-eq-' + slot, eqItemId(slotData), slotData.CanNeverBeRemoved || false);
         }
 
         // Inventory items
@@ -1311,7 +1363,9 @@
         function eqSlot(id) {
             const el = document.getElementById(id);
             const val = el ? (parseInt(el.dataset.value, 10) || 0) : 0;
-            return { ItemId: val };
+            const lockBtn = el && el.querySelector('.eq-lock-btn');
+            const locked = lockBtn ? lockBtn.dataset.locked === 'true' : false;
+            return { ItemId: val, CanNeverBeRemoved: locked };
         }
 
         const payload = {

--- a/_datafiles/html/admin/users.html
+++ b/_datafiles/html/admin/users.html
@@ -91,6 +91,23 @@
     .btn-icon { background: none; border: none; cursor: pointer; font-size: 1rem; color: var(--color-text-faint); padding: 0 0.2rem; line-height: 1; }
     .btn-icon:hover { color: var(--color-danger); }
 
+    /* equipment lock button */
+    .eq-lock-btn {
+        background: none; border: none; cursor: pointer; font-size: 1rem;
+        line-height: 1; padding: 0 0.15rem; transition: color 0.15s;
+        flex-shrink: 0;
+    }
+    .eq-lock-btn[data-locked="true"]  { color: #e53e3e; }
+    .eq-lock-btn[data-locked="false"] { color: var(--color-text-faint); }
+    .eq-lock-btn[data-locked="true"]:hover  { color: #c53030; }
+    .eq-lock-btn[data-locked="false"]:hover { color: #e53e3e; }
+    .shop-picker-wrap.item-locked {
+        border: 1px solid #e53e3e;
+        background: #fff5f5;
+        border-radius: 4px;
+        padding: 0.2rem 0.4rem;
+    }
+
     /* equipment picker */
     .shop-picker-wrap { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
     .shop-picker-display { font-size: 0.82rem; color: var(--color-text-strong); font-family: monospace; }
@@ -709,7 +726,8 @@
         const eq = ch.Equipment || {};
         for (const slot of EQ_SLOTS) {
             const key = slot.charAt(0).toUpperCase() + slot.slice(1);
-            setEquipSlot('f-eq-' + slot, eqItemId(eq[key]));
+            const slotData = eq[key] || {};
+            setEquipSlot('f-eq-' + slot, eqItemId(slotData), slotData.CanNeverBeRemoved || false);
         }
 
         // Inventory
@@ -765,6 +783,7 @@
                     '<span class="shop-picker-display empty">nothing</span>' +
                     '<button type="button" class="btn-add-sm" style="margin-top:0" onclick="pickEquip(\'' + id + '\')">Pick&hellip;</button>' +
                     '<button type="button" class="btn-icon" title="Clear" onclick="clearEquip(\'' + id + '\')">\u00d7</button>' +
+                    '<button type="button" class="eq-lock-btn" data-locked="false" title="Item is removable. Click to permanently bind it to this character." onclick="toggleEquipLock(\'' + id + '\')">\uD83D\uDD13</button>' +
                 '</div>';
             grid.appendChild(field);
         }
@@ -792,7 +811,7 @@
         }
     }
 
-    function setEquipSlot(slotId, itemId) {
+    function setEquipSlot(slotId, itemId, locked) {
         const wrap = document.getElementById(slotId);
         if (!wrap) return;
         wrap.dataset.value = itemId || 0;
@@ -801,11 +820,42 @@
         if (!itemId || itemId === 0) {
             display.textContent = 'nothing';
             display.className = 'shop-picker-display empty';
+            const lockBtn = wrap.querySelector('.eq-lock-btn');
+            if (lockBtn) {
+                lockBtn.dataset.locked = 'false';
+                lockBtn.textContent = '\uD83D\uDD13';
+                lockBtn.title = 'Item is removable. Click to permanently bind it to this character.';
+            }
+            wrap.classList.remove('item-locked');
         } else {
             display.textContent = '#' + itemId + ' ' + itemName(itemId);
             display.className = 'shop-picker-display';
+            const lockBtn = wrap.querySelector('.eq-lock-btn');
+            if (lockBtn && locked !== undefined) {
+                const isLocked = !!locked;
+                lockBtn.dataset.locked = isLocked ? 'true' : 'false';
+                lockBtn.textContent = isLocked ? '\uD83D\uDD12' : '\uD83D\uDD13';
+                lockBtn.title = isLocked
+                    ? 'Item is permanently bound. This item will NEVER be removed from this character (not even on death). Click to unlock.'
+                    : 'Item is removable. Click to permanently bind it to this character.';
+                wrap.classList.toggle('item-locked', isLocked);
+            }
         }
     }
+
+    window.toggleEquipLock = function (slotId) {
+        const wrap = document.getElementById(slotId);
+        if (!wrap || !wrap.dataset.value || wrap.dataset.value === '0') return;
+        const lockBtn = wrap.querySelector('.eq-lock-btn');
+        if (!lockBtn) return;
+        const nowLocked = lockBtn.dataset.locked !== 'true';
+        lockBtn.dataset.locked = nowLocked ? 'true' : 'false';
+        lockBtn.textContent = nowLocked ? '\uD83D\uDD12' : '\uD83D\uDD13';
+        lockBtn.title = nowLocked
+            ? 'Item is permanently bound. This item will NEVER be removed from this character (not even on death). Click to unlock.'
+            : 'Item is removable. Click to permanently bind it to this character.';
+        wrap.classList.toggle('item-locked', nowLocked);
+    };
 
     window.pickEquip = function (slotId) {
         Picker.open({
@@ -1197,7 +1247,9 @@
         function eqSlot(id) {
             const el = document.getElementById(id);
             const val = el ? (parseInt(el.dataset.value, 10) || 0) : 0;
-            return { ItemId: val };
+            const lockBtn = el && el.querySelector('.eq-lock-btn');
+            const locked = lockBtn ? lockBtn.dataset.locked === 'true' : false;
+            return { ItemId: val, CanNeverBeRemoved: locked };
         }
 
         const payload = {

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -1983,6 +1983,9 @@ func (c *Character) Wear(i items.Item) (returnItems []items.Item, newItemWorn bo
 		if !c.Equipment.Offhand.IsDisabled() { // Don't allow equipping on a disabled slot
 			// If it's a 2 handed weapon, remove whatever is in the offhand
 			if iHandsRequired == 2 || !canDualWield && c.Equipment.Offhand.GetSpec().Type == items.Weapon {
+				if c.Equipment.Offhand.IsRemoveLocked() && c.Health > 0 {
+					return returnItems, false, `Your ` + c.Equipment.Offhand.DisplayName() + ` is bound to you and cannot be removed.`
+				}
 				returnItems = append(returnItems, c.Equipment.Offhand)
 				c.Equipment.Offhand = items.Item{}
 			}
@@ -1990,6 +1993,9 @@ func (c *Character) Wear(i items.Item) (returnItems []items.Item, newItemWorn bo
 
 		if c.Equipment.Weapon.IsCursed() {
 			return returnItems, false, `Your ` + c.Equipment.Weapon.DisplayName() + ` is cursed and prevents you from removing it.`
+		}
+		if c.Equipment.Weapon.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Weapon.DisplayName() + ` is bound to you and cannot be removed.`
 		}
 
 		returnItems = append(returnItems, c.Equipment.Weapon)
@@ -2006,9 +2012,15 @@ func (c *Character) Wear(i items.Item) (returnItems []items.Item, newItemWorn bo
 				if c.Equipment.Weapon.IsCursed() {
 					return returnItems, false, `Your ` + c.Equipment.Weapon.DisplayName() + ` is cursed and prevents you from removing it.`
 				}
+				if c.Equipment.Weapon.IsRemoveLocked() && c.Health > 0 {
+					return returnItems, false, `Your ` + c.Equipment.Weapon.DisplayName() + ` is bound to you and cannot be removed.`
+				}
 				returnItems = append(returnItems, c.Equipment.Weapon)
 				c.Equipment.Weapon = items.Item{}
 			}
+		}
+		if c.Equipment.Offhand.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Offhand.DisplayName() + ` is bound to you and cannot be removed.`
 		}
 		returnItems = append(returnItems, c.Equipment.Offhand)
 		c.Equipment.Offhand = i
@@ -2016,11 +2028,17 @@ func (c *Character) Wear(i items.Item) (returnItems []items.Item, newItemWorn bo
 		if c.Equipment.Head.IsDisabled() { // Don't allow equipping on a disabled slot
 			return returnItems, false, `You can't wear things on your head.`
 		}
+		if c.Equipment.Head.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Head.DisplayName() + ` is bound to you and cannot be removed.`
+		}
 		returnItems = append(returnItems, c.Equipment.Head)
 		c.Equipment.Head = i
 	case items.Neck:
 		if c.Equipment.Neck.IsDisabled() { // Don't allow equipping on a disabled slot
 			return returnItems, false, `You can't wear things on your neck.`
+		}
+		if c.Equipment.Neck.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Neck.DisplayName() + ` is bound to you and cannot be removed.`
 		}
 		returnItems = append(returnItems, c.Equipment.Neck)
 		c.Equipment.Neck = i
@@ -2028,11 +2046,17 @@ func (c *Character) Wear(i items.Item) (returnItems []items.Item, newItemWorn bo
 		if c.Equipment.Body.IsDisabled() { // Don't allow equipping on a disabled slot
 			return returnItems, false, `You can't wear things on your body.`
 		}
+		if c.Equipment.Body.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Body.DisplayName() + ` is bound to you and cannot be removed.`
+		}
 		returnItems = append(returnItems, c.Equipment.Body)
 		c.Equipment.Body = i
 	case items.Belt:
 		if c.Equipment.Belt.IsDisabled() { // Don't allow equipping on a disabled slot
 			return returnItems, false, `You can't wear things on your head.`
+		}
+		if c.Equipment.Belt.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Belt.DisplayName() + ` is bound to you and cannot be removed.`
 		}
 		returnItems = append(returnItems, c.Equipment.Belt)
 		c.Equipment.Belt = i
@@ -2040,11 +2064,17 @@ func (c *Character) Wear(i items.Item) (returnItems []items.Item, newItemWorn bo
 		if c.Equipment.Gloves.IsDisabled() { // Don't allow equipping on a disabled slot
 			return returnItems, false, `You can't wear things as gloves.`
 		}
+		if c.Equipment.Gloves.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Gloves.DisplayName() + ` is bound to you and cannot be removed.`
+		}
 		returnItems = append(returnItems, c.Equipment.Gloves)
 		c.Equipment.Gloves = i
 	case items.Ring:
 		if c.Equipment.Ring.IsDisabled() { // Don't allow equipping on a disabled slot
 			return returnItems, false, `You can't wear rings.`
+		}
+		if c.Equipment.Ring.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Ring.DisplayName() + ` is bound to you and cannot be removed.`
 		}
 		returnItems = append(returnItems, c.Equipment.Ring)
 		c.Equipment.Ring = i
@@ -2052,11 +2082,17 @@ func (c *Character) Wear(i items.Item) (returnItems []items.Item, newItemWorn bo
 		if c.Equipment.Legs.IsDisabled() { // Don't allow equipping on a disabled slot
 			return returnItems, false, `You can't wear things on your legs.`
 		}
+		if c.Equipment.Legs.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Legs.DisplayName() + ` is bound to you and cannot be removed.`
+		}
 		returnItems = append(returnItems, c.Equipment.Legs)
 		c.Equipment.Legs = i
 	case items.Feet:
 		if c.Equipment.Feet.IsDisabled() { // Don't allow equipping on a disabled slot
 			return returnItems, false, `You can't wear things on your feet.`
+		}
+		if c.Equipment.Feet.IsRemoveLocked() && c.Health > 0 {
+			return returnItems, false, `Your ` + c.Equipment.Feet.DisplayName() + ` is bound to you and cannot be removed.`
 		}
 		returnItems = append(returnItems, c.Equipment.Feet)
 		c.Equipment.Feet = i
@@ -2073,6 +2109,9 @@ func (c *Character) RemoveFromBody(i items.Item) bool {
 
 	for _, slot := range AllSlots() {
 		if i.Equals(*c.Equipment.Get(slot)) {
+			if i.IsRemoveLocked() && c.Health > 0 {
+				return false
+			}
 			c.Equipment.Set(slot, items.Item{})
 			c.reapplyPermabuffs(i)
 			return true

--- a/internal/items/items.go
+++ b/internal/items/items.go
@@ -35,17 +35,18 @@ const (
 
 // Instance properties that may change
 type Item struct {
-	ItemId        int            `yaml:"itemid,omitempty"`
-	UUID          uuid.UUID      `yaml:"-"`                       // `yaml:"uuid,omitempty"`
-	Blob          string         `yaml:"blob,omitempty"`          // Does this item have a blob? Should be base64 encoded.
-	Uses          int            `yaml:"uses,omitempty"`          // How many uses it has left
-	LastUsedRound uint64         `yaml:"lastusedround,omitempty"` // Last round this item was used
-	Spec          *ItemSpec      `yaml:"overrides,omitempty"`
-	Uncursed      bool           `yaml:"uncursed,omitempty"`     // Is this item uncursed?
-	Enchantments  uint8          `yaml:"enchantments,omitempty"` // Is this item enchanted?
-	Adjectives    []string       `yaml:"adjectives,omitempty"`   // Decorative text for the name of the item (e.g. "exploding")
-	StashedBy     int            `yaml:"stashedby,omitempty"`    // userid of whoever stashed this item
-	tempDataStore map[string]any // Temporary data store for this item. Not saved to disk.
+	ItemId            int            `yaml:"itemid,omitempty"`
+	UUID              uuid.UUID      `yaml:"-"`                       // `yaml:"uuid,omitempty"`
+	Blob              string         `yaml:"blob,omitempty"`          // Does this item have a blob? Should be base64 encoded.
+	Uses              int            `yaml:"uses,omitempty"`          // How many uses it has left
+	LastUsedRound     uint64         `yaml:"lastusedround,omitempty"` // Last round this item was used
+	Spec              *ItemSpec      `yaml:"overrides,omitempty"`
+	Uncursed          bool           `yaml:"uncursed,omitempty"`          // Is this item uncursed?
+	Enchantments      uint8          `yaml:"enchantments,omitempty"`      // Is this item enchanted?
+	Adjectives        []string       `yaml:"adjectives,omitempty"`        // Decorative text for the name of the item (e.g. "exploding")
+	StashedBy         int            `yaml:"stashedby,omitempty"`         // userid of whoever stashed this item
+	CanNeverBeRemoved bool           `yaml:"canneverberemoved,omitempty"` // If true, this item can never be unequipped once worn
+	tempDataStore     map[string]any // Temporary data store for this item. Not saved to disk.
 }
 
 func New(itemId int) Item {
@@ -342,6 +343,10 @@ func (i *Item) Uncurse() {
 
 func (i *Item) IsCursed() bool {
 	return i.GetSpec().Cursed && !i.Uncursed
+}
+
+func (i *Item) IsRemoveLocked() bool {
+	return i.CanNeverBeRemoved
 }
 
 // Gets the specifics of the item damage

--- a/internal/mobcommands/suicide.go
+++ b/internal/mobcommands/suicide.go
@@ -354,6 +354,10 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 		for _, item := range allWornItems {
 
+			if item.IsRemoveLocked() {
+				continue
+			}
+
 			roll := util.Rand(100)
 
 			util.LogRoll(`Drop Item`, roll, mob.ItemDropChance)

--- a/internal/usercommands/remove.go
+++ b/internal/usercommands/remove.go
@@ -16,6 +16,9 @@ func Remove(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 	if rest == "all" {
 		removedItems := []items.Item{}
 		for _, item := range user.Character.Equipment.GetAllItems() {
+			if item.IsRemoveLocked() {
+				continue
+			}
 			Remove(item.Name(), user, room, flags)
 			removedItems = append(removedItems, item)
 		}
@@ -34,6 +37,13 @@ func Remove(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 	if !found || matchItem.ItemId < 1 {
 		user.SendText(fmt.Sprintf(`You don't appear to be using a "%s".`, rest))
 	} else {
+
+		if matchItem.IsRemoveLocked() {
+			user.SendText(
+				fmt.Sprintf(`Your <ansi fg="item">%s</ansi> is bound to you and <ansi fg="red-bold">cannot be removed</ansi>.`, matchItem.DisplayName()),
+			)
+			return true, nil
+		}
 
 		if matchItem.IsCursed() && user.Character.Health > 0 {
 			if user.Character.GetSkillLevel(skills.Enchant) < 4 {

--- a/internal/usercommands/skill.brawling.disarm.go
+++ b/internal/usercommands/skill.brawling.disarm.go
@@ -59,6 +59,11 @@ func Disarm(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 				return true, nil
 			}
 
+			if m.Character.Equipment.Weapon.IsRemoveLocked() {
+				user.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi>'s weapon is bound to them and cannot be disarmed!`, m.Character.Name))
+				return true, nil
+			}
+
 			chanceIn100 := (user.Character.Stats.Speed.ValueAdj + user.Character.Stats.Smarts.ValueAdj) - (m.Character.Stats.Strength.ValueAdj + m.Character.Stats.Perception.ValueAdj)
 			if chanceIn100 < 0 {
 				chanceIn100 = 0
@@ -103,6 +108,16 @@ func Disarm(rest string, user *users.UserRecord, room *rooms.Room, flags events.
 
 			if u.Character.HasBuffFlag(buffs.PermaGear) {
 				user.SendText(fmt.Sprintf(`Some force prevents you from disarming <ansi fg="username">%s</ansi>!`, u.Character.Name))
+				return true, nil
+			}
+
+			if u.Character.Equipment.Weapon.ItemId == 0 {
+				user.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> has no weapon to disarm!`, u.Character.Name))
+				return true, nil
+			}
+
+			if u.Character.Equipment.Weapon.IsRemoveLocked() {
+				user.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi>'s weapon is bound to them and cannot be disarmed!`, u.Character.Name))
 				return true, nil
 			}
 

--- a/internal/usercommands/suicide.go
+++ b/internal/usercommands/suicide.go
@@ -132,6 +132,9 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room, flags events
 
 			// Unequip everything
 			for _, itm := range user.Character.GetAllWornItems() {
+				if itm.IsRemoveLocked() {
+					continue
+				}
 				Remove(itm.Name(), user, room, flags)
 			}
 			// drop all items / gold
@@ -157,6 +160,9 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room, flags events
 		if config.Death.EquipmentDropChance >= 0 {
 			chanceInt := int(config.Death.EquipmentDropChance * 100)
 			for _, itm := range user.Character.GetAllWornItems() {
+				if itm.IsRemoveLocked() {
+					continue
+				}
 				if util.Rand(100) < chanceInt {
 
 					Remove(itm.Name(), user, room, flags)


### PR DESCRIPTION
# Description

**Permanently Bound Equipment (`CanNeverBeRemoved`)**

Adds a new per-item flag that permanently binds an equipped item to its wearer. Once set, the item cannot be removed by any in-game action — including the `remove` command, equipping a replacement, disarm skills, or death penalties. When a character or mob dies, bound items are silently excluded from corpse drops and loot rolls so they never appear on a corpse.

Admins configure this flag directly in the mob and user editors in the admin panel, per equipment slot.

---

## Changes

### Gameplay

- **Bound items cannot be unequipped.** Attempting to `remove` a bound item gives the message: *"Your \<item\> is bound to you and cannot be removed."* Using `remove all` silently skips bound items.
- **Bound items block slot replacement.** Trying to equip a new item into a slot occupied by a bound item fails with a clear message rather than displacing the bound item.
- **Bound items survive death.** On player or mob death, bound equipped items are excluded from equipment-drop rolls and never placed on a corpse. They remain on the character after respawn.
- **Bound items survive permadeath unequip.** The permadeath "unequip everything" pass skips bound items, so they stay on the character even through a perma-death reset.
- **Bound weapons cannot be disarmed.** The `disarm` brawling skill checks for the flag and refuses with: *"\<target\>'s weapon is bound to them and cannot be disarmed!"*

### Admin Panel — Mobs (`/admin/mobs`) and Users (`/admin/users`)

- Each equipment slot in the editor now has a **lock icon button** (🔓/🔒) next to the Clear button.
- **Unlocked state** (🔓, grey): the item will behave normally and can be removed in-game.
- **Locked state** (🔒, red): the item is permanently bound. The slot gets a red border and light red background to make it visually obvious at a glance.
- **Tooltip on hover** explains the current state and what clicking will do:
  - Unlocked: *"Item is removable. Click to permanently bind it to this mob/character."*
  - Locked: *"Item is permanently bound. This item will NEVER be removed from this mob/character (not even on death). Click to unlock."*
- The lock state is saved and loaded with the mob or user record — it persists across sessions.
- Clearing a slot automatically resets the lock to unlocked.
