### PR TITLE
Admin UX Improvements

### DIFF
--- a/_datafiles/html/admin/audio-api.html
+++ b/_datafiles/html/admin/audio-api.html
@@ -11,8 +11,10 @@
     .api-entry[open] summary::before { transform: rotate(90deg); }
     .api-entry summary:hover { background: var(--color-surface-alt); }
     .method { font-family: monospace; font-size: 0.8rem; font-weight: 700; padding: 0.15rem 0.45rem; border-radius: 3px; flex-shrink: 0; }
-    .method-get   { background: var(--color-success-bg); color: var(--color-success-text); }
-    .method-patch { background: var(--color-warning-bg); color: var(--color-warning-text); }
+    .method-get    { background: var(--color-success-bg); color: var(--color-success-text); }
+    .method-post   { background: var(--color-info-bg, #dbeafe); color: var(--color-info-text, #1d4ed8); }
+    .method-patch  { background: var(--color-warning-bg); color: var(--color-warning-text); }
+    .method-delete { background: var(--color-error-bg); color: var(--color-error-text); }
     .api-path { font-family: monospace; font-size: 0.9rem; color: var(--color-primary); }
     .api-desc { font-size: 0.85rem; color: var(--color-text-muted); margin-left: auto; text-align: right; }
     .api-body { padding: 0.75rem 1rem 1rem; border-top: 1px solid var(--color-border-light); background: var(--color-surface-alt); }
@@ -47,21 +49,59 @@
         <summary>
             <span class="method method-get">GET</span>
             <span class="api-path">/admin/api/v1/audio</span>
-            <span class="api-desc">Return sounds and music</span>
-            <span class="perm-badge">audio.read</span>
+            <span class="api-desc">Return sounds, music, and available sound files</span>
         </summary>
         <div class="api-body">
-            <p>Returns two sections:</p>
+            <p>Returns three sections:</p>
             <ul>
-                <li><code>sounds</code> - map of identifier &rarr; audio config loaded from <code>audio.yaml</code>. Each entry has an optional <code>description</code>, a <code>filepath</code> (relative to <code>WebCDNLocation</code>, or host root if blank), and an optional <code>volume</code> (0&ndash;100).</li>
-                <li><code>music</code> - sorted list of filenames found in <code>PublicHtml/static/audio/music/</code>. Files whose names begin with <code>_</code> are excluded. This list is read-only.</li>
+                <li><code>sounds</code> &mdash; map of identifier &rarr; audio config loaded from <code>audio.yaml</code>. Each entry has an optional <code>description</code>, a <code>filepath</code> (relative to <code>WebCDNLocation</code>, or host root if blank), and an optional <code>volume</code> (0&ndash;100).</li>
+                <li><code>music</code> &mdash; sorted list of filenames found in <code>PublicHtml/static/audio/music/</code>. Files beginning with <code>_</code> are excluded. Read-only.</li>
+                <li><code>soundFiles</code> &mdash; sorted list of all files found recursively under <code>PublicHtml/static/audio/sound/</code>. Files beginning with <code>_</code> are excluded. Read-only.</li>
             </ul>
             <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> \
      <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/audio</span></div>
             <div class="response-examples">
                 <details class="resp-entry">
                     <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
-                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"sounds":{"intro":{"description":"Plays at login screen","filepath":"static/audio/music/intro.mp3","volume":20},"levelup":{"description":"When leveling up","filepath":"static/audio/sound/other/levelup.mp3"}},"music":["static/audio/music/catacombs.mp3","static/audio/music/dark-forest.mp3","static/audio/music/frostfang.mp3","static/audio/music/intro.mp3"]}}</div></div>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"sounds":{"intro":{"description":"Plays at login screen","filepath":"static/audio/music/intro.mp3","volume":20},"levelup":{"description":"When leveling up","filepath":"static/audio/sound/other/levelup.mp3"}},"music":["static/audio/music/intro.mp3"],"soundFiles":["static/audio/sound/combat/hit-other.mp3","static/audio/sound/other/levelup.mp3"]}}</div></div>
+                </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-post">POST</span>
+            <span class="api-path">/admin/api/v1/audio</span>
+            <span class="api-desc">Create a new sound entry</span>
+            <span class="perm-badge">audio.write</span>
+        </summary>
+        <div class="api-body">
+            <p>Creates a new sound identifier. Returns <code>409 Conflict</code> if the identifier already exists.</p>
+            <p>Body fields:</p>
+            <ul>
+                <li><code>identifier</code> (string, required) &mdash; unique key used in code to trigger the sound.</li>
+                <li><code>description</code> (string, optional) &mdash; human-readable description.</li>
+                <li><code>filepath</code> (string, optional) &mdash; path relative to <code>WebCDNLocation</code>.</li>
+                <li><code>volume</code> (integer 0&ndash;100, optional) &mdash; base volume; 0 means use 100%.</li>
+                <li><code>tags</code> (array of strings, optional) &mdash; free-form labels describing where this sound is used.</li>
+            </ul>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> <span class="flag">-X</span> POST \
+     <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
+     <span class="flag">-d</span> <span class="str">'{"identifier":"my-sound","description":"Custom sound","filepath":"static/audio/sound/other/change.mp3","volume":80}'</span> \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/audio</span></div>
+            <div class="response-examples">
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success &mdash; returns full updated audio data</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"sounds":{...},"music":[...],"soundFiles":[...]}}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">400</span> <span class="resp-label">Bad Request &mdash; missing identifier</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"identifier is required"}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">409</span> <span class="resp-label">Conflict &mdash; identifier already exists</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"identifier already exists: my-sound"}</div></div>
                 </details>
             </div>
         </div>
@@ -71,29 +111,48 @@
         <summary>
             <span class="method method-patch">PATCH</span>
             <span class="api-path">/admin/api/v1/audio</span>
-            <span class="api-desc">Replace the sounds configuration</span>
+            <span class="api-desc">Replace the entire sounds configuration</span>
             <span class="perm-badge">audio.write</span>
         </summary>
         <div class="api-body">
             <p>Replaces the entire sounds configuration with the provided map. The body must be a JSON object mapping identifiers to audio config objects. The updated configuration is written to <code>audio.yaml</code> and reloaded in memory.</p>
-            <p>The <code>music</code> list is derived from disk and cannot be modified through this endpoint. The response includes the saved sounds and the current music file list.</p>
-            <p>Each entry supports three optional fields: <code>description</code> (string), <code>filepath</code> (string), and <code>volume</code> (integer 0&ndash;100).</p>
+            <p>The <code>music</code> and <code>soundFiles</code> lists are derived from disk and cannot be modified through this endpoint.</p>
             <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> <span class="flag">-X</span> PATCH \
      <span class="flag">-H</span> <span class="str">"Content-Type: application/json"</span> \
-     <span class="flag">-d</span> <span class="str">'{"intro":{"description":"Plays at login screen","filepath":"static/audio/music/intro.mp3","volume":20},"levelup":{"description":"When leveling up","filepath":"static/audio/sound/other/levelup.mp3"}}'</span> \
+     <span class="flag">-d</span> <span class="str">'{"intro":{"description":"Plays at login screen","filepath":"static/audio/music/intro.mp3","volume":20}}'</span> \
      <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/audio</span></div>
             <div class="response-examples">
                 <details class="resp-entry">
                     <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
-                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"sounds":{"intro":{"description":"Plays at login screen","filepath":"static/audio/music/intro.mp3","volume":20},"levelup":{"description":"When leveling up","filepath":"static/audio/sound/other/levelup.mp3"}},"music":["static/audio/music/catacombs.mp3","static/audio/music/dark-forest.mp3","static/audio/music/frostfang.mp3","static/audio/music/intro.mp3"]}}</div></div>
+                    <div class="resp-body"><div class="curl-block">{"success":true,"data":{"sounds":{...},"music":[...],"soundFiles":[...]}}</div></div>
                 </details>
                 <details class="resp-entry">
                     <summary><span class="method resp-label status-err">400</span> <span class="resp-label">Bad Request</span></summary>
                     <div class="resp-body"><div class="curl-block">{"success":false,"error":"malformed request body: unexpected EOF"}</div></div>
                 </details>
+            </div>
+        </div>
+    </details>
+
+    <details class="api-entry">
+        <summary>
+            <span class="method method-delete">DELETE</span>
+            <span class="api-path">/admin/api/v1/audio/{identifier}</span>
+            <span class="api-desc">Delete a single sound entry</span>
+            <span class="perm-badge">audio.write</span>
+        </summary>
+        <div class="api-body">
+            <p>Removes the named sound identifier from <code>audio.yaml</code> and reloads the in-memory configuration. Returns <code>404</code> if the identifier does not exist.</p>
+            <div class="curl-block"><span class="kw">curl</span> <span class="flag">-s</span> <span class="flag">-u</span> <span class="str">admin:password</span> <span class="flag">-X</span> DELETE \
+     <span class="str">http://{{.CONFIG.FilePaths.WebDomain}}/admin/api/v1/audio/my-sound</span></div>
+            <div class="response-examples">
                 <details class="resp-entry">
-                    <summary><span class="method resp-label status-err">500</span> <span class="resp-label">Internal Server Error</span></summary>
-                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"writing audio config file: permission denied"}</div></div>
+                    <summary><span class="method resp-label status-ok">200</span> <span class="resp-label">Success</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":true}</div></div>
+                </details>
+                <details class="resp-entry">
+                    <summary><span class="method resp-label status-err">404</span> <span class="resp-label">Not Found</span></summary>
+                    <div class="resp-body"><div class="curl-block">{"success":false,"error":"identifier not found: my-sound"}</div></div>
                 </details>
             </div>
         </div>

--- a/_datafiles/html/admin/audio.html
+++ b/_datafiles/html/admin/audio.html
@@ -4,31 +4,37 @@
     h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
     .subtitle { color: var(--color-text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
 
-    .page-layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
+    .page-layout { display: grid; grid-template-columns: 270px 1fr; gap: 1.25rem; align-items: start; }
     @media (max-width: 800px) { .page-layout { grid-template-columns: 1fr; } }
 
     .sidebar { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; display: flex; flex-direction: column; }
-    .sidebar-header { padding: 0.75rem 0.9rem; border-bottom: 1px solid var(--color-border-light); }
-    .sidebar-header input[type="search"] { width: 100%; padding: 0.35rem 0.6rem; border: 1px solid var(--color-border-medium); border-radius: 4px; font-size: 0.85rem; }
-    .entry-list { overflow-y: auto; max-height: 72vh; }
+    .sidebar-header { padding: 0.6rem 0.9rem; border-bottom: 1px solid var(--color-border-light); display: flex; gap: 0.5rem; align-items: center; }
+    .sidebar-header input[type="search"] { flex: 1; padding: 0.35rem 0.6rem; border: 1px solid var(--color-border-medium); border-radius: 4px; font-size: 0.85rem; }
+    .entry-list { overflow-y: auto; max-height: 70vh; }
 
     .list-section-label {
         padding: 0.35rem 0.9rem; font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
-        letter-spacing: 0.07em; color: var(--color-text-faint); background: var(--color-page-bg); border-bottom: 1px solid var(--color-border-light);
-        border-top: 1px solid var(--color-border-light); position: sticky; top: 0; z-index: 1;
+        letter-spacing: 0.07em; color: var(--color-text-faint); background: var(--color-page-bg);
+        border-bottom: 1px solid var(--color-border-light); border-top: 1px solid var(--color-border-light);
+        position: sticky; top: 0; z-index: 1;
     }
     .list-section-label:first-child { border-top: none; }
 
     .entry-row {
-        padding: 0.45rem 0.9rem; cursor: pointer; border-bottom: 1px solid var(--color-border-faint);
+        padding: 0.4rem 0.9rem; cursor: pointer; border-bottom: 1px solid var(--color-border-faint);
         font-size: 0.875rem; display: flex; align-items: center; justify-content: space-between; gap: 0.4rem;
     }
     .entry-row:last-child { border-bottom: none; }
     .entry-row:hover { background: var(--color-row-hover); }
     .entry-row.active { background: var(--color-primary); color: var(--color-surface-white); }
     .entry-row.active .play-btn { color: var(--color-nav-link); }
-    .entry-row.active .play-btn:hover { color: var(--color-surface-white); }
     .entry-name { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .entry-badge {
+        flex-shrink: 0; font-size: 0.65rem; font-weight: 700; padding: 0.1rem 0.35rem;
+        border-radius: 3px; background: var(--color-border-faint); color: var(--color-text-faint);
+        text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .entry-row.active .entry-badge { background: rgba(255,255,255,0.2); color: rgba(255,255,255,0.8); }
     .play-btn {
         flex-shrink: 0; background: none; border: none; cursor: pointer; padding: 0 0.2rem;
         font-size: 1rem; color: var(--color-text-muted); line-height: 1;
@@ -38,6 +44,13 @@
     .entry-row.active .play-btn.playing { color: var(--color-error-text); }
     .no-entries { padding: 1.5rem; text-align: center; color: var(--color-text-faint); font-size: 0.85rem; }
 
+    .btn-new {
+        margin: 0.55rem 0.9rem; padding: 0.38rem 0.9rem; border: none; border-radius: 4px;
+        background: var(--color-success-text); color: var(--color-surface-white);
+        font-size: 0.82rem; font-weight: 600; cursor: pointer; display: block; text-align: center;
+    }
+    .btn-new:hover { background: var(--color-btn-new-hover); }
+
     .editor-panel { background: var(--color-surface-white); border: 1px solid var(--color-border); border-radius: 6px; padding: 1.25rem; }
     .editor-placeholder { color: var(--color-text-placeholder); text-align: center; padding: 4rem 1rem; font-size: 0.9rem; }
 
@@ -45,29 +58,87 @@
     .status-bar.success { background: var(--color-success-bg); color: var(--color-success-text); display: block; }
     .status-bar.error   { background: var(--color-error-bg); color: var(--color-error-text); display: block; }
 
-    .section-title { font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-subtle); padding: 0.5rem 0 0.4rem; border-bottom: 1px solid var(--color-border-light); margin-bottom: 0.75rem; }
+    .section-title { font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-subtle); padding: 0.5rem 0 0.4rem; border-bottom: 1px solid var(--color-border-light); margin-bottom: 0.85rem; }
 
     .field { margin-bottom: 1rem; }
     .field label { display: block; font-size: 0.78rem; font-weight: 600; color: var(--color-text-muted); margin-bottom: 0.25rem; text-transform: uppercase; letter-spacing: 0.03em; }
-    .field input[type="text"] { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid var(--color-border-medium); border-radius: 4px; font-size: 0.875rem; font-family: inherit; }
+    .field input[type="text"] { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid var(--color-border-medium); border-radius: 4px; font-size: 0.875rem; font-family: inherit; box-sizing: border-box; }
     .field input:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; border-color: transparent; }
+    .field input[readonly] { background: var(--color-page-bg); color: var(--color-text-muted); cursor: default; }
     .field-hint { font-size: 0.75rem; color: var(--color-text-faint); margin-top: 0.2rem; }
+
+    .filepath-row { display: flex; gap: 0.5rem; align-items: flex-start; }
+    .filepath-row input[type="text"] { flex: 1; }
+    .filepath-row select { flex: 1; padding: 0.4rem 0.6rem; border: 1px solid var(--color-border-medium); border-radius: 4px; font-size: 0.85rem; font-family: inherit; background: var(--color-surface-white); cursor: pointer; }
+    .filepath-row select:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; border-color: transparent; }
+    .filepath-toggle { flex-shrink: 0; padding: 0.4rem 0.65rem; border: 1px solid var(--color-border-medium); border-radius: 4px; font-size: 0.8rem; background: var(--color-page-bg); cursor: pointer; color: var(--color-text-muted); white-space: nowrap; }
+    .filepath-toggle:hover { background: var(--color-row-hover); color: var(--color-primary); }
 
     .volume-row { display: flex; align-items: center; gap: 0.75rem; }
     .volume-row input[type="range"] { flex: 1; accent-color: var(--color-primary); cursor: pointer; }
     .volume-value { font-size: 0.875rem; font-weight: 600; color: var(--color-primary); min-width: 2.5rem; text-align: right; white-space: nowrap; }
     .volume-default-label { font-size: 0.78rem; color: var(--color-text-faint); font-style: italic; margin-top: 0.25rem; min-height: 1.1em; }
 
+    .playback-preview {
+        margin-top: 0.75rem; padding: 0.65rem 0.85rem; border-radius: 5px;
+        background: var(--color-page-bg); border: 1px solid var(--color-border-light);
+        display: flex; align-items: center; gap: 0.75rem;
+    }
+    .preview-play-btn {
+        flex-shrink: 0; width: 30px; height: 30px; border-radius: 50%;
+        border: none; background: var(--color-primary); color: var(--color-surface-white);
+        cursor: pointer; font-size: 0.85rem; display: flex; align-items: center; justify-content: center;
+    }
+    .preview-play-btn:hover { background: var(--color-primary-hover); }
+    .preview-play-btn.playing { background: var(--color-danger); }
+    .progress-wrap { flex: 1; display: flex; flex-direction: column; gap: 0.2rem; }
+    .progress-bar-bg { height: 4px; background: var(--color-border-medium); border-radius: 2px; overflow: hidden; }
+    .progress-bar-fill { height: 100%; background: var(--color-primary); border-radius: 2px; width: 0%; transition: width 0.1s linear; }
+    .preview-label { font-size: 0.75rem; color: var(--color-text-faint); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+    .tags-input-wrap {
+        display: flex; flex-wrap: wrap; gap: 0.35rem; align-items: center;
+        padding: 0.35rem 0.5rem; border: 1px solid var(--color-border-medium);
+        border-radius: 4px; min-height: 2.2rem; cursor: text;
+    }
+    .tags-input-wrap:focus-within { outline: 2px solid var(--color-primary); outline-offset: 1px; border-color: transparent; }
+    .tag-chip {
+        display: inline-flex; align-items: center; gap: 0.25rem;
+        padding: 0.15rem 0.5rem; border-radius: 10px;
+        background: var(--color-border-faint); border: 1px solid var(--color-border-light);
+        font-size: 0.78rem; color: var(--color-text-muted); white-space: nowrap;
+    }
+    .tag-chip-remove { background: none; border: none; cursor: pointer; padding: 0; line-height: 1; font-size: 0.8rem; color: var(--color-text-faint); }
+    .tag-chip-remove:hover { color: var(--color-error-text); }
+    .tags-text-input { border: none; outline: none; font-size: 0.85rem; font-family: inherit; background: transparent; min-width: 120px; flex: 1; }
+
     .btn-row { display: flex; gap: 0.6rem; margin-top: 1.25rem; }
     .btn-save { padding: 0.45rem 1.2rem; background: var(--color-primary); color: var(--color-surface-white); border: none; border-radius: 4px; font-size: 0.875rem; font-weight: 600; cursor: pointer; }
     .btn-save:hover { background: var(--color-primary-hover); }
+    .btn-delete { padding: 0.45rem 1rem; background: var(--color-surface-white); color: var(--color-error-text); border: 1px solid var(--color-btn-delete-border); border-radius: 4px; font-size: 0.875rem; font-weight: 600; cursor: pointer; }
+    .btn-delete:hover { background: var(--color-error-bg); }
 
-    .music-info { color: var(--color-text-muted); font-size: 0.875rem; padding: 2rem 1rem; text-align: center; }
-    .music-info strong { display: block; margin-bottom: 0.4rem; font-size: 1rem; color: var(--color-primary); }
+    .music-file-name { font-size: 1rem; font-weight: 600; color: var(--color-primary); margin-bottom: 0.5rem; }
+    .music-hint { color: var(--color-text-muted); font-size: 0.875rem; margin-bottom: 1rem; }
+
+    .unassigned-callout {
+        margin-top: 1.25rem; padding: 0.75rem 0.9rem;
+        background: var(--color-warning-bg); border: 1px solid var(--color-warning-border, var(--color-border));
+        border-radius: 5px;
+    }
+    .unassigned-callout h4 { font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-warning-text); margin-bottom: 0.5rem; }
+    .unassigned-file-list { display: flex; flex-direction: column; gap: 0.3rem; }
+    .unassigned-file-row { display: flex; align-items: center; gap: 0.5rem; font-size: 0.82rem; }
+    .unassigned-file-path { flex: 1; font-family: monospace; color: var(--color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .btn-assign { flex-shrink: 0; padding: 0.2rem 0.55rem; border: 1px solid var(--color-primary); border-radius: 3px; background: none; color: var(--color-primary); font-size: 0.75rem; cursor: pointer; white-space: nowrap; }
+    .btn-assign:hover { background: var(--color-primary); color: var(--color-surface-white); }
+    .btn-play-small { flex-shrink: 0; background: none; border: none; cursor: pointer; padding: 0 0.15rem; font-size: 0.9rem; color: var(--color-text-muted); line-height: 1; }
+    .btn-play-small:hover { color: var(--color-primary); }
+    .btn-play-small.playing { color: var(--color-danger); }
 </style>
 
 <h1>Audio</h1>
-<p class="subtitle">View and edit audio configuration. Play or stop any sound or music file.</p>
+<p class="subtitle">Manage sound event mappings and preview music files.</p>
 
 <div class="page-layout">
     <div class="sidebar">
@@ -77,10 +148,11 @@
         <div id="entryList" class="entry-list">
             <div class="no-entries">Loading&hellip;</div>
         </div>
+        <button class="btn-new" onclick="newSound()">+ New Sound</button>
     </div>
 
     <div class="editor-panel">
-        <div id="editorPlaceholder" class="editor-placeholder">Select an entry to view or edit.</div>
+        <div id="editorPlaceholder" class="editor-placeholder">Select an entry to view or edit, or click &ldquo;New Sound&rdquo; to add one.</div>
 
         <div id="soundForm" style="display:none">
             <div id="statusBar" class="status-bar"></div>
@@ -88,19 +160,34 @@
 
             <div class="field">
                 <label for="fieldId">Identifier</label>
-                <input type="text" id="fieldId" readonly />
-                <div class="field-hint">Identifier cannot be changed.</div>
+                <input type="text" id="fieldId" placeholder="e.g. my-sound" />
+                <div class="field-hint" id="fieldIdHint">Used in code: <code>user.PlaySound("my-sound", "category")</code></div>
             </div>
 
             <div class="field">
                 <label for="fieldDescription">Description</label>
-                <input type="text" id="fieldDescription" placeholder="e.g. Plays at login screen" />
+                <input type="text" id="fieldDescription" placeholder="e.g. Plays when leveling up" />
             </div>
 
             <div class="field">
-                <label for="fieldFilePath">File Path</label>
-                <input type="text" id="fieldFilePath" placeholder="e.g. static/audio/sound/other/change.mp3" />
-                <div class="field-hint">Relative to WebCDNLocation in config.yaml, or host root if blank.</div>
+                <label>File Path</label>
+                <div class="filepath-row">
+                    <input type="text" id="fieldFilePath" placeholder="e.g. static/audio/sound/other/change.mp3" oninput="onFilePathInput()" />
+                    <button class="filepath-toggle" id="filePickerToggle" onclick="toggleFilePicker()" title="Pick from available files">Browse</button>
+                </div>
+                <div style="display:none; margin-top:0.4rem;" id="filePickerWrap">
+                    <select id="filePicker" size="6" style="width:100%;" onchange="onFilePickerChange()">
+                        <option value="" disabled>Loading files&hellip;</option>
+                    </select>
+                </div>
+                <div class="field-hint">Relative to <code>WebCDNLocation</code> in config.yaml, or host root if blank.</div>
+                <div class="playback-preview">
+                    <button class="preview-play-btn" id="previewPlayBtn" onclick="togglePreviewPlay()" title="Preview">&#9654;</button>
+                    <div class="progress-wrap">
+                        <div class="preview-label" id="previewLabel">No file selected</div>
+                        <div class="progress-bar-bg"><div class="progress-bar-fill" id="progressFill"></div></div>
+                    </div>
+                </div>
             </div>
 
             <div class="field">
@@ -109,19 +196,41 @@
                     <input type="range" id="fieldVolume" min="0" max="100" value="0" oninput="updateVolumeDisplay()" />
                     <span class="volume-value" id="volumeValueDisplay">0</span>
                 </div>
-                <div class="volume-default-label" id="volumeDefaultLabel">Default volume</div>
-                <div class="field-hint">Percentage of the file&rsquo;s full encoded volume (1&ndash;100). At 0, the server uses 100% as the default. This is the base level before the player&rsquo;s own category slider and per-sound overrides are applied on top.</div>
+                <div class="volume-default-label" id="volumeDefaultLabel">Default volume (100%)</div>
+                <div class="field-hint">Base volume 1&ndash;100. At 0, the server uses 100% as the default. Applied before the player&rsquo;s own category and per-sound overrides.</div>
+            </div>
+
+            <div class="field">
+                <label>Tags</label>
+                <div class="tags-input-wrap" id="tagsWrap" onclick="document.getElementById('tagsTextInput').focus()">
+                    <input class="tags-text-input" id="tagsTextInput" placeholder="Add tag&hellip;" onkeydown="onTagKeyDown(event)" />
+                </div>
+                <div class="field-hint">Press Enter or comma to add. Describe where this sound is used, e.g. &ldquo;combat&rdquo; or &ldquo;login screen&rdquo;.</div>
             </div>
 
             <div class="btn-row">
                 <button class="btn-save" onclick="saveEntry()">Save</button>
+                <button class="btn-delete" id="btnDelete" onclick="deleteEntry()" style="display:none">Delete</button>
+            </div>
+
+            <div id="unassignedCallout" style="display:none" class="unassigned-callout">
+                <h4>Unassigned Files</h4>
+                <p style="font-size:0.82rem;color:var(--color-text-muted);margin-bottom:0.6rem;">These files exist on disk but are not mapped to any sound identifier. Click &ldquo;Use&rdquo; to fill in the path above.</p>
+                <div id="unassignedList" class="unassigned-file-list"></div>
             </div>
         </div>
 
-        <div id="musicInfo" style="display:none">
-            <div class="music-info">
-                <strong id="musicInfoName"></strong>
-                Music files are served from <code>static/audio/music/</code> and are not configurable here.
+        <div id="musicPanel" style="display:none">
+            <div id="statusBarMusic" class="status-bar"></div>
+            <p class="section-title">Music File</p>
+            <div class="music-file-name" id="musicFileName"></div>
+            <div class="music-hint">Music files are served from <code>static/audio/music/</code> and are not configurable here. Place new <code>.mp3</code> files in that directory and they will appear automatically (files beginning with <code>_</code> are hidden).</div>
+            <div class="playback-preview">
+                <button class="preview-play-btn" id="musicPreviewPlayBtn" onclick="toggleMusicPreviewPlay()" title="Preview">&#9654;</button>
+                <div class="progress-wrap">
+                    <div class="preview-label" id="musicPreviewLabel">Ready</div>
+                    <div class="progress-bar-bg"><div class="progress-bar-fill" id="musicProgressFill"></div></div>
+                </div>
             </div>
         </div>
     </div>
@@ -130,10 +239,15 @@
 <script>
 let soundsData = {};
 let musicFiles = [];
+let soundFiles = [];
 let activeId = null;
 let activeType = null; // 'sound' | 'music'
+let isNew = false;
 let currentAudio = null;
 let currentPlayingId = null;
+let progressInterval = null;
+let filePickerVisible = false;
+let currentTags = [];
 
 async function loadAudio() {
     const res = await AdminAPI.get('/admin/api/v1/audio');
@@ -141,39 +255,51 @@ async function loadAudio() {
     const data = (res.data && res.data.data) || {};
     soundsData = data.sounds || {};
     musicFiles = data.music || [];
+    soundFiles = data.soundFiles || [];
     renderList();
 }
 
 function filterEntries() {
     const q = document.getElementById('entrySearch').value.toLowerCase();
-    document.querySelectorAll('.entry-row').forEach(row => {
-        const name = (row.dataset.id || '').toLowerCase();
-        row.style.display = name.includes(q) ? '' : 'none';
+    let lastLabel = null;
+    let labelHasVisible = false;
+    document.querySelectorAll('#entryList > *').forEach(el => {
+        if (el.classList.contains('list-section-label')) {
+            if (lastLabel) lastLabel.style.display = labelHasVisible ? '' : 'none';
+            lastLabel = el;
+            labelHasVisible = false;
+        } else if (el.classList.contains('entry-row')) {
+            const visible = !q || (el.dataset.id || '').toLowerCase().includes(q);
+            el.style.display = visible ? '' : 'none';
+            if (visible) labelHasVisible = true;
+        }
     });
-    document.querySelectorAll('.list-section-label').forEach(lbl => {
-        lbl.style.display = '';
-    });
+    if (lastLabel) lastLabel.style.display = labelHasVisible ? '' : 'none';
 }
 
 function renderList() {
     const list = document.getElementById('entryList');
     let html = '';
 
-    // Sounds section
     const soundIds = Object.keys(soundsData).sort();
     html += '<div class="list-section-label">Sounds</div>';
     if (soundIds.length === 0) {
         html += '<div class="no-entries">No sound entries.</div>';
     } else {
         soundIds.forEach(id => {
+            const entry = soundsData[id] || {};
+            const hasTags = entry.tags && entry.tags.length > 0;
+            const badge = hasTags
+                ? `<span class="entry-badge" title="${escAttr(entry.tags.join(', '))}">${escHtml(entry.tags[0])}</span>`
+                : '';
             html += `<div class="entry-row" data-id="${escAttr(id)}" data-type="sound">
                 <span class="entry-name" onclick="selectEntry(${escAttr(JSON.stringify(id))}, 'sound')">${escHtml(id)}</span>
+                ${badge}
                 <button class="play-btn" id="playbtn-sound-${escAttr(id)}" onclick="togglePlay(event, ${escAttr(JSON.stringify(id))}, 'sound')" title="Play">&#9654;</button>
             </div>`;
         });
     }
 
-    // Music section
     html += '<div class="list-section-label">Music</div>';
     if (musicFiles.length === 0) {
         html += '<div class="no-entries">No music files found.</div>';
@@ -189,55 +315,231 @@ function renderList() {
 
     list.innerHTML = html;
     if (activeId && activeType) highlightRow(activeId, activeType);
-    if (currentPlayingId) refreshPlayButton(currentPlayingId);
+    refreshAllPlayButtons();
+    filterEntries();
 }
 
 function highlightRow(id, type) {
     document.querySelectorAll('.entry-row').forEach(r => r.classList.remove('active'));
     const row = document.querySelector(`.entry-row[data-id="${escAttr(id)}"][data-type="${escAttr(type)}"]`);
-    if (row) row.classList.add('active');
+    if (row) { row.classList.add('active'); row.scrollIntoView({ block: 'nearest' }); }
 }
 
 function selectEntry(id, type) {
     activeId = id;
     activeType = type;
+    isNew = false;
     highlightRow(id, type);
-
-    document.getElementById('editorPlaceholder').style.display = 'none';
-    document.getElementById('soundForm').style.display = 'none';
-    document.getElementById('musicInfo').style.display = 'none';
-    document.getElementById('statusBar').className = 'status-bar';
-    document.getElementById('statusBar').textContent = '';
+    hideAllPanels();
 
     if (type === 'sound') {
         const entry = soundsData[id] || {};
         document.getElementById('soundForm').style.display = '';
-        document.getElementById('editorTitle').textContent = 'Edit: ' + id;
-        document.getElementById('fieldId').value = id;
+        document.getElementById('editorTitle').textContent = 'Edit Sound';
+        const idField = document.getElementById('fieldId');
+        idField.value = id;
+        idField.readOnly = true;
+        document.getElementById('fieldIdHint').innerHTML = `Used in code: <code>user.PlaySound("${escHtml(id)}", "category")</code>`;
         document.getElementById('fieldDescription').value = entry.description || '';
         document.getElementById('fieldFilePath').value = entry.filepath || '';
         document.getElementById('fieldVolume').value = entry.volume != null ? entry.volume : 0;
+        document.getElementById('btnDelete').style.display = '';
+        document.getElementById('unassignedCallout').style.display = 'none';
         updateVolumeDisplay();
+        updatePreviewLabel();
+        setTags(entry.tags || []);
+        hideFilePicker();
+        populateFilePicker();
     } else {
-        document.getElementById('musicInfo').style.display = '';
-        document.getElementById('musicInfoName').textContent = id.replace(/^.*\//, '');
+        showMusicPanel(id);
     }
+}
+
+function newSound() {
+    stopAudio();
+    activeId = null;
+    activeType = 'sound';
+    isNew = true;
+    document.querySelectorAll('.entry-row').forEach(r => r.classList.remove('active'));
+    hideAllPanels();
+    document.getElementById('soundForm').style.display = '';
+    document.getElementById('editorTitle').textContent = 'New Sound';
+    const idField = document.getElementById('fieldId');
+    idField.value = '';
+    idField.readOnly = false;
+    document.getElementById('fieldIdHint').innerHTML = 'Choose a unique identifier used in code to trigger this sound.';
+    document.getElementById('fieldDescription').value = '';
+    document.getElementById('fieldFilePath').value = '';
+    document.getElementById('fieldVolume').value = 0;
+    document.getElementById('btnDelete').style.display = 'none';
+    updateVolumeDisplay();
+    updatePreviewLabel();
+    setTags([]);
+    hideFilePicker();
+    populateFilePicker();
+    renderUnassignedFiles();
+    idField.focus();
+}
+
+function showMusicPanel(path) {
+    document.getElementById('musicPanel').style.display = '';
+    document.getElementById('musicFileName').textContent = path.replace(/^.*\//, '');
+    document.getElementById('musicPreviewLabel').textContent = 'Ready';
+    document.getElementById('musicProgressFill').style.width = '0%';
+    const btn = document.getElementById('musicPreviewPlayBtn');
+    btn.textContent = '\u25B6';
+    btn.classList.remove('playing');
+}
+
+function renderUnassignedFiles() {
+    const assignedPaths = new Set(Object.values(soundsData).map(e => e.filepath).filter(Boolean));
+    const allFiles = [...soundFiles, ...musicFiles];
+    const unassigned = allFiles.filter(f => !assignedPaths.has(f));
+
+    const callout = document.getElementById('unassignedCallout');
+    const listEl = document.getElementById('unassignedList');
+    if (unassigned.length === 0) { callout.style.display = 'none'; return; }
+
+    callout.style.display = '';
+    listEl.innerHTML = unassigned.map(f =>
+        `<div class="unassigned-file-row">
+            <button class="btn-play-small" id="uplaybtn-${escAttr(f)}" onclick="togglePlayPath(event, ${escAttr(JSON.stringify(f))})" title="Preview">&#9654;</button>
+            <span class="unassigned-file-path" title="${escAttr(f)}">${escHtml(f)}</span>
+            <button class="btn-assign" onclick="assignFile(${escAttr(JSON.stringify(f))})">Use</button>
+        </div>`
+    ).join('');
+}
+
+function assignFile(filepath) {
+    stopAudio();
+    const name = filepath.replace(/^.*\//, '').replace(/\.[^.]+$/, '');
+    document.getElementById('fieldFilePath').value = filepath;
+    document.getElementById('fieldId').value = name;
+    updatePreviewLabel();
+    const sel = document.getElementById('filePicker');
+    sel.value = filepath;
+}
+
+function hideAllPanels() {
+    document.getElementById('editorPlaceholder').style.display = 'none';
+    document.getElementById('soundForm').style.display = 'none';
+    document.getElementById('musicPanel').style.display = 'none';
+    const sb = document.getElementById('statusBar');
+    sb.className = 'status-bar'; sb.textContent = '';
+    const sbm = document.getElementById('statusBarMusic');
+    sbm.className = 'status-bar'; sbm.textContent = '';
+}
+
+// ---- Tags ----
+
+function setTags(tags) {
+    currentTags = tags.slice();
+    renderTagChips();
+}
+
+function renderTagChips() {
+    const wrap = document.getElementById('tagsWrap');
+    const input = document.getElementById('tagsTextInput');
+    wrap.querySelectorAll('.tag-chip').forEach(c => c.remove());
+    currentTags.forEach((tag, i) => {
+        const chip = document.createElement('span');
+        chip.className = 'tag-chip';
+        chip.innerHTML = `${escHtml(tag)}<button class="tag-chip-remove" onclick="removeTag(${i})" title="Remove">&times;</button>`;
+        wrap.insertBefore(chip, input);
+    });
+    input.placeholder = currentTags.length === 0 ? 'Add tag\u2026' : '';
+}
+
+function removeTag(index) {
+    currentTags.splice(index, 1);
+    renderTagChips();
+}
+
+function onTagKeyDown(e) {
+    if (e.key === 'Enter' || e.key === ',') {
+        e.preventDefault();
+        commitTag();
+    } else if (e.key === 'Backspace' && e.target.value === '' && currentTags.length > 0) {
+        currentTags.pop();
+        renderTagChips();
+    }
+}
+
+function commitTag() {
+    const input = document.getElementById('tagsTextInput');
+    const val = input.value.replace(/,/g, '').trim();
+    if (val && !currentTags.includes(val)) {
+        currentTags.push(val);
+        renderTagChips();
+    }
+    input.value = '';
+}
+
+// ---- File picker ----
+
+function populateFilePicker() {
+    const sel = document.getElementById('filePicker');
+    const allFiles = [...soundFiles, ...musicFiles];
+    if (allFiles.length === 0) { sel.innerHTML = '<option value="" disabled>No files found</option>'; return; }
+    sel.innerHTML = '<option value="">-- select a file --</option>' +
+        allFiles.map(f => `<option value="${escAttr(f)}">${escHtml(f)}</option>`).join('');
+    const cur = document.getElementById('fieldFilePath').value.trim();
+    if (cur) sel.value = cur;
+}
+
+function toggleFilePicker() {
+    filePickerVisible = !filePickerVisible;
+    document.getElementById('filePickerWrap').style.display = filePickerVisible ? '' : 'none';
+    document.getElementById('filePickerToggle').textContent = filePickerVisible ? 'Hide' : 'Browse';
+}
+
+function hideFilePicker() {
+    filePickerVisible = false;
+    document.getElementById('filePickerWrap').style.display = 'none';
+    document.getElementById('filePickerToggle').textContent = 'Browse';
+}
+
+function onFilePickerChange() {
+    const sel = document.getElementById('filePicker');
+    if (sel.value) {
+        document.getElementById('fieldFilePath').value = sel.value;
+        updatePreviewLabel();
+    }
+}
+
+function onFilePathInput() {
+    const val = document.getElementById('fieldFilePath').value.trim();
+    document.getElementById('filePicker').value = val || '';
+    updatePreviewLabel();
 }
 
 // ---- Playback ----
 
-function togglePlay(evt, id, type) {
-    evt.stopPropagation();
-    if (currentPlayingId === id && currentAudio && !currentAudio.paused) {
-        stopAudio();
-    } else {
-        playAudio(id, type);
-    }
+function updatePreviewLabel() {
+    const fp = document.getElementById('fieldFilePath').value.trim();
+    document.getElementById('previewLabel').textContent = fp ? fp.replace(/^.*\//, '') : 'No file selected';
+    document.getElementById('progressFill').style.width = '0%';
+    const btn = document.getElementById('previewPlayBtn');
+    if (!fp) { btn.textContent = '\u25B6'; btn.classList.remove('playing'); }
 }
 
-function playAudio(id, type) {
-    stopAudio();
+function togglePreviewPlay() {
+    const fp = document.getElementById('fieldFilePath').value.trim();
+    if (!fp) return;
+    const src = '/' + fp.replace(/^\//, '');
+    if (currentPlayingId === src && currentAudio && !currentAudio.paused) { stopAudio(); }
+    else { playAudioSrc(src); }
+}
 
+function toggleMusicPreviewPlay() {
+    if (!activeId || activeType !== 'music') return;
+    const src = '/' + activeId.replace(/^\//, '');
+    if (currentPlayingId === src && currentAudio && !currentAudio.paused) { stopAudio(); }
+    else { playAudioSrc(src); }
+}
+
+function togglePlay(evt, id, type) {
+    evt.stopPropagation();
     let src;
     if (type === 'sound') {
         const entry = soundsData[id] || {};
@@ -245,90 +547,159 @@ function playAudio(id, type) {
     } else {
         src = '/' + id;
     }
+    if (!src) return;
+    if (currentPlayingId === src && currentAudio && !currentAudio.paused) { stopAudio(); }
+    else { playAudioSrc(src); }
+}
 
-    if (!src) {
-        return;
-    }
+function togglePlayPath(evt, filepath) {
+    evt.stopPropagation();
+    const src = '/' + filepath.replace(/^\//, '');
+    if (currentPlayingId === src && currentAudio && !currentAudio.paused) { stopAudio(); }
+    else { playAudioSrc(src); }
+}
 
+function playAudioSrc(src) {
+    stopAudio();
     currentAudio = new Audio(src);
-    currentPlayingId = id;
-    refreshPlayButton(id);
+    currentPlayingId = src;
+    refreshAllPlayButtons();
 
-    currentAudio.addEventListener('ended', () => {
-        currentPlayingId = null;
-        currentAudio = null;
-        refreshPlayButton(id);
-    });
-    currentAudio.addEventListener('error', () => {
-        currentPlayingId = null;
-        currentAudio = null;
-        refreshPlayButton(id);
-    });
+    clearInterval(progressInterval);
+    progressInterval = setInterval(() => {
+        if (!currentAudio || currentAudio.paused) { clearInterval(progressInterval); return; }
+        const pct = currentAudio.duration ? (currentAudio.currentTime / currentAudio.duration) * 100 : 0;
+        document.getElementById('progressFill').style.width = pct + '%';
+        document.getElementById('musicProgressFill').style.width = pct + '%';
+    }, 100);
 
-    currentAudio.play().catch(() => {
-        currentPlayingId = null;
-        currentAudio = null;
-        refreshPlayButton(id);
-    });
+    currentAudio.addEventListener('ended', () => { stopAudio(); });
+    currentAudio.addEventListener('error', () => { stopAudio(); });
+    currentAudio.play().catch(() => { stopAudio(); });
 }
 
 function stopAudio() {
+    clearInterval(progressInterval);
     if (currentAudio) {
         currentAudio.pause();
         currentAudio.currentTime = 0;
-        const prev = currentPlayingId;
         currentAudio = null;
-        currentPlayingId = null;
-        if (prev) refreshPlayButton(prev);
     }
+    currentPlayingId = null;
+    document.getElementById('progressFill').style.width = '0%';
+    document.getElementById('musicProgressFill').style.width = '0%';
+    refreshAllPlayButtons();
 }
 
-function refreshPlayButton(id) {
-    // Reset all play buttons first, then set the active one
-    document.querySelectorAll('.play-btn').forEach(btn => {
-        btn.textContent = '\u25B6';
-        btn.classList.remove('playing');
-        btn.title = 'Play';
+function refreshAllPlayButtons() {
+    document.querySelectorAll('.play-btn').forEach(btn => { btn.textContent = '\u25B6'; btn.classList.remove('playing'); btn.title = 'Play'; });
+    document.querySelectorAll('.btn-play-small').forEach(btn => { btn.textContent = '\u25B6'; btn.classList.remove('playing'); });
+    const previewBtn = document.getElementById('previewPlayBtn');
+    if (previewBtn) { previewBtn.textContent = '\u25B6'; previewBtn.classList.remove('playing'); }
+    const musicBtn = document.getElementById('musicPreviewPlayBtn');
+    if (musicBtn) { musicBtn.textContent = '\u25B6'; musicBtn.classList.remove('playing'); }
+
+    if (!currentPlayingId) return;
+
+    Object.entries(soundsData).forEach(([id, entry]) => {
+        if (entry.filepath && '/' + entry.filepath.replace(/^\//, '') === currentPlayingId) {
+            const btn = document.getElementById(`playbtn-sound-${id}`);
+            if (btn) { btn.textContent = '\u25A0'; btn.classList.add('playing'); btn.title = 'Stop'; }
+        }
     });
-    if (currentPlayingId) {
-        // Find the button for the currently playing entry (could be sound or music)
-        ['sound', 'music'].forEach(type => {
-            const btn = document.getElementById(`playbtn-${type}-${currentPlayingId}`);
-            if (btn) {
-                btn.textContent = '\u25A0';
-                btn.classList.add('playing');
-                btn.title = 'Stop';
-            }
-        });
+    musicFiles.forEach(path => {
+        if ('/' + path === currentPlayingId) {
+            const btn = document.getElementById(`playbtn-music-${path}`);
+            if (btn) { btn.textContent = '\u25A0'; btn.classList.add('playing'); btn.title = 'Stop'; }
+        }
+    });
+    document.querySelectorAll('.btn-play-small').forEach(btn => {
+        const row = btn.closest('.unassigned-file-row');
+        if (!row) return;
+        const pathSpan = row.querySelector('.unassigned-file-path');
+        if (pathSpan && '/' + pathSpan.title.replace(/^\//, '') === currentPlayingId) {
+            btn.textContent = '\u25A0'; btn.classList.add('playing');
+        }
+    });
+    const fp = document.getElementById('fieldFilePath');
+    if (fp && fp.value && '/' + fp.value.replace(/^\//, '') === currentPlayingId) {
+        if (previewBtn) { previewBtn.textContent = '\u25A0'; previewBtn.classList.add('playing'); }
+    }
+    if (activeType === 'music' && activeId && '/' + activeId === currentPlayingId) {
+        if (musicBtn) { musicBtn.textContent = '\u25A0'; musicBtn.classList.add('playing'); }
     }
 }
 
 function updateVolumeDisplay() {
     const val = parseInt(document.getElementById('fieldVolume').value, 10) || 0;
     document.getElementById('volumeValueDisplay').textContent = val;
-    document.getElementById('volumeDefaultLabel').textContent = val === 0 ? 'Default volume' : '';
+    document.getElementById('volumeDefaultLabel').textContent = val === 0 ? 'Default volume (100%)' : '';
 }
 
+// ---- Save / Delete ----
 
 async function saveEntry() {
-    if (!activeId || activeType !== 'sound') return;
+    commitTag();
+    const id = document.getElementById('fieldId').value.trim();
+    if (!id) { showStatus('error', 'Identifier is required.'); return; }
+
     const description = document.getElementById('fieldDescription').value.trim();
     const filepath = document.getElementById('fieldFilePath').value.trim();
     const volume = parseInt(document.getElementById('fieldVolume').value, 10) || 0;
+    const tags = currentTags.slice();
 
-    const updated = Object.assign({}, soundsData);
-    updated[activeId] = { description, filepath, volume };
-
-    const res = await AdminAPI.patch('/admin/api/v1/audio', updated);
-    if (res.ok) {
-        const data = (res.data && res.data.data) || {};
-        soundsData = data.sounds || updated;
-        musicFiles = data.music || musicFiles;
-        renderList();
-        highlightRow(activeId, 'sound');
-        showStatus('success', `Entry "${activeId}" saved.`);
+    if (isNew) {
+        const res = await AdminAPI.post('/admin/api/v1/audio', { identifier: id, description, filepath, volume, tags });
+        if (res.ok) {
+            const data = (res.data && res.data.data) || {};
+            soundsData = data.sounds || soundsData;
+            musicFiles = data.music || musicFiles;
+            soundFiles = data.soundFiles || soundFiles;
+            activeId = id;
+            activeType = 'sound';
+            isNew = false;
+            renderList();
+            highlightRow(id, 'sound');
+            document.getElementById('fieldId').readOnly = true;
+            document.getElementById('btnDelete').style.display = '';
+            document.getElementById('unassignedCallout').style.display = 'none';
+            document.getElementById('fieldIdHint').innerHTML = `Used in code: <code>user.PlaySound("${escHtml(id)}", "category")</code>`;
+            showStatus('success', `Sound "${id}" created.`);
+        } else {
+            showStatus('error', res.error || 'Create failed.');
+        }
     } else {
-        showStatus('error', res.error || 'Save failed.');
+        const updated = Object.assign({}, soundsData);
+        updated[activeId] = Object.assign({}, soundsData[activeId] || {}, { description, filepath, volume, tags });
+        const res = await AdminAPI.patch('/admin/api/v1/audio', updated);
+        if (res.ok) {
+            const data = (res.data && res.data.data) || {};
+            soundsData = data.sounds || updated;
+            musicFiles = data.music || musicFiles;
+            soundFiles = data.soundFiles || soundFiles;
+            renderList();
+            highlightRow(activeId, 'sound');
+            showStatus('success', `Sound "${activeId}" saved.`);
+        } else {
+            showStatus('error', res.error || 'Save failed.');
+        }
+    }
+}
+
+async function deleteEntry() {
+    if (!activeId || activeType !== 'sound') return;
+    if (!confirm(`Delete sound "${activeId}"? This cannot be undone.`)) return;
+
+    const res = await AdminAPI.delete(`/admin/api/v1/audio/${encodeURIComponent(activeId)}`);
+    if (res.ok) {
+        delete soundsData[activeId];
+        activeId = null;
+        activeType = null;
+        renderList();
+        hideAllPanels();
+        document.getElementById('editorPlaceholder').style.display = '';
+    } else {
+        showStatus('error', res.error || 'Delete failed.');
     }
 }
 
@@ -341,6 +712,17 @@ function showStatus(type, msg) {
 
 function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 function escAttr(s) { return String(s).replace(/"/g,'&quot;'); }
+
+// AdminAPI.delete shim
+if (AdminAPI && !AdminAPI.delete) {
+    AdminAPI.delete = async function(url) {
+        try {
+            const resp = await fetch(url, { method: 'DELETE', headers: { 'Content-Type': 'application/json' } });
+            const json = await resp.json().catch(() => ({}));
+            return { ok: resp.ok && json.success !== false, data: json, error: json.error || (resp.ok ? null : resp.statusText) };
+        } catch(e) { return { ok: false, error: String(e) }; }
+    };
+}
 
 loadAudio();
 </script>

--- a/_datafiles/html/admin/conversations.html
+++ b/_datafiles/html/admin/conversations.html
@@ -114,27 +114,77 @@
     .supported-row .btn-icon { background: none; border: none; cursor: pointer; color: var(--color-text-placeholder); font-size: 1rem; line-height: 1; padding: 0 0.15rem; flex-shrink: 0; margin-top: 0.35rem; }
     .supported-row .btn-icon:hover { color: var(--color-danger); }
 
-    /* ---- turn list ---- */
+    /* ---- turn / phase list ---- */
     .turns-hint { font-size: 0.75rem; color: var(--color-text-faint); margin-bottom: 0.5rem; line-height: 1.5; }
-    .turn-rows { display: flex; flex-direction: column; gap: 0.35rem; }
-    .turn-row { display: flex; gap: 0.5rem; align-items: flex-start; }
-    .turn-row-num { font-size: 0.7rem; color: var(--color-btn-cancel-hover); font-family: monospace; padding-top: 0.45rem; min-width: 1.6rem; text-align: right; flex-shrink: 0; }
+    .turn-rows { display: flex; flex-direction: column; gap: 0.5rem; }
+
+    /* Phase card — one card per game-round turn */
+    .phase-card {
+        border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden;
+        transition: border-left-width 0.12s, border-left-color 0.12s;
+    }
+    .phase-card.phase-grouped {
+        border-left: 3px solid var(--color-info-text);
+    }
+    .phase-header {
+        background: var(--color-surface-raised); padding: 0.35rem 0.65rem;
+        display: flex; align-items: center; gap: 0.55rem;
+        border-bottom: 1px solid var(--color-border-light);
+    }
+    .phase-num {
+        background: var(--color-primary); color: var(--color-primary-on);
+        border-radius: 10px; font-size: 0.68rem; font-weight: 700;
+        padding: 0.15rem 0.55rem; min-width: 1.6rem; text-align: center;
+        font-family: monospace; flex-shrink: 0;
+    }
+    .phase-sim-badge {
+        display: none;
+        background: var(--color-info-bg); color: var(--color-info-text);
+        border-radius: 10px; font-size: 0.65rem; font-weight: 700;
+        padding: 0.12rem 0.55rem; letter-spacing: 0.04em; text-transform: uppercase;
+        flex-shrink: 0;
+    }
+    .phase-card.phase-grouped .phase-sim-badge { display: inline-block; }
+    .phase-header .phase-remove {
+        margin-left: auto; background: none; border: none; cursor: pointer;
+        color: var(--color-text-placeholder); font-size: 1rem; line-height: 1; padding: 0 0.15rem;
+    }
+    .phase-header .phase-remove:hover { color: var(--color-danger); }
+    .phase-body {
+        padding: 0.5rem 0.65rem; display: flex; flex-direction: column; gap: 0.3rem;
+        background: var(--color-surface-white);
+    }
+    .phase-card.phase-grouped .phase-body {
+        background: var(--color-row-hover);
+    }
+
+    /* Individual command line within a phase */
+    .phase-cmd-line { display: flex; gap: 0.4rem; align-items: center; }
     .turn-speaker {
-        width: 4.5rem; flex-shrink: 0; padding: 0.35rem 0.45rem; border: 1px solid var(--color-border-medium);
+        width: 4.5rem; flex-shrink: 0; padding: 0.32rem 0.4rem; border: 1px solid var(--color-border-medium);
         border-radius: 4px; font-size: 0.82rem; font-family: monospace; background: var(--color-surface-white);
         text-align: center;
     }
     .turn-speaker:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; border-color: transparent; }
     .turn-cmd {
-        flex: 1; padding: 0.35rem 0.55rem; border: 1px solid var(--color-border-medium); border-radius: 4px;
+        flex: 1; padding: 0.32rem 0.5rem; border: 1px solid var(--color-border-medium); border-radius: 4px;
         font-size: 0.83rem; font-family: monospace; background: var(--color-surface-white);
     }
     .turn-cmd:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; border-color: transparent; }
-    .turn-row .btn-icon { background: none; border: none; cursor: pointer; color: var(--color-text-placeholder); font-size: 1rem; line-height: 1; padding: 0 0.15rem; flex-shrink: 0; margin-top: 0.35rem; }
-    .turn-row .btn-icon:hover { color: var(--color-danger); }
-    .turn-row-actions { display: flex; gap: 0.2rem; flex-direction: column; flex-shrink: 0; }
-    .turn-row-actions .btn-micro { background: none; border: 1px solid var(--color-border); border-radius: 3px; cursor: pointer; font-size: 0.7rem; color: var(--color-text-placeholder); padding: 0.1rem 0.3rem; line-height: 1; }
-    .turn-row-actions .btn-micro:hover { color: var(--color-primary); border-color: var(--color-text-placeholder); }
+    .phase-cmd-line .cmd-remove {
+        background: none; border: none; cursor: pointer;
+        color: var(--color-text-placeholder); font-size: 0.9rem; line-height: 1; padding: 0 0.1rem; flex-shrink: 0;
+    }
+    .phase-cmd-line .cmd-remove:hover { color: var(--color-danger); }
+
+    /* Add-simultaneous button inside a phase body */
+    .btn-add-sim {
+        font-size: 0.72rem; padding: 0.18rem 0.55rem;
+        border: 1px dashed var(--color-text-placeholder); background: none;
+        border-radius: 4px; cursor: pointer; color: var(--color-text-muted);
+        width: fit-content; margin-top: 0.1rem;
+    }
+    .btn-add-sim:hover { border-color: var(--color-info-text); color: var(--color-info-text); }
 
     .btn-add-sm { font-size: 0.8rem; padding: 0.3rem 0.7rem; border: 1px dashed var(--color-text-placeholder); background: none; border-radius: 4px; cursor: pointer; color: var(--color-text-muted); margin-top: 0.3rem; }
     .btn-add-sm:hover { border-color: var(--color-primary); color: var(--color-primary); }
@@ -706,65 +756,71 @@
     };
 
     // -------------------------------------------------------------------------
-    // Turn rows
+    // Turn / phase rows
     // -------------------------------------------------------------------------
     function appendTurnRow(container, cmds) {
-        // Each turn is an array of commands. We render the first command inline;
-        // additional commands in the same turn are shown as sub-rows.
-        const row = document.createElement('div');
-        row.className = 'turn-row';
+        const card = document.createElement('div');
+        card.className = 'phase-card';
 
-        const num = document.createElement('span');
-        num.className = 'turn-row-num';
-        renumberTurns(container, num);
+        // Header: phase number badge + simultaneous badge + remove button
+        const header = document.createElement('div');
+        header.className = 'phase-header';
 
-        // We store all commands for this turn in a sub-container
-        const cmdWrap = document.createElement('div');
-        cmdWrap.className = 'turn-cmds';
-        cmdWrap.style.cssText = 'flex:1; display:flex; flex-direction:column; gap:0.25rem;';
+        const numBadge = document.createElement('span');
+        numBadge.className = 'phase-num';
+        numBadge.textContent = String(container.querySelectorAll('.phase-card').length + 1);
 
-        const firstCmd = (cmds && cmds.length) ? cmds[0] : '';
-        appendCmdLine(cmdWrap, firstCmd);
-        for (let i = 1; i < (cmds || []).length; i++) {
-            appendCmdLine(cmdWrap, cmds[i]);
-        }
-
-        const addCmdBtn = document.createElement('button');
-        addCmdBtn.type = 'button';
-        addCmdBtn.className = 'btn-add-sm';
-        addCmdBtn.style.cssText = 'font-size:0.72rem; padding:0.15rem 0.5rem; margin-top:0.15rem; width:fit-content;';
-        addCmdBtn.textContent = '+ simultaneous cmd';
-        addCmdBtn.title = 'Add another command that runs in the same round as this turn';
-        addCmdBtn.onclick = () => appendCmdLine(cmdWrap, '');
-        cmdWrap.appendChild(addCmdBtn);
+        const simBadge = document.createElement('span');
+        simBadge.className = 'phase-sim-badge';
+        simBadge.textContent = 'simultaneous';
 
         const removeBtn = document.createElement('button');
         removeBtn.type = 'button';
-        removeBtn.className = 'btn-icon';
-        removeBtn.title = 'Remove turn';
+        removeBtn.className = 'phase-remove';
+        removeBtn.title = 'Remove this turn';
         removeBtn.textContent = '\u00d7';
-        removeBtn.style.marginTop = '0.35rem';
         removeBtn.onclick = () => {
-            row.remove();
+            card.remove();
             renumberAllTurns(container);
         };
 
-        row.appendChild(num);
-        row.appendChild(cmdWrap);
-        row.appendChild(removeBtn);
-        container.appendChild(row);
+        header.appendChild(numBadge);
+        header.appendChild(simBadge);
+        header.appendChild(removeBtn);
+
+        // Body: command lines + add-simultaneous button
+        const body = document.createElement('div');
+        body.className = 'phase-body';
+
+        const addSimBtn = document.createElement('button');
+        addSimBtn.type = 'button';
+        addSimBtn.className = 'btn-add-sim';
+        addSimBtn.textContent = '+ simultaneous cmd';
+        addSimBtn.title = 'Add another command that runs in the same round';
+        addSimBtn.onclick = () => appendCmdLine(body, '');
+        body.appendChild(addSimBtn);
+
+        // Populate command lines (insert before the add button)
+        const cmdList = (cmds && cmds.length) ? cmds : [''];
+        for (const cmd of cmdList) {
+            appendCmdLine(body, cmd);
+        }
+
+        card.appendChild(header);
+        card.appendChild(body);
+        container.appendChild(card);
         renumberAllTurns(container);
+        updatePhaseGrouped(card);
     }
 
-    function appendCmdLine(cmdWrap, value) {
+    function appendCmdLine(body, value) {
         const line = document.createElement('div');
-        line.style.cssText = 'display:flex; gap:0.4rem; align-items:center;';
+        line.className = 'phase-cmd-line';
 
         const speakerSel = document.createElement('select');
         speakerSel.className = 'turn-speaker';
-        speakerSel.style.cssText = 'width:5rem; flex-shrink:0; padding:0.35rem 0.45rem; border:1px solid var(--color-border-medium); border-radius:4px; font-size:0.82rem; font-family:monospace; background:var(--color-surface-white);';
         speakerSel.title = '#1 = initiator, #2 = participant';
-        [['#1', '#1 (initiator)'], ['#2', '#2 (participant)']].forEach(([val, label]) => {
+        [['#1', '#1 (initiator)'], ['#2', '#2 (participant)']].forEach(([val]) => {
             const o = document.createElement('option');
             o.value = val; o.textContent = val;
             speakerSel.appendChild(o);
@@ -775,7 +831,6 @@
         cmdInput.className = 'turn-cmd';
         cmdInput.placeholder = 'e.g. say Hello there!';
 
-        // Parse existing value: split on first space after #1/#2 prefix
         const trimmed = (value || '').trim();
         const match = trimmed.match(/^(#[12])\s+(.*)$/);
         if (match) {
@@ -788,25 +843,32 @@
 
         const removeBtn = document.createElement('button');
         removeBtn.type = 'button';
-        removeBtn.className = 'btn-icon';
+        removeBtn.className = 'cmd-remove';
         removeBtn.title = 'Remove command';
         removeBtn.textContent = '\u00d7';
-        removeBtn.style.cssText = 'background:none; border:none; cursor:pointer; color:var(--color-text-placeholder); font-size:0.9rem; line-height:1; padding:0 0.1rem; flex-shrink:0;';
         removeBtn.onclick = () => {
-            // Don't remove the last cmd line in a turn
-            const lines = cmdWrap.querySelectorAll('div');
-            if (lines.length <= 1) return;
+            const card = body.closest('.phase-card');
+            if (body.querySelectorAll('.phase-cmd-line').length <= 1) return;
             line.remove();
+            updatePhaseGrouped(card);
         };
 
         line.appendChild(speakerSel);
         line.appendChild(cmdInput);
         line.appendChild(removeBtn);
 
-        // Insert before the "+ simultaneous cmd" button if it exists
-        const addBtn = cmdWrap.querySelector('.btn-add-sm');
-        if (addBtn) cmdWrap.insertBefore(line, addBtn);
-        else cmdWrap.appendChild(line);
+        // Insert before the add-sim button
+        const addBtn = body.querySelector('.btn-add-sim');
+        if (addBtn) body.insertBefore(line, addBtn);
+        else body.appendChild(line);
+
+        const card = body.closest('.phase-card');
+        if (card) updatePhaseGrouped(card);
+    }
+
+    function updatePhaseGrouped(card) {
+        const count = card.querySelectorAll('.phase-cmd-line').length;
+        card.classList.toggle('phase-grouped', count > 1);
     }
 
     window.addTurnRow = function (btn) {
@@ -814,16 +876,10 @@
         appendTurnRow(turnRows, ['']);
     };
 
-    function renumberTurns(container, numEl) {
-        // Used during initial append before the row is in the DOM
-        const count = container.querySelectorAll('.turn-row').length;
-        numEl.textContent = (count + 1) + '.';
-    }
-
     function renumberAllTurns(container) {
-        container.querySelectorAll('.turn-row').forEach((row, i) => {
-            const num = row.querySelector('.turn-row-num');
-            if (num) num.textContent = (i + 1) + '.';
+        container.querySelectorAll('.phase-card').forEach((card, i) => {
+            const num = card.querySelector('.phase-num');
+            if (num) num.textContent = String(i + 1);
         });
     }
 
@@ -856,9 +912,9 @@
 
             // Conversation (array of turns, each turn is array of command strings)
             const conversation = [];
-            block.querySelectorAll('.turn-row').forEach(row => {
+            block.querySelectorAll('.phase-card').forEach(card => {
                 const cmds = [];
-                row.querySelectorAll('.turn-cmds > div').forEach(line => {
+                card.querySelectorAll('.phase-cmd-line').forEach(line => {
                     const speaker = line.querySelector('select') ? line.querySelector('select').value : '#1';
                     const cmd     = (line.querySelector('input[type="text"]') || {}).value || '';
                     const full    = (cmd.trim()) ? speaker + ' ' + cmd.trim() : '';

--- a/_datafiles/html/admin/items-attack-messages.html
+++ b/_datafiles/html/admin/items-attack-messages.html
@@ -56,6 +56,7 @@
         display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.35rem 0;
         border-bottom: 1px solid var(--color-page-bg); font-size: 0.84rem;
     }
+    .msg-item.editing { align-items: flex-start; background: var(--color-row-hover); padding: 0.5rem 0.35rem; border-radius: 4px; border-bottom-color: var(--color-border-medium); }
     .msg-index {
         font-size: 0.72rem; color: var(--color-text-secondary); font-family: monospace; min-width: 1.5rem;
         text-align: right; padding-top: 0.15rem; flex-shrink: 0;
@@ -106,7 +107,35 @@
 
     .empty-msg { font-size: 0.82rem; color: var(--color-text-placeholder); font-style: italic; padding: 0.3rem 0; }
 
-    .msg-add-warning {
+    .msg-edit {
+        background: none; border: none; cursor: pointer; color: var(--color-text-placeholder); font-size: 0.85rem; padding: 0 0.2rem;
+        flex-shrink: 0; line-height: 1.2;
+    }
+    .msg-edit:hover { color: var(--color-primary); }
+
+    .msg-inline-edit { flex: 1; display: flex; flex-direction: column; gap: 0.35rem; }
+    .msg-inline-edit textarea {
+        width: 100%; padding: 0.3rem 0.45rem; border: 1px solid var(--color-primary);
+        border-radius: 4px; font-size: 0.82rem; font-family: monospace; resize: vertical; min-height: 2.2rem;
+    }
+    .msg-inline-edit textarea:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; border-color: transparent; }
+    .msg-inline-actions { display: flex; gap: 0.35rem; align-items: center; }
+    .btn-save-edit {
+        padding: 0.25rem 0.65rem; background: var(--color-primary); color: var(--color-surface-white);
+        border: none; border-radius: 4px; font-size: 0.78rem; font-weight: 600; cursor: pointer;
+    }
+    .btn-save-edit:hover { background: var(--color-primary-hover); }
+    .btn-save-edit:disabled { background: var(--color-btn-disabled); cursor: default; }
+    .btn-cancel-edit {
+        padding: 0.25rem 0.65rem; background: none; color: var(--color-text-muted);
+        border: 1px solid var(--color-border-medium); border-radius: 4px; font-size: 0.78rem; cursor: pointer;
+    }
+    .btn-cancel-edit:hover { border-color: var(--color-text-subtle); color: var(--color-text); }
+    .msg-inline-preview {
+        font-family: monospace; font-size: 0.78rem;
+        background: var(--color-code-bg); color: var(--color-border-medium);
+        border-radius: 3px; padding: 0.2rem 0.4rem; min-height: 1.3em;
+    }
         display: none; font-size: 0.78rem; color: var(--color-error-text); background: var(--color-error-bg);
         border: 1px solid var(--color-danger); border-radius: 4px; padding: 0.3rem 0.55rem;
         margin-top: 0.3rem; line-height: 1.4;
@@ -140,7 +169,7 @@
         white-space: pre;
         pointer-events: none;
         z-index: 9999;
-        max-width: 600px;
+        width: max-content;
     }
 </style>
 
@@ -326,24 +355,25 @@
                 renderProximitySection('separate', 'Separate Rooms', 'Combatants are in different rooms (ranged only)', SEPARATE_TARGETS, sep, int) +
             '</div>';
         }).join('');
-
-        document.querySelectorAll('.proximity-section').forEach(function(s) {
-            s.classList.add('open');
-        });
     }
 
     function renderProximitySection(proximity, title, hint, targets, data, intensity) {
-        var html = '<div class="proximity-section open">' +
-            '<div class="proximity-header" onclick="this.parentElement.classList.toggle(\'open\')">' +
+        var hasAny = false;
+        for (var i = 0; i < targets.length; i++) {
+            var key = capitalizeTarget(targets[i]);
+            if ((data[key] || []).length > 0) { hasAny = true; break; }
+        }
+
+        var html = '<div class="proximity-section' + (hasAny ? ' open' : '') + '">' +
+            '<div class="proximity-header" onclick="this.parentElement.classList.toggle(\'open\')">'+
                 '<span class="arrow">&#9654;</span> ' + escHtml(title) +
                 ' <span class="proximity-hint">(' + escHtml(hint) + ')</span>' +
             '</div>' +
             '<div class="proximity-body">';
 
-        for (var i = 0; i < targets.length; i++) {
-            var t = targets[i];
-            var key = t.charAt(0).toUpperCase() === t.charAt(0) ? t : capitalizeTarget(t);
-            var msgs = data[key] || [];
+        for (var j = 0; j < targets.length; j++) {
+            var t = targets[j];
+            var msgs = data[capitalizeTarget(t)] || [];
             html += renderTargetGroup(intensity, proximity, t, msgs);
         }
 
@@ -372,9 +402,10 @@
             html += '<li class="empty-msg">No messages defined.</li>';
         } else {
             for (var i = 0; i < msgs.length; i++) {
-                html += '<li class="msg-item">' +
+                html += '<li class="msg-item" id="msg-item-' + id + '-' + i + '">' +
                     '<span class="msg-index">' + i + '</span>' +
                     '<span class="msg-text" onmouseenter="showAnsiTooltip(event,this)" onmouseleave="hideAnsiTooltip()">' + escHtml(msgs[i]) + '</span>' +
+                    '<button class="msg-edit" title="Edit" onclick="editMsg(\'' + escAttr(intensity) + '\',\'' + escAttr(proximity) + '\',\'' + escAttr(target) + '\',' + i + ')" aria-label="Edit message">&#9998;</button>' +
                     '<button class="msg-delete" title="Delete" onclick="deleteMsg(\'' + escAttr(intensity) + '\',\'' + escAttr(proximity) + '\',\'' + escAttr(target) + '\',' + i + ')">&times;</button>' +
                 '</li>';
             }
@@ -528,6 +559,94 @@
     document.addEventListener('mousemove', function(event) {
         if (_ansiTooltip && _ansiTooltip.style.display === 'block') positionTooltip(event);
     });
+
+    function editMsg(intensity, proximity, target, index) {
+        var id = intensity + '-' + proximity + '-' + target;
+        var li = document.getElementById('msg-item-' + id + '-' + index);
+        if (!li || li.classList.contains('editing')) return;
+
+        var textEl = li.querySelector('.msg-text');
+        var rawText = textEl ? textEl.textContent : '';
+
+        li.classList.add('editing');
+        // Hide the static display elements
+        li.querySelector('.msg-index').style.display = 'none';
+        textEl.style.display = 'none';
+        li.querySelector('.msg-edit').style.display = 'none';
+        li.querySelector('.msg-delete').style.display = 'none';
+
+        var wrap = document.createElement('div');
+        wrap.className = 'msg-inline-edit';
+
+        var ta = document.createElement('textarea');
+        ta.value = rawText;
+        ta.rows = Math.max(1, Math.ceil(rawText.length / 80));
+
+        var preview = document.createElement('div');
+        preview.className = 'msg-inline-preview';
+        var renderPreview = function() {
+            var raw = ta.value
+                .replace(/\{sourcetype\}/g, 'username')
+                .replace(/\{targettype\}/g, 'mobname');
+            preview.innerHTML = raw.trim() ? ansitags.parse(raw) : '';
+        };
+        renderPreview();
+        ta.addEventListener('input', renderPreview);
+
+        var actions = document.createElement('div');
+        actions.className = 'msg-inline-actions';
+
+        var saveBtn = document.createElement('button');
+        saveBtn.className = 'btn-save-edit';
+        saveBtn.textContent = 'Save';
+        saveBtn.onclick = function() { saveEdit(saveBtn, intensity, proximity, target, index, ta); };
+
+        var cancelBtn = document.createElement('button');
+        cancelBtn.className = 'btn-cancel-edit';
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.onclick = function() { cancelEdit(li, textEl); };
+
+        actions.appendChild(saveBtn);
+        actions.appendChild(cancelBtn);
+        wrap.appendChild(ta);
+        wrap.appendChild(preview);
+        wrap.appendChild(actions);
+        li.appendChild(wrap);
+        ta.focus();
+        ta.setSelectionRange(ta.value.length, ta.value.length);
+    }
+
+    function cancelEdit(li, textEl) {
+        var wrap = li.querySelector('.msg-inline-edit');
+        if (wrap) wrap.remove();
+        li.classList.remove('editing');
+        li.querySelector('.msg-index').style.display = '';
+        textEl.style.display = '';
+        li.querySelector('.msg-edit').style.display = '';
+        li.querySelector('.msg-delete').style.display = '';
+    }
+
+    async function saveEdit(btn, intensity, proximity, target, index, ta) {
+        var message = ta.value.trim();
+        if (!message) { showStatus('error', 'Message cannot be empty.'); return; }
+
+        btn.disabled = true;
+        btn.textContent = 'Saving\u2026';
+
+        var url = '/admin/api/v1/items/attack-messages/' +
+            encodeURIComponent(activeSubtype) + '/' +
+            encodeURIComponent(intensity) + '/' +
+            encodeURIComponent(proximity) + '/' +
+            encodeURIComponent(target) + '/' + index;
+
+        var res = await AdminAPI.patch(url, { message: message });
+        btn.disabled = false;
+        btn.textContent = 'Save';
+        if (!res.ok) { showStatus('error', res.error || 'Save failed.'); return; }
+
+        showStatus('success', 'Message updated.');
+        await reloadAndRender();
+    }
 
     loadData();
 </script>

--- a/_datafiles/html/admin/scripting-functions.html
+++ b/_datafiles/html/admin/scripting-functions.html
@@ -378,6 +378,27 @@
             </div>
         </details>
 
+        <details class="fn-card" data-search="PlaySound sound audio identifier category user actor">
+            <summary><span class="fn-name-sig"><span class="fn-n">ActorObject.PlaySound</span><span class="fn-p">(</span><span class="fn-a">soundId</span> <span class="fn-t">string</span>, <span class="fn-a">category</span> <span class="fn-t">string</span><span class="fn-p">)</span></span><span class="fn-ret-badge ret-void">void</span></summary>
+            <div class="fn-body">
+                <p class="fn-desc">Plays a sound for this actor. Only affects user actors &mdash; silently ignored for mobs. <code>soundId</code> must match an identifier defined in <strong>audio.yaml</strong> (e.g. <code>"levelup"</code>). <code>category</code> groups related sounds for client-side volume control (e.g. <code>"combat"</code>, <code>"other"</code>).</p>
+                <table class="arg-table"><thead><tr><th>Argument</th><th>Type</th><th>Description</th></tr></thead><tbody>
+                    <tr><td class="an">soundId</td><td class="at">string</td><td>Identifier from audio.yaml (e.g. <code>"levelup"</code>, <code>"hit-self"</code>).</td></tr>
+                    <tr><td class="an">category</td><td class="at">string</td><td>Client volume category (e.g. <code>"combat"</code>, <code>"movement"</code>, <code>"other"</code>).</td></tr>
+                </tbody></table>
+            </div>
+        </details>
+
+        <details class="fn-card" data-search="PlayMusic music audio file identifier user actor stop off">
+            <summary><span class="fn-name-sig"><span class="fn-n">ActorObject.PlayMusic</span><span class="fn-p">(</span><span class="fn-a">musicFileOrId</span> <span class="fn-t">string</span><span class="fn-p">)</span></span><span class="fn-ret-badge ret-void">void</span></summary>
+            <div class="fn-body">
+                <p class="fn-desc">Changes the background music for this actor. Only affects user actors. <code>musicFileOrId</code> may be a filepath (e.g. <code>"static/audio/music/intro.mp3"</code>) or a sound identifier from audio.yaml whose filepath resolves to a music file. Pass <code>"Off"</code> to stop music.</p>
+                <table class="arg-table"><thead><tr><th>Argument</th><th>Type</th><th>Description</th></tr></thead><tbody>
+                    <tr><td class="an">musicFileOrId</td><td class="at">string</td><td>Music filepath, audio.yaml identifier, or <code>"Off"</code> to stop.</td></tr>
+                </tbody></table>
+            </div>
+        </details>
+
         <details class="fn-card" data-search="Command execute command string waitTurns force action">
             <summary><span class="fn-name-sig"><span class="fn-n">ActorObject.Command</span><span class="fn-p">(</span><span class="fn-a">cmd</span> <span class="fn-t">string</span><span class="fn-p"> [, </span><span class="fn-a">waitTurns</span> <span class="fn-t">int</span><span class="fn-p">])</span></span><span class="fn-ret-badge ret-void">void</span></summary>
             <div class="fn-body">
@@ -1043,6 +1064,18 @@ if (pet !== null) {
         <details class="fn-card" data-search="GetItems items floor array ItemObject room">
             <summary><span class="fn-name-sig"><span class="fn-n">RoomObject.GetItems</span><span class="fn-p">()</span></span><span class="fn-ret-badge ret-array">[]ItemObject</span></summary>
             <div class="fn-body"><p class="fn-desc">Returns all items on the floor of the room.</p></div>
+        </details>
+
+        <details class="fn-card" data-search="PlaySound sound audio identifier category room all players">
+            <summary><span class="fn-name-sig"><span class="fn-n">RoomObject.PlaySound</span><span class="fn-p">(</span><span class="fn-a">soundId</span> <span class="fn-t">string</span>, <span class="fn-a">category</span> <span class="fn-t">string</span><span class="fn-p"> [, </span><span class="fn-a">excludeUserIds&hellip;</span><span class="fn-p">])</span></span><span class="fn-ret-badge ret-void">void</span></summary>
+            <div class="fn-body">
+                <p class="fn-desc">Plays a sound for all players currently in the room. <code>soundId</code> must match an identifier defined in <strong>audio.yaml</strong> (e.g. <code>"room-enter"</code>). <code>category</code> groups related sounds for client-side volume control. Optionally exclude specific user IDs from receiving the sound.</p>
+                <table class="arg-table"><thead><tr><th>Argument</th><th>Type</th><th>Description</th></tr></thead><tbody>
+                    <tr><td class="an">soundId</td><td class="at">string</td><td>Identifier from audio.yaml (e.g. <code>"room-enter"</code>, <code>"change"</code>).</td></tr>
+                    <tr><td class="an">category</td><td class="at">string</td><td>Client volume category (e.g. <code>"combat"</code>, <code>"movement"</code>, <code>"other"</code>).</td></tr>
+                    <tr><td class="an">excludeUserIds</td><td class="at">int&hellip; (optional)</td><td>User IDs that should not receive the sound.</td></tr>
+                </tbody></table>
+            </div>
         </details>
 
         <details class="fn-card" data-search="GetStashItems stash items hidden array ItemObject room">

--- a/_datafiles/world/default/combat-messages/bludgeoning.yaml
+++ b/_datafiles/world/default/combat-messages/bludgeoning.yaml
@@ -9,108 +9,194 @@
 # {entrancename}- name of entrance for attack e.g. 'south'
 optionid: bludgeoning
 options:
-  prepare:
-    # messages for when they are in the same room
-    together:
-      toattacker:
-      - 'You prepare to enter into mortal combat with <ansi fg="{targettype}">{target}</ansi>.'
-      - 'You heft your <ansi fg="item">{itemname}</ansi>, readying yourself against <ansi fg="{targettype}">{target}</ansi>.'
-      - 'You grip your <ansi fg="item">{itemname}</ansi> tightly, eyeing <ansi fg="{targettype}">{target}</ansi> for battle.'
-      todefender:
-      - '<ansi fg="{sourcetype}">{source}</ansi> prepares to fight you with their <ansi fg="item">{itemname}</ansi>.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> hefts their <ansi fg="item">{itemname}</ansi>, eyeing you menacingly.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> readies their <ansi fg="item">{itemname}</ansi> and focuses on you.'
-      toroom:
-      - '<ansi fg="{sourcetype}">{source}</ansi> prepares to attack <ansi fg="{targettype}">{target}</ansi> with their <ansi fg="item">{itemname}</ansi>.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> grips their <ansi fg="item">{itemname}</ansi> tightly, preparing to engage <ansi fg="{targettype}">{target}</ansi>.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> readies their <ansi fg="item">{itemname}</ansi>, eyes fixed on <ansi fg="{targettype}">{target}</ansi>.'
-  wait:
-    # messages for when they are in the same room
-    together:
-      toattacker:
-      - 'You aim carefully at <ansi fg="{targettype}">{target}</ansi>.'
-      - 'You circle around <ansi fg="{targettype}">{target}</ansi>, looking for an opening.'
-      - 'You watch <ansi fg="{targettype}">{target}</ansi> closely, waiting for the perfect moment to strike.'
-      todefender:
-      - '<ansi fg="{sourcetype}">{source}</ansi> circles dangerously.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> watches you intently, their <ansi fg="item">{itemname}</ansi> at the ready.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> holds their <ansi fg="item">{itemname}</ansi> steady, eyeing you carefully.'
-      toroom:
-      - '<ansi fg="{sourcetype}">{source}</ansi> circles <ansi fg="{targettype}">{target}</ansi> with cruel intentions.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> stalks around <ansi fg="{targettype}">{target}</ansi>, awaiting an opportunity.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> eyes <ansi fg="{targettype}">{target}</ansi> warily, ready to strike.'
-  miss:
-    # messages for when they are in the same room
-    together:
-      toattacker:
-      - 'You swing your <ansi fg="item">{itemname}</ansi> at <ansi fg="{targettype}">{target}</ansi>, but miss!'
-      - 'Your swing at <ansi fg="{targettype}">{target}</ansi> misses completely!'
-      - 'You attempt to smash <ansi fg="{targettype}">{target}</ansi>, but fail to connect!'
-      todefender:
-      - '<ansi fg="{sourcetype}">{source}</ansi> swings their <ansi fg="item">{itemname}</ansi> at you, but misses!'
-      - '<ansi fg="{sourcetype}">{source}</ansi> swings wildly but fails to hit you!'
-      - '<ansi fg="{sourcetype}">{source}</ansi> tries to smash you but misses!'
-      toroom:
-      - '<ansi fg="{sourcetype}">{source}</ansi> swings their <ansi fg="item">{itemname}</ansi> at <ansi fg="{targettype}">{target}</ansi>, but misses!'
-      - '<ansi fg="{sourcetype}">{source}</ansi> swings at <ansi fg="{targettype}">{target}</ansi> but misses completely.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> attempts to smash <ansi fg="{targettype}">{target}</ansi> but fails to connect!'
-  weak:
-    # messages for when they are in the same room
-    together:
-      toattacker:
-      - 'You heave your <ansi fg="item">{itemname}</ansi> at <ansi fg="{targettype}">{target}</ansi>, but it bounces off for <ansi fg="damage">{damage} damage</ansi>.'
-      - 'Your <ansi fg="item">{itemname}</ansi> barely affects <ansi fg="{targettype}">{target}</ansi>, causing <ansi fg="damage">{damage} damage</ansi>.'
-      - 'You land a weak blow on <ansi fg="{targettype}">{target}</ansi>, dealing only <ansi fg="damage">{damage} damage</ansi>.'
-      todefender:
-      - '<ansi fg="{sourcetype}">{source}</ansi> heaves their <ansi fg="item">{itemname}</ansi> but does barely <ansi fg="damage">{damage} damage</ansi> to you.'
-      - 'You feel a light impact as <ansi fg="{sourcetype}">{source}</ansi> strikes you for <ansi fg="damage">{damage} damage</ansi>.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> lands a weak hit on you, causing <ansi fg="damage">{damage} damage</ansi>.'
-      toroom:
-      - '<ansi fg="{sourcetype}">{source}</ansi> heaves their <ansi fg="item">{itemname}</ansi> but does barely any damage to <ansi fg="{targettype}">{target}</ansi>.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> barely affects <ansi fg="{targettype}">{target}</ansi> with their attack.'
-      - '<ansi fg="{sourcetype}">{source}</ansi> lands a weak blow on <ansi fg="{targettype}">{target}</ansi>.'
-  normal:
-    # messages for when they are in the same room
-    together:
-      toattacker:
-      - 'You swing your <ansi fg="item">{itemname}</ansi> and hit <ansi fg="{targettype}">{target}</ansi> for <ansi fg="damage">{damage} damage</ansi>!'
-      - 'Your <ansi fg="item">{itemname}</ansi> connects solidly with <ansi fg="{targettype}">{target}</ansi>, dealing <ansi fg="damage">{damage} damage</ansi>!'
-      - 'You land a solid blow on <ansi fg="{targettype}">{target}</ansi> with your <ansi fg="item">{itemname}</ansi> for <ansi fg="damage">{damage} damage</ansi>!'
-      todefender:
-      - '<ansi fg="{sourcetype}">{source}</ansi> swings their <ansi fg="item">{itemname}</ansi> and hits you for <ansi fg="damage">{damage}</ansi>!'
-      - 'You are struck by <ansi fg="{sourcetype}">{source}</ansi>''s <ansi fg="item">{itemname}</ansi>, taking <ansi fg="damage">{damage} damage</ansi>!'
-      - '<ansi fg="{sourcetype}">{source}</ansi> lands a solid blow on you with their <ansi fg="item">{itemname}</ansi> for <ansi fg="damage">{damage} damage</ansi>!'
-      toroom:
-      - '<ansi fg="{sourcetype}">{source}</ansi> swings their <ansi fg="item">{itemname}</ansi> and hits <ansi fg="{targettype}">{target}</ansi>.'
-      - '<ansi fg="{sourcetype}">{source}</ansi>''s <ansi fg="item">{itemname}</ansi> connects with <ansi fg="{targettype}">{target}</ansi>!'
-      - '<ansi fg="{sourcetype}">{source}</ansi> lands a solid blow on <ansi fg="{targettype}">{target}</ansi>!'
-  heavy:
-    # messages for when they are in the same room
-    together:
-      toattacker:
-      - 'Your <ansi fg="item">{itemname}</ansi> lands squarely on <ansi fg="{targettype}">{target}</ansi> for <ansi fg="damage">{damage} damage</ansi>!'
-      - 'You deliver a powerful smash to <ansi fg="{targettype}">{target}</ansi>, causing <ansi fg="damage">{damage} damage</ansi>!'
-      - 'Your heavy swing hits <ansi fg="{targettype}">{target}</ansi> hard, dealing significant damage of <ansi fg="damage">{damage}</ansi>!'
-      todefender:
-      - '<ansi fg="{sourcetype}">{source}''s</ansi> <ansi fg="item">{itemname}</ansi> lands squarely on you for <ansi fg="damage">{damage} damage</ansi>!'
-      - 'You are hit hard as <ansi fg="{sourcetype}">{source}</ansi> smashes you for <ansi fg="damage">{damage} damage</ansi>!'
-      - '<ansi fg="{sourcetype}">{source}</ansi>''s heavy swing deals significant damage of <ansi fg="damage">{damage} damage</ansi> to you!'
-      toroom:
-      - '<ansi fg="{sourcetype}">{source}''s</ansi> <ansi fg="item">{itemname}</ansi> lands squarely on <ansi fg="{targettype}">{target}</ansi>!'
-      - '<ansi fg="{sourcetype}">{source}</ansi> delivers a powerful smash to <ansi fg="{targettype}">{target}</ansi>!'
-      - '<ansi fg="{sourcetype}">{source}</ansi>''s heavy swing hits <ansi fg="{targettype}">{target}</ansi> hard!'
   critical:
-    # messages for when they are in the same room
     together:
       toattacker:
-      - 'Your <ansi fg="item">{itemname}</ansi> <ansi fg="cyan-bold">CRITICALLY SMASHES</ansi> <ansi fg="{targettype}">{target}</ansi> for <ansi fg="damage">{damage} damage</ansi>!'
-      - 'You deliver a <ansi fg="cyan-bold">CRITICAL SMASH</ansi> to <ansi fg="{targettype}">{target}</ansi>, causing <ansi fg="damage">{damage} damage</ansi>!'
-      - 'Your <ansi fg="item">{itemname}</ansi> <ansi fg="cyan-bold">CRUSHES</ansi> <ansi fg="{targettype}">{target}</ansi>, dealing a massive <ansi fg="damage">{damage} damage</ansi>!'
+      - Your <ansi fg="item">{itemname}</ansi> <ansi fg="cyan-bold">CRITICALLY SMASHES</ansi>
+        <ansi fg="{targettype}">{target}</ansi> for <ansi fg="damage">{damage} damage</ansi>!
+      - You deliver a <ansi fg="cyan-bold">CRITICAL SMASH</ansi> to <ansi fg="{targettype}">{target}</ansi>,
+        causing <ansi fg="damage">{damage} damage</ansi>!
+      - Your <ansi fg="item">{itemname}</ansi> <ansi fg="cyan-bold">CRUSHES</ansi>
+        <ansi fg="{targettype}">{target}</ansi>, dealing a massive <ansi fg="damage">{damage}
+        damage</ansi>!
       todefender:
-      - '<ansi fg="{sourcetype}">{source}''s</ansi> <ansi fg="item">{itemname}</ansi> <ansi fg="cyan-bold">CRITICALLY SMASHES</ansi> you for <ansi fg="damage">{damage} damage</ansi>!'
-      - 'You are <ansi fg="cyan-bold">CRITICALLY SMASHED</ansi> by <ansi fg="{sourcetype}">{source}</ansi>, taking <ansi fg="damage">{damage} damage</ansi>!'
-      - '<ansi fg="{sourcetype}">{source}</ansi>''s <ansi fg="item">{itemname}</ansi> <ansi fg="cyan-bold">CRUSHES</ansi> you, dealing a massive <ansi fg="damage">{damage} damage</ansi>!'
+      - <ansi fg="{sourcetype}">{source}'s</ansi> <ansi fg="item">{itemname}</ansi>
+        <ansi fg="cyan-bold">CRITICALLY SMASHES</ansi> you for <ansi fg="damage">{damage}
+        damage</ansi>!
+      - You are <ansi fg="cyan-bold">CRITICALLY SMASHED</ansi> by <ansi fg="{sourcetype}">{source}</ansi>,
+        taking <ansi fg="damage">{damage} damage</ansi>!
+      - <ansi fg="{sourcetype}">{source}</ansi>'s <ansi fg="item">{itemname}</ansi>
+        <ansi fg="cyan-bold">CRUSHES</ansi> you, dealing a massive <ansi fg="damage">{damage}
+        damage</ansi>!
       toroom:
-      - '<ansi fg="{sourcetype}">{source}''s</ansi> <ansi fg="item">{itemname}</ansi> <ansi fg="cyan-bold">CRITICALLY SMASHES</ansi> <ansi fg="{targettype}">{target}</ansi>!'
-      - '<ansi fg="{sourcetype}">{source}</ansi> delivers a <ansi fg="cyan-bold">CRITICAL SMASH</ansi> to <ansi fg="{targettype}">{target}</ansi>!'
-      - '<ansi fg="{sourcetype}">{source}</ansi> <ansi fg="cyan-bold">CRUSHES</ansi> <ansi fg="{targettype}">{target}</ansi> with a massive blow!'
+      - <ansi fg="{sourcetype}">{source}'s</ansi> <ansi fg="item">{itemname}</ansi>
+        <ansi fg="cyan-bold">CRITICALLY SMASHES</ansi> <ansi fg="{targettype}">{target}</ansi>!
+      - <ansi fg="{sourcetype}">{source}</ansi> delivers a <ansi fg="cyan-bold">CRITICAL
+        SMASH</ansi> to <ansi fg="{targettype}">{target}</ansi>!
+      - <ansi fg="{sourcetype}">{source}</ansi> <ansi fg="cyan-bold">CRUSHES</ansi>
+        <ansi fg="{targettype}">{target}</ansi> with a massive blow!
+    separate:
+      toattacker: []
+      todefender: []
+      toattackerroom: []
+      todefenderroom: []
+  heavy:
+    together:
+      toattacker:
+      - Your <ansi fg="item">{itemname}</ansi> lands squarely on <ansi fg="{targettype}">{target}</ansi>
+        for <ansi fg="damage">{damage} damage</ansi>!
+      - You deliver a powerful smash to <ansi fg="{targettype}">{target}</ansi>, causing
+        <ansi fg="damage">{damage} damage</ansi>!
+      - Your heavy swing hits <ansi fg="{targettype}">{target}</ansi> hard, dealing
+        significant damage of <ansi fg="damage">{damage}</ansi>!
+      todefender:
+      - <ansi fg="{sourcetype}">{source}'s</ansi> <ansi fg="item">{itemname}</ansi>
+        lands squarely on you for <ansi fg="damage">{damage} damage</ansi>!
+      - You are hit hard as <ansi fg="{sourcetype}">{source}</ansi> smashes you for
+        <ansi fg="damage">{damage} damage</ansi>!
+      - <ansi fg="{sourcetype}">{source}</ansi>'s heavy swing deals significant damage
+        of <ansi fg="damage">{damage} damage</ansi> to you!
+      toroom:
+      - <ansi fg="{sourcetype}">{source}'s</ansi> <ansi fg="item">{itemname}</ansi>
+        lands squarely on <ansi fg="{targettype}">{target}</ansi>!
+      - <ansi fg="{sourcetype}">{source}</ansi> delivers a powerful smash to <ansi
+        fg="{targettype}">{target}</ansi>!
+      - <ansi fg="{sourcetype}">{source}</ansi>'s heavy swing hits <ansi fg="{targettype}">{target}</ansi>
+        hard!
+    separate:
+      toattacker: []
+      todefender: []
+      toattackerroom: []
+      todefenderroom: []
+  miss:
+    together:
+      toattacker:
+      - You swing your <ansi fg="item">{itemname}</ansi> at <ansi fg="{targettype}">{target}</ansi>,
+        but miss!
+      - Your swing at <ansi fg="{targettype}">{target}</ansi> misses completely!
+      - You attempt to smash <ansi fg="{targettype}">{target}</ansi>, but fail to
+        connect!
+      todefender:
+      - <ansi fg="{sourcetype}">{source}</ansi> swings their <ansi fg="item">{itemname}</ansi>
+        at you, but misses!
+      - <ansi fg="{sourcetype}">{source}</ansi> swings wildly but fails to hit you!
+      - <ansi fg="{sourcetype}">{source}</ansi> tries to smash you but misses!
+      toroom:
+      - <ansi fg="{sourcetype}">{source}</ansi> swings their <ansi fg="item">{itemname}</ansi>
+        at <ansi fg="{targettype}">{target}</ansi>, but misses!
+      - <ansi fg="{sourcetype}">{source}</ansi> swings at <ansi fg="{targettype}">{target}</ansi>
+        but misses completely.
+      - <ansi fg="{sourcetype}">{source}</ansi> attempts to smash <ansi fg="{targettype}">{target}</ansi>
+        but fails to connect!
+    separate:
+      toattacker: []
+      todefender: []
+      toattackerroom: []
+      todefenderroom: []
+  normal:
+    together:
+      toattacker:
+      - You swing your <ansi fg="item">{itemname}</ansi> and hit <ansi fg="{targettype}">{target}</ansi>
+        for <ansi fg="damage">{damage} damage</ansi>!
+      - Your <ansi fg="item">{itemname}</ansi> connects solidly with <ansi fg="{targettype}">{target}</ansi>,
+        dealing <ansi fg="damage">{damage} damage</ansi>!
+      - You land a solid blow on <ansi fg="{targettype}">{target}</ansi> with your
+        <ansi fg="item">{itemname}</ansi> for <ansi fg="damage">{damage} damage</ansi>!
+      todefender:
+      - <ansi fg="{sourcetype}">{source}</ansi> swings their <ansi fg="item">{itemname}</ansi>
+        and hits you for <ansi fg="damage">{damage}</ansi>!
+      - You are struck by <ansi fg="{sourcetype}">{source}</ansi>'s <ansi fg="item">{itemname}</ansi>,
+        taking <ansi fg="damage">{damage} damage</ansi>!
+      - <ansi fg="{sourcetype}">{source}</ansi> lands a solid blow on you with their
+        <ansi fg="item">{itemname}</ansi> for <ansi fg="damage">{damage} damage</ansi>!
+      toroom:
+      - <ansi fg="{sourcetype}">{source}</ansi> swings their <ansi fg="item">{itemname}</ansi>
+        and hits <ansi fg="{targettype}">{target}</ansi>.
+      - <ansi fg="{sourcetype}">{source}</ansi>'s <ansi fg="item">{itemname}</ansi>
+        connects with <ansi fg="{targettype}">{target}</ansi>!
+      - <ansi fg="{sourcetype}">{source}</ansi> lands a solid blow on <ansi fg="{targettype}">{target}</ansi>!
+    separate:
+      toattacker: []
+      todefender: []
+      toattackerroom: []
+      todefenderroom: []
+  prepare:
+    together:
+      toattacker:
+      - You prepare to enter into mortal combat with <ansi fg="{targettype}">{target}</ansi>.
+      - You heft your <ansi fg="item">{itemname}</ansi>, readying yourself against
+        <ansi fg="{targettype}">{target}</ansi>.
+      - You grip your <ansi fg="item">{itemname}</ansi> tightly, eyeing <ansi fg="{targettype}">{target}</ansi>
+        for battle.
+      todefender:
+      - <ansi fg="{sourcetype}">{source}</ansi> prepares to fight you with their <ansi
+        fg="item">{itemname}</ansi>.
+      - <ansi fg="{sourcetype}">{source}</ansi> hefts their <ansi fg="item">{itemname}</ansi>,
+        eyeing you menacingly.
+      - <ansi fg="{sourcetype}">{source}</ansi> readies their <ansi fg="item">{itemname}</ansi>
+        and focuses on you.
+      toroom:
+      - <ansi fg="{sourcetype}">{source}</ansi> prepares to attack <ansi fg="{targettype}">{target}</ansi>
+        with their <ansi fg="item">{itemname}</ansi>.
+      - <ansi fg="{sourcetype}">{source}</ansi> grips their <ansi fg="item">{itemname}</ansi>
+        tightly, preparing to engage <ansi fg="{targettype}">{target}</ansi>.
+      - <ansi fg="{sourcetype}">{source}</ansi> readies their <ansi fg="item">{itemname}</ansi>,
+        eyes fixed on <ansi fg="{targettype}">{target}</ansi>.
+    separate:
+      toattacker: []
+      todefender: []
+      toattackerroom: []
+      todefenderroom: []
+  wait:
+    together:
+      toattacker:
+      - You aim carefully at <ansi fg="{targettype}">{target}</ansi>.
+      - You circle around <ansi fg="{targettype}">{target}</ansi>, looking for an
+        opening.
+      - You watch <ansi fg="{targettype}">{target}</ansi> closely, waiting for the
+        perfect moment to strike.
+      todefender:
+      - <ansi fg="{sourcetype}">{source}</ansi> circles dangerously.
+      - <ansi fg="{sourcetype}">{source}</ansi> watches you intently, their <ansi
+        fg="item">{itemname}</ansi> at the ready.
+      - <ansi fg="{sourcetype}">{source}</ansi> holds their <ansi fg="item">{itemname}</ansi>
+        steady, eyeing you carefully.
+      toroom:
+      - <ansi fg="{sourcetype}">{source}</ansi> circles <ansi fg="{targettype}">{target}</ansi>
+        with cruel intentions.
+      - <ansi fg="{sourcetype}">{source}</ansi> stalks around <ansi fg="{targettype}">{target}</ansi>,
+        awaiting an opportunity.
+      - <ansi fg="{sourcetype}">{source}</ansi> eyes <ansi fg="{targettype}">{target}</ansi>
+        warily, ready to strike.
+    separate:
+      toattacker: []
+      todefender: []
+      toattackerroom: []
+      todefenderroom: []
+  weak:
+    together:
+      toattacker:
+      - You heave your <ansi fg="item">{itemname}</ansi> at <ansi fg="{targettype}">{target}</ansi>,
+        but it bounces off for <ansi fg="damage">{damage} damage</ansi>.
+      - Your <ansi fg="item">{itemname}</ansi> barely affects <ansi fg="{targettype}">{target}</ansi>,
+        causing <ansi fg="damage">{damage} damage</ansi>.
+      - You land a weak blow on <ansi fg="{targettype}">{target}</ansi>, dealing only
+        <ansi fg="damage">{damage} damage</ansi>.
+      todefender:
+      - <ansi fg="{sourcetype}">{source}</ansi> heaves their <ansi fg="item">{itemname}</ansi>
+        but does barely <ansi fg="damage">{damage} damage</ansi> to you.
+      - You feel a light impact as <ansi fg="{sourcetype}">{source}</ansi> strikes
+        you for <ansi fg="damage">{damage} damage</ansi>.
+      - <ansi fg="{sourcetype}">{source}</ansi> lands a weak hit on you, causing <ansi
+        fg="damage">{damage} damage</ansi>.
+      toroom:
+      - <ansi fg="{sourcetype}">{source}</ansi> heaves their <ansi fg="item">{itemname}</ansi>
+        but does barely any damage to <ansi fg="{targettype}">{target}</ansi>.
+      - <ansi fg="{sourcetype}">{source}</ansi> barely affects <ansi fg="{targettype}">{target}</ansi>
+        with their attack.
+      - <ansi fg="{sourcetype}">{source}</ansi> lands a weak blow on <ansi fg="{targettype}">{target}</ansi>.
+    separate:
+      toattacker: []
+      todefender: []
+      toattackerroom: []
+      todefenderroom: []

--- a/_datafiles/world/default/mobs/frostfang/38-player_guide.yaml
+++ b/_datafiles/world/default/mobs/frostfang/38-player_guide.yaml
@@ -1,21 +1,48 @@
-mobid:  38
+mobid: 38
 zone: Frostfang
 itemdropchance: 2
-hostile: false
-maxwander: 0
-groups: 
-  - frostfang-npc
 activitylevel: 10
+groups:
+- frostfang-npc
 character:
   name: player guide
-  description: 'In combat, the Guide proves to be a steadfast protector, always ready to lend a helping hand when danger looms. They are a skilled warrior, wielding their frost-forged weapon with precision and using their keen senses to anticipate threats. New players can rely on the Guide to watch their back in the heat of battle, providing both tactical advice and unwavering support to ensure their safety.'
+  description: In combat, the Guide proves to be a steadfast protector, always ready
+    to lend a helping hand when danger looms. They are a skilled warrior, wielding
+    their frost-forged weapon with precision and using their keen senses to anticipate
+    threats. New players can rely on the Guide to watch their back in the heat of
+    battle, providing both tactical advice and unwavering support to ensure their
+    safety.
+  zone: Nowhere
   raceid: 1
+  stats:
+    strength:
+      base: 1
+    speed: {}
+    smarts:
+      base: 1
+    vitality:
+      base: 1
+    mysticism: {}
+    perception:
+      base: 1
   level: 10
+  experience: 1
   gold: 3
   equipment:
     weapon:
       itemid: 10002
+      canneverberemoved: true
+    offhand: {}
+    head: {}
     neck:
       itemid: 20002
+      canneverberemoved: true
+    body: {}
+    belt: {}
+    gloves: {}
+    ring: {}
+    legs: {}
     feet:
       itemid: 20003
+      canneverberemoved: true
+  created: 2026-06-01T09:27:31.459452-07:00

--- a/internal/audio/audio.go
+++ b/internal/audio/audio.go
@@ -16,9 +16,10 @@ import (
 )
 
 type AudioConfig struct {
-	Description string `yaml:"description,omitempty" json:"description,omitempty"`
-	FilePath    string `yaml:"filepath,omitempty" json:"filepath,omitempty"`
-	Volume      int    `yaml:"volume,omitempty" json:"volume,omitempty"`
+	Description string   `yaml:"description,omitempty" json:"description,omitempty"`
+	FilePath    string   `yaml:"filepath,omitempty" json:"filepath,omitempty"`
+	Volume      int      `yaml:"volume,omitempty" json:"volume,omitempty"`
+	Tags        []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 }
 
 var (
@@ -62,6 +63,32 @@ func GetMusicFiles() []string {
 		}
 		files = append(files, "static/audio/music/"+name)
 	}
+	sort.Strings(files)
+	return files
+}
+
+// GetSoundFiles returns a sorted list of all sound filenames found recursively
+// under PublicHtml/static/audio/sound/. Files whose names begin with "_" are skipped.
+func GetSoundFiles() []string {
+	publicHtml := configs.GetFilePathsConfig().PublicHtml.String()
+	root := filepath.Join(publicHtml, "static", "audio", "sound")
+
+	var files []string
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if strings.HasPrefix(name, "_") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(publicHtml, path)
+		if relErr != nil {
+			return nil
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
 	sort.Strings(files)
 	return files
 }

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -47,48 +47,48 @@ const (
 type Character struct {
 	Name                string                         // The name of the character
 	Description         string                         // A description of the character.
-	Adjectives          []string                       `yaml:"adjectives,omitempty"` // Decorative text for the name of the character (e.g. "sleeping", "dead", "wounded")
-	RoomId              int                            // The room id the character is in.
-	RoomIdOnReset       int                            // The room they are sent to if their RoomId isn't found.
-	Zone                string                         // The zone the character is in. The folder the room can be located in too.
-	RaceId              int                            // Character race
-	FormRaceId          int                            `yaml:"formraceid,omitempty"` // Temporary race override (0 = not transformed)
+	Adjectives          []string                       `yaml:"adjectives,omitempty"`    // Decorative text for the name of the character (e.g. "sleeping", "dead", "wounded")
+	RoomId              int                            `yaml:"roomid,omitempty"`        // The room id the character is in.
+	RoomIdOnReset       int                            `yaml:"roomidonreset,omitempty"` // The room they are sent to if their RoomId isn't found.
+	Zone                string                         `yaml:"zone,omitempty"`          // The zone the character is in. The folder the room can be located in too.
+	RaceId              int                            `yaml:"raceid,omitempty"`        // Character race
+	FormRaceId          int                            `yaml:"formraceid,omitempty"`    // Temporary race override (0 = not transformed)
 	Stats               stats.Statistics               // Character stats
-	Level               int                            // The level of the character
-	Experience          int                            // The experience of the character
-	TrainingPoints      int                            // The number of training points the character has
-	StatPoints          int                            // The number of skill points the character has
-	Health              int                            // The health of the character
-	Mana                int                            // The mana of the character
-	ActionPoints        int                            // The resevoir of action points the character has to spend on movement etc.
-	Alignment           int8                           // The alignment of the character
-	Gold                int                            // The gold the character is holding
-	Bank                int                            // The gold the character has in the bank
-	Shop                Shop                           `yaml:"shop,omitempty"`          // Definition of shop services/items this character stocks (or just has at the moment)
-	SpellBook           map[string]int                 `yaml:"spellbook,omitempty"`     // The spells the character has learned
-	Charmed             *CharmInfo                     `yaml:"-"`                       // If they are charmed, this is the info
-	CharmedMobs         []int                          `yaml:"-"`                       // If they have charmed anyone, this is the list of mob instance ids
-	Items               []items.Item                   `yaml:"items,omitempty"`         // The items the character is holding
-	Buffs               buffs.Buffs                    `yaml:"buffs,omitempty"`         // The buffs the character has active
-	Equipment           Worn                           `yaml:"equipment,omitempty"`     // The equipment the character is wearing
-	TNLScale            float32                        `yaml:"-"`                       // The experience scale of the character. Don't write to yaml since is dynamically calculated.
-	HealthMax           stats.StatInfo                 `yaml:"-"`                       // The maximum health of the character. Don't write to yaml since is dynamically calculated.
-	ManaMax             stats.StatInfo                 `yaml:"-"`                       // The maximum mana of the character. Don't write to yaml since is dynamically calculated.
-	ActionPointsMax     stats.StatInfo                 `yaml:"-"`                       // The maximum actions of character. Don't write to yaml since is dynamically calculated.
-	Aggro               *Aggro                         `yaml:"-"`                       // Dont' store this. If they leave they break their aggro
-	Skills              map[string]int                 `yaml:"skills,omitempty"`        // The skills the character has, and what level they are at
-	Cooldowns           Cooldowns                      `yaml:"cooldowns,omitempty"`     // How many rounds until it is cooled down
-	Settings            map[string]string              `yaml:"settings,omitempty"`      // custom setting tracking, used for anything.
-	QuestProgress       map[int]string                 `yaml:"questprogress,omitempty"` // quest progress tracking
-	KeyRing             map[string]string              `yaml:"keyring,omitempty"`       // key is the lock id, value is the sequence
-	KD                  KDStats                        `yaml:"kd,omitempty"`            // Kill/Death stats
-	MiscData            map[string]any                 `yaml:"miscdata,omitempty"`      // Any random other data that needs to be stored
-	ExtraLives          int                            `yaml:"extralives,omitempty"`    // How many lives remain. If enabled, players can perma-die if they die at zero
-	MobMastery          MobMasteries                   `yaml:"mobmastery,omitempty"`    // Tracks particular masteries around a given mob
-	Pet                 pets.Pet                       `yaml:"pet,omitempty"`           // Do they have a pet?
-	Created             time.Time                      `yaml:"created"`                 // When this character was created
-	Timers              map[string]gametime.RoundTimer `yaml:"timers,omitempty"`        // any special timers added to this character
-	ZonesVisited        map[string]RoomBitset          `yaml:"zonesvisited,omitempty"`  // permanent record of every room visited, keyed by zone name
+	Level               int                            `yaml:"level,omitempty"`          // The level of the character
+	Experience          int                            `yaml:"experience,omitempty"`     // The experience of the character
+	TrainingPoints      int                            `yaml:"trainingpoints,omitempty"` // The number of training points the character has
+	StatPoints          int                            `yaml:"statpoints,omitempty"`     // The number of skill points the character has
+	Health              int                            `yaml:"health,omitempty"`         // The health of the character
+	Mana                int                            `yaml:"mana,omitempty"`           // The mana of the character
+	ActionPoints        int                            `yaml:"actionpoints,omitempty"`   // The resevoir of action points the character has to spend on movement etc.
+	Alignment           int8                           `yaml:"alignment,omitempty"`      // The alignment of the character
+	Gold                int                            `yaml:"gold,omitempty"`           // The gold the character is holding
+	Bank                int                            `yaml:"bank,omitempty"`           // The gold the character has in the bank
+	Shop                Shop                           `yaml:"shop,omitempty"`           // Definition of shop services/items this character stocks (or just has at the moment)
+	SpellBook           map[string]int                 `yaml:"spellbook,omitempty"`      // The spells the character has learned
+	Charmed             *CharmInfo                     `yaml:"-"`                        // If they are charmed, this is the info
+	CharmedMobs         []int                          `yaml:"-"`                        // If they have charmed anyone, this is the list of mob instance ids
+	Items               []items.Item                   `yaml:"items,omitempty"`          // The items the character is holding
+	Buffs               buffs.Buffs                    `yaml:"buffs,omitempty"`          // The buffs the character has active
+	Equipment           Worn                           `yaml:"equipment,omitempty"`      // The equipment the character is wearing
+	TNLScale            float32                        `yaml:"-"`                        // The experience scale of the character. Don't write to yaml since is dynamically calculated.
+	HealthMax           stats.StatInfo                 `yaml:"-"`                        // The maximum health of the character. Don't write to yaml since is dynamically calculated.
+	ManaMax             stats.StatInfo                 `yaml:"-"`                        // The maximum mana of the character. Don't write to yaml since is dynamically calculated.
+	ActionPointsMax     stats.StatInfo                 `yaml:"-"`                        // The maximum actions of character. Don't write to yaml since is dynamically calculated.
+	Aggro               *Aggro                         `yaml:"-"`                        // Dont' store this. If they leave they break their aggro
+	Skills              map[string]int                 `yaml:"skills,omitempty"`         // The skills the character has, and what level they are at
+	Cooldowns           Cooldowns                      `yaml:"cooldowns,omitempty"`      // How many rounds until it is cooled down
+	Settings            map[string]string              `yaml:"settings,omitempty"`       // custom setting tracking, used for anything.
+	QuestProgress       map[int]string                 `yaml:"questprogress,omitempty"`  // quest progress tracking
+	KeyRing             map[string]string              `yaml:"keyring,omitempty"`        // key is the lock id, value is the sequence
+	KD                  KDStats                        `yaml:"kd,omitempty"`             // Kill/Death stats
+	MiscData            map[string]any                 `yaml:"miscdata,omitempty"`       // Any random other data that needs to be stored
+	ExtraLives          int                            `yaml:"extralives,omitempty"`     // How many lives remain. If enabled, players can perma-die if they die at zero
+	MobMastery          MobMasteries                   `yaml:"mobmastery,omitempty"`     // Tracks particular masteries around a given mob
+	Pet                 pets.Pet                       `yaml:"pet,omitempty"`            // Do they have a pet?
+	Created             time.Time                      `yaml:"created"`                  // When this character was created
+	Timers              map[string]gametime.RoundTimer `yaml:"timers,omitempty"`         // any special timers added to this character
+	ZonesVisited        map[string]RoomBitset          `yaml:"zonesvisited,omitempty"`   // permanent record of every room visited, keyed by zone name
 	roomHistory         []int                          // A stack FILO of the last X rooms the character has been in
 	PlayerDamage        map[int]int                    `yaml:"-"` // key = who, value = how much
 	LastPlayerDamage    uint64                         `yaml:"-"` // last round a player damaged this character

--- a/internal/items/admin.go
+++ b/internal/items/admin.go
@@ -68,6 +68,64 @@ func AddAttackMessage(subtype ItemSubType, intensity Intensity, proximity, targe
 	return SaveAttackMessageGroup(group)
 }
 
+func UpdateAttackMessage(subtype ItemSubType, intensity Intensity, proximity, target string, index int, message string) error {
+	group, ok := attackMessages[subtype]
+	if !ok {
+		return fmt.Errorf("unknown subtype: %s", subtype)
+	}
+
+	opts, ok := group.Options[intensity]
+	if !ok {
+		return fmt.Errorf("unknown intensity: %s", intensity)
+	}
+
+	update := func(sl MessageOptions, i int) (MessageOptions, error) {
+		if i < 0 || i >= len(sl) {
+			return nil, fmt.Errorf("index %d out of range (length %d)", i, len(sl))
+		}
+		sl[i] = ItemMessage(message)
+		return sl, nil
+	}
+
+	var err error
+	switch proximity {
+	case "together":
+		switch target {
+		case "toattacker":
+			opts.Together.ToAttacker, err = update(opts.Together.ToAttacker, index)
+		case "todefender":
+			opts.Together.ToDefender, err = update(opts.Together.ToDefender, index)
+		case "toroom":
+			opts.Together.ToRoom, err = update(opts.Together.ToRoom, index)
+		default:
+			return fmt.Errorf("unknown together target: %s", target)
+		}
+	case "separate":
+		switch target {
+		case "toattacker":
+			opts.Separate.ToAttacker, err = update(opts.Separate.ToAttacker, index)
+		case "todefender":
+			opts.Separate.ToDefender, err = update(opts.Separate.ToDefender, index)
+		case "toattackerroom":
+			opts.Separate.ToAttackerRoom, err = update(opts.Separate.ToAttackerRoom, index)
+		case "todefenderroom":
+			opts.Separate.ToDefenderRoom, err = update(opts.Separate.ToDefenderRoom, index)
+		default:
+			return fmt.Errorf("unknown separate target: %s", target)
+		}
+	default:
+		return fmt.Errorf("unknown proximity: %s (expected together or separate)", proximity)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	group.Options[intensity] = opts
+
+	return SaveAttackMessageGroup(group)
+}
+
 func DeleteAttackMessage(subtype ItemSubType, intensity Intensity, proximity, target string, index int) error {
 	group, ok := attackMessages[subtype]
 	if !ok {

--- a/internal/mobs/mobs.go
+++ b/internal/mobs/mobs.go
@@ -42,30 +42,30 @@ type MobId int // Creating a custom type to help prevent confusion over MobId an
 type Mob struct {
 	MobId           MobId
 	Zone            string   `yaml:"zone,omitempty"`
-	ItemDropChance  int      // chance in 100
-	ActivityLevel   int      `yaml:"activitylevel,omitempty"` // 1-100%
+	ItemDropChance  int      `yaml:"itemdropchance,omitempty"` // chance in 100
+	ActivityLevel   int      `yaml:"activitylevel,omitempty"`  // 1-100%
 	InstanceId      int      `yaml:"-"`
 	HomeRoomId      int      `yaml:"-"`
-	Hostile         bool     // whether they attack on sight
-	LastIdleCommand uint8    `yaml:"-"` // Track what hte last used idlecommand was
-	BoredomCounter  uint8    `yaml:"-"` // how many rounds have passed since this mob has seen a player
-	Groups          []string // What group do they identify with? Helps with teamwork
-	Hates           []string `yaml:"hates,omitempty"`        // What NPC groups or races do they hate and probably fight if encountered?
-	IdleCommands    []string `yaml:"idlecommands,omitempty"` // Commands they may do while idle (not in combat)
-	AngryCommands   []string // randomly chosen to queue when they are angry/entering combat.
+	Hostile         bool     `yaml:"hostile,omitempty"`        // whether they attack on sight
+	LastIdleCommand uint8    `yaml:"-"`                        // Track what hte last used idlecommand was
+	BoredomCounter  uint8    `yaml:"-"`                        // how many rounds have passed since this mob has seen a player
+	Groups          []string `yaml:"groups,omitempty"`         // What group do they identify with? Helps with teamwork
+	Hates           []string `yaml:"hates,omitempty"`          // What NPC groups or races do they hate and probably fight if encountered?
+	IdleCommands    []string `yaml:"idlecommands,omitempty"`   // Commands they may do while idle (not in combat)
+	AngryCommands   []string `yaml:"angrycommands,omitempty"`  // randomly chosen to queue when they are angry/entering combat.
 	CombatCommands  []string `yaml:"combatcommands,omitempty"` // Commands they may do while in combat
 	Character       characters.Character
-	MaxWander       int      `yaml:"maxwander,omitempty"`       // Max rooms to wander from home
-	WanderCount     int      `yaml:"-"`                         // How many times this mob has wandered
-	PreventIdle     bool     `yaml:"-"`                         // Whether they can't possibly be idle
-	ScriptTag       string   `yaml:"scripttag"`                 // Script for this mob: mobs/frostfang/scripts/{mobId}-{mobname}-{ScriptTag}.js
-	QuestFlags      []string `yaml:"questflags,omitempty,flow"` // What quest flags are set on this mob?
-	BuffIds         []int    `yaml:"buffids,omitempty"`         // Buff Id's this mob always has upon spawn
-	EliteChance     int      `yaml:"elitechance,omitempty"`     // Percent chance (0-100) this mob spawns as elite
-	IsElite         bool     `yaml:"-"`                         // Runtime flag: true if this instance is elite
+	MaxWander       int       `yaml:"maxwander,omitempty"`       // Max rooms to wander from home
+	WanderCount     int       `yaml:"-"`                         // How many times this mob has wandered
+	PreventIdle     bool      `yaml:"-"`                         // Whether they can't possibly be idle
+	ScriptTag       string    `yaml:"scripttag,omitempty"`       // Script for this mob: mobs/frostfang/scripts/{mobId}-{mobname}-{ScriptTag}.js
+	QuestFlags      []string  `yaml:"questflags,omitempty,flow"` // What quest flags are set on this mob?
+	BuffIds         []int     `yaml:"buffids,omitempty"`         // Buff Id's this mob always has upon spawn
+	EliteChance     int       `yaml:"elitechance,omitempty"`     // Percent chance (0-100) this mob spawns as elite
+	IsElite         bool      `yaml:"-"`                         // Runtime flag: true if this instance is elite
+	Path            PathQueue `yaml:"-"`                         // a pre-calculated path the mob is following.
 	tempDataStore   map[string]any
 	conversationId  int              // Identifier of conversation currently involved in.
-	Path            PathQueue        `yaml:"-"` // a pre-calculated path the mob is following.
 	lastCommandTurn uint64           // The last turn a command was scheduled for
 	playersAttacked map[int]struct{} // all players this mob has attacked at some point
 }

--- a/internal/scripting/actor_func.go
+++ b/internal/scripting/actor_func.go
@@ -824,6 +824,27 @@ func (a ScriptActor) GetLastInputRound() uint64 {
 	return 0
 }
 
+// PlaySound sends a sound event to this actor. Only affects user actors.
+// soundId is the identifier defined in audio.yaml (e.g. "levelup").
+// category groups related sounds for client-side volume control (e.g. "combat", "other").
+func (a ScriptActor) PlaySound(soundId string, category string) {
+	if a.userRecord == nil {
+		return
+	}
+	a.userRecord.PlaySound(soundId, category)
+}
+
+// PlayMusic sends a music-change event to this actor. Only affects user actors.
+// musicFileOrId may be a filepath (e.g. "static/audio/music/intro.mp3") or a sound
+// identifier from audio.yaml whose filepath resolves to a music file.
+// Pass "Off" to stop music.
+func (a ScriptActor) PlayMusic(musicFileOrId string) {
+	if a.userRecord == nil {
+		return
+	}
+	a.userRecord.PlayMusic(musicFileOrId)
+}
+
 func (a ScriptActor) Pathing() bool {
 	if a.mobRecord == nil {
 		return false

--- a/internal/scripting/room_func.go
+++ b/internal/scripting/room_func.go
@@ -412,6 +412,14 @@ func (r ScriptRoom) IsEphemeral() bool {
 	return rooms.IsEphemeralRoomId(r.roomRecord.RoomId)
 }
 
+// PlaySound plays a sound for all players currently in the room.
+// soundId is the identifier defined in audio.yaml (e.g. "room-enter").
+// category groups related sounds for client-side volume control (e.g. "combat", "movement").
+// Optional excludeUserIds are user IDs that should NOT receive the sound.
+func (r ScriptRoom) PlaySound(soundId string, category string, excludeUserIds ...int) {
+	r.roomRecord.PlaySound(soundId, category, excludeUserIds...)
+}
+
 // ////////////////////////////////////////////////////////
 //
 // # These functions get exported to the scripting engine

--- a/internal/web/api_routes.go
+++ b/internal/web/api_routes.go
@@ -140,7 +140,9 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 
 	// Audio
 	mux.HandleFunc("GET /admin/api/v1/audio", doBasicAuth(RunWithMUDLocked(apiV1GetAudio)))
+	mux.HandleFunc("POST /admin/api/v1/audio", doBasicAuth(RequirePermission("audio.write", RunWithMUDLocked(apiV1CreateAudio))))
 	mux.HandleFunc("PATCH /admin/api/v1/audio", doBasicAuth(RequirePermission("audio.write", RunWithMUDLocked(apiV1PatchAudio))))
+	mux.HandleFunc("DELETE /admin/api/v1/audio/{identifier}", doBasicAuth(RequirePermission("audio.write", RunWithMUDLocked(apiV1DeleteAudio))))
 
 	// Keywords
 	mux.HandleFunc("GET /admin/api/v1/keywords", doBasicAuth(RunWithMUDLocked(apiV1GetKeywords)))

--- a/internal/web/api_routes.go
+++ b/internal/web/api_routes.go
@@ -42,6 +42,7 @@ func registerAdminAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/api/v1/items/ranks/weapons", doBasicAuth(RunWithMUDLocked(apiV1GetItemRanksWeapons)))
 	mux.HandleFunc("GET /admin/api/v1/items/ranks/armor", doBasicAuth(RunWithMUDLocked(apiV1GetItemRanksArmor)))
 	mux.HandleFunc("PUT /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}", doBasicAuth(RequirePermission("items.write", RunWithMUDLocked(apiV1PutItemAttackMessage))))
+	mux.HandleFunc("PATCH /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}/{index}", doBasicAuth(RequirePermission("items.write", RunWithMUDLocked(apiV1PatchItemAttackMessage))))
 	mux.HandleFunc("DELETE /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}/{index}", doBasicAuth(RequirePermission("items.write", RunWithMUDLocked(apiV1DeleteItemAttackMessage))))
 	mux.HandleFunc("GET /admin/api/v1/items", doBasicAuth(RunWithMUDLocked(apiV1GetItems)))
 	mux.HandleFunc("POST /admin/api/v1/items", doBasicAuth(RequirePermission("items.write", RunWithMUDLocked(apiV1CreateItem))))

--- a/internal/web/api_v1_audio.go
+++ b/internal/web/api_v1_audio.go
@@ -3,13 +3,15 @@ package web
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/GoMudEngine/GoMud/internal/audio"
 )
 
 type audioAPIResponse struct {
-	Sounds map[string]audio.AudioConfig `json:"sounds"`
-	Music  []string                     `json:"music"`
+	Sounds     map[string]audio.AudioConfig `json:"sounds"`
+	Music      []string                     `json:"music"`
+	SoundFiles []string                     `json:"soundFiles"`
 }
 
 // GET /admin/api/v1/audio
@@ -17,15 +19,66 @@ func apiV1GetAudio(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, APIResponse[audioAPIResponse]{
 		Success: true,
 		Data: audioAPIResponse{
-			Sounds: audio.GetAllAudio(),
-			Music:  audio.GetMusicFiles(),
+			Sounds:     audio.GetAllAudio(),
+			Music:      audio.GetMusicFiles(),
+			SoundFiles: audio.GetSoundFiles(),
+		},
+	})
+}
+
+// POST /admin/api/v1/audio
+// Body: {"identifier": "my-sound", "description": "...", "filepath": "...", "volume": 80, "tags": ["combat"]}
+// Creates a new sound entry. Returns 409 if the identifier already exists.
+func apiV1CreateAudio(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Identifier  string   `json:"identifier"`
+		Description string   `json:"description"`
+		FilePath    string   `json:"filepath"`
+		Volume      int      `json:"volume"`
+		Tags        []string `json:"tags"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+
+	body.Identifier = strings.TrimSpace(body.Identifier)
+	if body.Identifier == "" {
+		writeAPIError(w, http.StatusBadRequest, "identifier is required")
+		return
+	}
+
+	current := audio.GetAllAudio()
+	if _, exists := current[body.Identifier]; exists {
+		writeAPIError(w, http.StatusConflict, "identifier already exists: "+body.Identifier)
+		return
+	}
+
+	current[body.Identifier] = audio.AudioConfig{
+		Description: body.Description,
+		FilePath:    body.FilePath,
+		Volume:      body.Volume,
+		Tags:        body.Tags,
+	}
+
+	if err := audio.SaveAudio(current); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[audioAPIResponse]{
+		Success: true,
+		Data: audioAPIResponse{
+			Sounds:     audio.GetAllAudio(),
+			Music:      audio.GetMusicFiles(),
+			SoundFiles: audio.GetSoundFiles(),
 		},
 	})
 }
 
 // PATCH /admin/api/v1/audio
 // Body: {"identifier": {"description":"...","filepath":"...","volume":80}, ...}
-// Only the sounds map is writable; music is derived from disk.
+// Replaces the entire sounds configuration.
 func apiV1PatchAudio(w http.ResponseWriter, r *http.Request) {
 	var patches map[string]audio.AudioConfig
 	if err := json.NewDecoder(r.Body).Decode(&patches); err != nil {
@@ -41,8 +94,34 @@ func apiV1PatchAudio(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, APIResponse[audioAPIResponse]{
 		Success: true,
 		Data: audioAPIResponse{
-			Sounds: audio.GetAllAudio(),
-			Music:  audio.GetMusicFiles(),
+			Sounds:     audio.GetAllAudio(),
+			Music:      audio.GetMusicFiles(),
+			SoundFiles: audio.GetSoundFiles(),
 		},
 	})
+}
+
+// DELETE /admin/api/v1/audio/{identifier}
+// Removes a single sound entry from audio.yaml.
+func apiV1DeleteAudio(w http.ResponseWriter, r *http.Request) {
+	identifier := r.PathValue("identifier")
+	if identifier == "" {
+		writeAPIError(w, http.StatusBadRequest, "identifier is required")
+		return
+	}
+
+	current := audio.GetAllAudio()
+	if _, exists := current[identifier]; !exists {
+		writeAPIError(w, http.StatusNotFound, "identifier not found: "+identifier)
+		return
+	}
+
+	delete(current, identifier)
+
+	if err := audio.SaveAudio(current); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
 }

--- a/internal/web/api_v1_items.go
+++ b/internal/web/api_v1_items.go
@@ -247,6 +247,39 @@ func apiV1PutItemAttackMessage(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
 }
 
+// PATCH /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}/{index}
+func apiV1PatchItemAttackMessage(w http.ResponseWriter, r *http.Request) {
+	subtype := items.ItemSubType(r.PathValue("subtype"))
+	intensity := items.Intensity(r.PathValue("intensity"))
+	proximity := r.PathValue("proximity")
+	target := r.PathValue("target")
+
+	index, err := strconv.Atoi(r.PathValue("index"))
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid index: "+r.PathValue("index"))
+		return
+	}
+
+	var body struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	if body.Message == "" {
+		writeAPIError(w, http.StatusBadRequest, "message is required")
+		return
+	}
+
+	if err := items.UpdateAttackMessage(subtype, intensity, proximity, target, index, body.Message); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, APIResponse[struct{}]{Success: true})
+}
+
 // DELETE /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}/{index}
 func apiV1DeleteItemAttackMessage(w http.ResponseWriter, r *http.Request) {
 	subtype := items.ItemSubType(r.PathValue("subtype"))


### PR DESCRIPTION
## DESCRIPTION

Improves the admin audio management page with full CRUD support, a file browser, playback previews, and tag-based organization. Adds scripting APIs for playing sounds from room and actor scripts. Rounds out the attack messages admin API with inline editing. Includes minor YAML tag and struct alignment fixes across the codebase.

## CHANGES

- **Audio admin page**: Added "New Sound" flow with create, save, and delete support. Sound entries can now be created and removed directly from the UI without manually editing `audio.yaml`.
- **Audio file browser**: The file path field now includes a "Browse" toggle that lists all available sound files on disk, making it easy to assign a file to a sound identifier.
- **Audio playback preview**: Added an inline play/stop button with a progress bar directly in the sound editor and on the music panel.
- **Unassigned files callout**: When creating a new sound, the editor surfaces any audio files on disk that are not yet mapped to a sound identifier, with a one-click "Use" button to fill in the path.
- **Sound tags**: Sound entries now support a free-form tags field for labeling where a sound is used (e.g. "combat", "login screen"). Tags are shown as chips in the editor and as a badge on list entries.
- **Audio API**: Added `POST /admin/api/v1/audio` (create) and `DELETE /admin/api/v1/audio/{identifier}` endpoints. The `GET` response now includes a `soundFiles` list of all files under `static/audio/sound/`.
- **Scripting — actor**: Added `actor.PlaySound(soundId, category)` and `actor.PlayMusic(musicFileOrId)` for triggering audio from mob and room scripts.
- **Scripting — room**: Added `room.PlaySound(soundId, category, ...excludeUserIds)` for broadcasting a sound to all players in a room.
- **Attack messages API**: Added `PATCH /admin/api/v1/items/attack-messages/{subtype}/{intensity}/{proximity}/{target}/{index}` for editing an existing message in place without replacing the entire list.
- **Conversations admin page**: Redesigned the turn editor with phase cards that clearly group simultaneous commands, improving readability and reducing visual noise.
- **YAML struct tags**: Added explicit `yaml:` tags to previously untagged fields on `Character` and `Mob` structs to make serialized output deterministic and self-documenting.
