### PR TITLE
feat(net): optional AI/test telnet port (Network.AI.*) with IsAI flag

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -553,6 +553,16 @@ Network:
   # - MaxSSHConnections -
   #   The maximum number of SSH connections the server will accept.
   MaxSSHConnections: 100
+  # - AIPort -
+  #   Dedicated telnet port for AI playtest clients.
+  #   0 (zero) means disabled. Set e.g. 55555 to enable.
+  AIPort: 0
+  # - MaxAIConnections -
+  #   The maximum number of concurrent AI connections the server will accept.
+  MaxAIConnections: 20
+  # - AICommandsPerRound -
+  #   Maximum number of commands an AI connection may submit per round.
+  AICommandsPerRound: 2
   # - AfkSeconds -
   #   If this many seconds pass without player input, they are flagged as afk
   #   Set to zero to never mark anyone as AFK

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -553,16 +553,19 @@ Network:
   # - MaxSSHConnections -
   #   The maximum number of SSH connections the server will accept.
   MaxSSHConnections: 100
-  # - AIPort -
-  #   Dedicated telnet port for AI playtest clients.
-  #   0 (zero) means disabled. Set e.g. 55555 to enable.
-  AIPort: 0
-  # - MaxAIConnections -
-  #   The maximum number of concurrent AI connections the server will accept.
-  MaxAIConnections: 20
-  # - AICommandsPerRound -
-  #   Maximum number of commands an AI connection may submit per round.
-  AICommandsPerRound: 2
+  # - AI -
+  #   Dedicated AI-client connection settings (grouped under Network.AI).
+  AI:
+    # - Port -
+    #   Dedicated telnet port for AI playtest clients.
+    #   0 (zero) means disabled. Set e.g. 55555 to enable.
+    Port: 0
+    # - MaxConnections -
+    #   The maximum number of concurrent AI connections the server will accept.
+    MaxConnections: 20
+    # - CommandsPerRound -
+    #   Maximum number of commands an AI connection may submit per round.
+    CommandsPerRound: 2
   # - AfkSeconds -
   #   If this many seconds pass without player input, they are flagged as afk
   #   Set to zero to never mark anyone as AFK

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -9,6 +9,9 @@ type Network struct {
 	HttpsRedirect        ConfigBool        `yaml:"HttpsRedirect"`        // If true, http traffic will be redirected to https
 	SSHPort              ConfigInt         `yaml:"SSHPort"`              // Port used for SSH connections (0 to disable)
 	MaxSSHConnections    ConfigInt         `yaml:"MaxSSHConnections"`    // Maximum number of SSH connections to accept
+	AIPort               ConfigInt         `yaml:"AIPort"`               // Dedicated telnet port for AI clients (0 = disabled)
+	MaxAIConnections     ConfigInt         `yaml:"MaxAIConnections"`     // Maximum number of concurrent AI connections
+	AICommandsPerRound   ConfigInt         `yaml:"AICommandsPerRound"`   // Max commands an AI connection may submit per round
 	AfkSeconds           ConfigInt         `yaml:"AfkSeconds"`           // How long until a player is marked as afk?
 	MaxIdleSeconds       ConfigInt         `yaml:"MaxIdleSeconds"`       // How many seconds a player can go without a command in game before being kicked.
 	TimeoutMods          ConfigBool        `yaml:"TimeoutMods"`          // Whether to kick admin/mods when idle too long.
@@ -32,6 +35,18 @@ func (n *Network) Validate() {
 
 	if n.MaxSSHConnections < 1 {
 		n.MaxSSHConnections = 50 // default
+	}
+
+	if n.AIPort < 0 {
+		n.AIPort = 0
+	}
+
+	if n.MaxAIConnections < 1 {
+		n.MaxAIConnections = 20 // default
+	}
+
+	if n.AICommandsPerRound < 1 {
+		n.AICommandsPerRound = 2 // default
 	}
 
 	if n.HttpPort < 0 {

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -9,14 +9,19 @@ type Network struct {
 	HttpsRedirect        ConfigBool        `yaml:"HttpsRedirect"`        // If true, http traffic will be redirected to https
 	SSHPort              ConfigInt         `yaml:"SSHPort"`              // Port used for SSH connections (0 to disable)
 	MaxSSHConnections    ConfigInt         `yaml:"MaxSSHConnections"`    // Maximum number of SSH connections to accept
-	AIPort               ConfigInt         `yaml:"AIPort"`               // Dedicated telnet port for AI clients (0 = disabled)
-	MaxAIConnections     ConfigInt         `yaml:"MaxAIConnections"`     // Maximum number of concurrent AI connections
-	AICommandsPerRound   ConfigInt         `yaml:"AICommandsPerRound"`   // Max commands an AI connection may submit per round
+	AI                   AINetwork         `yaml:"AI"`                   // Dedicated AI-client port and limits (see AINetwork)
 	AfkSeconds           ConfigInt         `yaml:"AfkSeconds"`           // How long until a player is marked as afk?
 	MaxIdleSeconds       ConfigInt         `yaml:"MaxIdleSeconds"`       // How many seconds a player can go without a command in game before being kicked.
 	TimeoutMods          ConfigBool        `yaml:"TimeoutMods"`          // Whether to kick admin/mods when idle too long.
 	LinkDeadSeconds      ConfigInt         `yaml:"LinkDeadSeconds"`      // How many seconds a player will be link-dead allowing them to reconnect.
 	LogoutRounds         ConfigInt         `yaml:"LogoutRounds"`         // How many rounds of uninterrupted meditation must be completed to log out.
+}
+
+// AINetwork groups the dedicated AI-client connection settings under Network.AI.
+type AINetwork struct {
+	Port             ConfigInt `yaml:"Port"`             // Dedicated telnet port for AI clients (0 = disabled)
+	MaxConnections   ConfigInt `yaml:"MaxConnections"`   // Maximum number of concurrent AI connections
+	CommandsPerRound ConfigInt `yaml:"CommandsPerRound"` // Max commands an AI connection may submit per round
 }
 
 func (n *Network) Validate() {
@@ -37,16 +42,16 @@ func (n *Network) Validate() {
 		n.MaxSSHConnections = 50 // default
 	}
 
-	if n.AIPort < 0 {
-		n.AIPort = 0
+	if n.AI.Port < 0 {
+		n.AI.Port = 0
 	}
 
-	if n.MaxAIConnections < 1 {
-		n.MaxAIConnections = 20 // default
+	if n.AI.MaxConnections < 1 {
+		n.AI.MaxConnections = 20 // default
 	}
 
-	if n.AICommandsPerRound < 1 {
-		n.AICommandsPerRound = 2 // default
+	if n.AI.CommandsPerRound < 1 {
+		n.AI.CommandsPerRound = 2 // default
 	}
 
 	if n.HttpPort < 0 {

--- a/internal/configs/config.network_test.go
+++ b/internal/configs/config.network_test.go
@@ -8,26 +8,22 @@ import (
 
 func TestNetworkValidateAIDefaults(t *testing.T) {
 	n := &Network{
-		AIPort:             -1,
-		MaxAIConnections:   0,
-		AICommandsPerRound: 0,
+		AI: AINetwork{Port: -1, MaxConnections: 0, CommandsPerRound: 0},
 	}
 	n.Validate()
 
-	assert.Equal(t, 0, int(n.AIPort), "negative AIPort should clamp to 0 (disabled)")
-	assert.Equal(t, 20, int(n.MaxAIConnections), "MaxAIConnections <1 should default to 20")
-	assert.Equal(t, 2, int(n.AICommandsPerRound), "AICommandsPerRound <1 should default to 2")
+	assert.Equal(t, 0, int(n.AI.Port), "negative AI.Port should clamp to 0 (disabled)")
+	assert.Equal(t, 20, int(n.AI.MaxConnections), "AI.MaxConnections <1 should default to 20")
+	assert.Equal(t, 2, int(n.AI.CommandsPerRound), "AI.CommandsPerRound <1 should default to 2")
 }
 
 func TestNetworkValidateAIPreservesValidValues(t *testing.T) {
 	n := &Network{
-		AIPort:             55555,
-		MaxAIConnections:   10,
-		AICommandsPerRound: 5,
+		AI: AINetwork{Port: 55555, MaxConnections: 10, CommandsPerRound: 5},
 	}
 	n.Validate()
 
-	assert.Equal(t, 55555, int(n.AIPort))
-	assert.Equal(t, 10, int(n.MaxAIConnections))
-	assert.Equal(t, 5, int(n.AICommandsPerRound))
+	assert.Equal(t, 55555, int(n.AI.Port))
+	assert.Equal(t, 10, int(n.AI.MaxConnections))
+	assert.Equal(t, 5, int(n.AI.CommandsPerRound))
 }

--- a/internal/configs/config.network_test.go
+++ b/internal/configs/config.network_test.go
@@ -1,0 +1,36 @@
+package configs
+
+import "testing"
+
+func TestNetworkValidateAIDefaults(t *testing.T) {
+	n := &Network{
+		AIPort:             -1,
+		MaxAIConnections:   0,
+		AICommandsPerRound: 0,
+	}
+	n.Validate()
+
+	if int(n.AIPort) != 0 {
+		t.Errorf("AIPort: negative should clamp to 0 (disabled), got %d", int(n.AIPort))
+	}
+	if int(n.MaxAIConnections) != 20 {
+		t.Errorf("MaxAIConnections: <1 should default to 20, got %d", int(n.MaxAIConnections))
+	}
+	if int(n.AICommandsPerRound) != 2 {
+		t.Errorf("AICommandsPerRound: <1 should default to 2, got %d", int(n.AICommandsPerRound))
+	}
+}
+
+func TestNetworkValidateAIPreservesValidValues(t *testing.T) {
+	n := &Network{
+		AIPort:             55555,
+		MaxAIConnections:   10,
+		AICommandsPerRound: 5,
+	}
+	n.Validate()
+
+	if int(n.AIPort) != 55555 || int(n.MaxAIConnections) != 10 || int(n.AICommandsPerRound) != 5 {
+		t.Errorf("Validate must not overwrite valid values: got AIPort=%d Max=%d Cmds=%d",
+			int(n.AIPort), int(n.MaxAIConnections), int(n.AICommandsPerRound))
+	}
+}

--- a/internal/configs/config.network_test.go
+++ b/internal/configs/config.network_test.go
@@ -1,6 +1,10 @@
 package configs
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestNetworkValidateAIDefaults(t *testing.T) {
 	n := &Network{
@@ -10,15 +14,9 @@ func TestNetworkValidateAIDefaults(t *testing.T) {
 	}
 	n.Validate()
 
-	if int(n.AIPort) != 0 {
-		t.Errorf("AIPort: negative should clamp to 0 (disabled), got %d", int(n.AIPort))
-	}
-	if int(n.MaxAIConnections) != 20 {
-		t.Errorf("MaxAIConnections: <1 should default to 20, got %d", int(n.MaxAIConnections))
-	}
-	if int(n.AICommandsPerRound) != 2 {
-		t.Errorf("AICommandsPerRound: <1 should default to 2, got %d", int(n.AICommandsPerRound))
-	}
+	assert.Equal(t, 0, int(n.AIPort), "negative AIPort should clamp to 0 (disabled)")
+	assert.Equal(t, 20, int(n.MaxAIConnections), "MaxAIConnections <1 should default to 20")
+	assert.Equal(t, 2, int(n.AICommandsPerRound), "AICommandsPerRound <1 should default to 2")
 }
 
 func TestNetworkValidateAIPreservesValidValues(t *testing.T) {
@@ -29,8 +27,7 @@ func TestNetworkValidateAIPreservesValidValues(t *testing.T) {
 	}
 	n.Validate()
 
-	if int(n.AIPort) != 55555 || int(n.MaxAIConnections) != 10 || int(n.AICommandsPerRound) != 5 {
-		t.Errorf("Validate must not overwrite valid values: got AIPort=%d Max=%d Cmds=%d",
-			int(n.AIPort), int(n.MaxAIConnections), int(n.AICommandsPerRound))
-	}
+	assert.Equal(t, 55555, int(n.AIPort))
+	assert.Equal(t, 10, int(n.MaxAIConnections))
+	assert.Equal(t, 5, int(n.AICommandsPerRound))
 }

--- a/internal/connections/aicount_test.go
+++ b/internal/connections/aicount_test.go
@@ -1,0 +1,32 @@
+package connections
+
+import (
+	"net"
+	"testing"
+)
+
+func TestActiveAIConnectionCount(t *testing.T) {
+	base := ActiveAIConnectionCount()
+
+	// net.Pipe gives a real in-memory net.Conn whose Close() is safe to call.
+	hConn, _ := net.Pipe()
+	a1Conn, _ := net.Pipe()
+	a2Conn, _ := net.Pipe()
+
+	human := Add(hConn, nil) // defaults to ConnHuman
+	ai1 := Add(a1Conn, nil, ConnAI)
+	ai2 := Add(a2Conn, nil, ConnAI)
+
+	if got := ActiveAIConnectionCount(); got != base+2 {
+		t.Errorf("expected %d AI connections, got %d", base+2, got)
+	}
+
+	// cleanup
+	Remove(human.ConnectionId())
+	Remove(ai1.ConnectionId())
+	Remove(ai2.ConnectionId())
+
+	if got := ActiveAIConnectionCount(); got != base {
+		t.Errorf("expected count to return to %d after removal, got %d", base, got)
+	}
+}

--- a/internal/connections/aicount_test.go
+++ b/internal/connections/aicount_test.go
@@ -3,6 +3,8 @@ package connections
 import (
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestActiveAIConnectionCount(t *testing.T) {
@@ -17,16 +19,12 @@ func TestActiveAIConnectionCount(t *testing.T) {
 	ai1 := Add(a1Conn, nil, ConnAI)
 	ai2 := Add(a2Conn, nil, ConnAI)
 
-	if got := ActiveAIConnectionCount(); got != base+2 {
-		t.Errorf("expected %d AI connections, got %d", base+2, got)
-	}
+	assert.Equal(t, base+2, ActiveAIConnectionCount())
 
 	// cleanup
 	Remove(human.ConnectionId())
 	Remove(ai1.ConnectionId())
 	Remove(ai2.ConnectionId())
 
-	if got := ActiveAIConnectionCount(); got != base {
-		t.Errorf("expected count to return to %d after removal, got %d", base, got)
-	}
+	assert.Equal(t, base, ActiveAIConnectionCount())
 }

--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -272,7 +272,7 @@ func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
 		return 0, nil
 	}
 
-	if cd.stripAnsi && (len(p) == 0 || p[0] != byte(term.TELNET_IAC)) {
+	if cd.stripAnsi && p[0] != byte(term.TELNET_IAC) {
 		p = StripAnsi(p)
 		if len(p) == 0 {
 			return 0, nil

--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -23,6 +23,14 @@ const (
 	MaxHistory = 10
 )
 
+// ConnType distinguishes human telnet/web connections from AI client connections.
+type ConnType uint32
+
+const (
+	ConnHuman ConnType = 0
+	ConnAI    ConnType = 1
+)
+
 type InputHistory struct {
 	inhistory bool
 	position  int
@@ -128,6 +136,7 @@ type ConnectionDetails struct {
 	outputSuppressed  bool
 	clientSettings    ClientSettings
 	heartbeat         *heartbeatManager
+	connType          ConnType
 }
 
 func (cd *ConnectionDetails) IsLocal() bool {
@@ -335,6 +344,16 @@ func (cd *ConnectionDetails) State() ConnectState {
 
 func (cd *ConnectionDetails) SetState(state ConnectState) {
 	atomic.StoreUint32((*uint32)(&cd.state), uint32(state))
+}
+
+// ConnType returns the connection type (human or AI). Safe for concurrent reads.
+func (cd *ConnectionDetails) ConnType() ConnType {
+	return ConnType(atomic.LoadUint32((*uint32)(&cd.connType)))
+}
+
+// SetConnType sets the connection type. Set once at accept time.
+func (cd *ConnectionDetails) SetConnType(t ConnType) {
+	atomic.StoreUint32((*uint32)(&cd.connType), uint32(t))
 }
 
 func (cd *ConnectionDetails) InputDisabled(setTo ...bool) bool {

--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -147,6 +147,8 @@ type ConnectionDetails struct {
 	heartbeat         *heartbeatManager
 	connType          ConnType
 	stripAnsi         bool
+	aiCommandRound    int64
+	aiCommandCount    int
 }
 
 func (cd *ConnectionDetails) IsLocal() bool {
@@ -376,6 +378,17 @@ func (cd *ConnectionDetails) SetConnType(t ConnType) {
 // SetStripAnsi enables ANSI escape stripping on output (for AI clients).
 func (cd *ConnectionDetails) SetStripAnsi(on bool) {
 	cd.stripAnsi = on
+}
+
+// AICommandAllowed enforces a per-round command budget for AI connections.
+// It is called only from the connection's own input goroutine, so it needs no lock.
+func (cd *ConnectionDetails) AICommandAllowed(currentRound int64, maxPerRound int) bool {
+	if currentRound != cd.aiCommandRound {
+		cd.aiCommandRound = currentRound
+		cd.aiCommandCount = 0
+	}
+	cd.aiCommandCount++
+	return cd.aiCommandCount <= maxPerRound
 }
 
 func (cd *ConnectionDetails) InputDisabled(setTo ...bool) bool {

--- a/internal/connections/connectiondetails.go
+++ b/internal/connections/connectiondetails.go
@@ -3,6 +3,7 @@ package connections
 import (
 	"errors"
 	"net"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -30,6 +31,14 @@ const (
 	ConnHuman ConnType = 0
 	ConnAI    ConnType = 1
 )
+
+// ansiStripRegexp matches SGR (color/style) escape sequences.
+var ansiStripRegexp = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// StripAnsi removes ANSI SGR escape sequences from p, returning clean text.
+func StripAnsi(p []byte) []byte {
+	return ansiStripRegexp.ReplaceAll(p, nil)
+}
 
 type InputHistory struct {
 	inhistory bool
@@ -137,6 +146,7 @@ type ConnectionDetails struct {
 	clientSettings    ClientSettings
 	heartbeat         *heartbeatManager
 	connType          ConnType
+	stripAnsi         bool
 }
 
 func (cd *ConnectionDetails) IsLocal() bool {
@@ -260,6 +270,13 @@ func (cd *ConnectionDetails) Write(p []byte) (n int, err error) {
 		return 0, nil
 	}
 
+	if cd.stripAnsi && (len(p) == 0 || p[0] != byte(term.TELNET_IAC)) {
+		p = StripAnsi(p)
+		if len(p) == 0 {
+			return 0, nil
+		}
+	}
+
 	if cd.sshChannel != nil {
 		return cd.sshChannel.Write(p)
 	}
@@ -354,6 +371,11 @@ func (cd *ConnectionDetails) ConnType() ConnType {
 // SetConnType sets the connection type. Set once at accept time.
 func (cd *ConnectionDetails) SetConnType(t ConnType) {
 	atomic.StoreUint32((*uint32)(&cd.connType), uint32(t))
+}
+
+// SetStripAnsi enables ANSI escape stripping on output (for AI clients).
+func (cd *ConnectionDetails) SetStripAnsi(on bool) {
+	cd.stripAnsi = on
 }
 
 func (cd *ConnectionDetails) InputDisabled(setTo ...bool) bool {

--- a/internal/connections/connections.go
+++ b/internal/connections/connections.go
@@ -44,7 +44,7 @@ func SignalShutdown(s os.Signal) {
 	}
 }
 
-func Add(conn net.Conn, wsConn *websocket.Conn) *ConnectionDetails {
+func Add(conn net.Conn, wsConn *websocket.Conn, connType ...ConnType) *ConnectionDetails {
 
 	lock.Lock()
 	defer lock.Unlock()
@@ -57,6 +57,10 @@ func Add(conn net.Conn, wsConn *websocket.Conn) *ConnectionDetails {
 		wsConn,
 		nil,
 	)
+
+	if len(connType) > 0 {
+		connDetails.SetConnType(connType[0])
+	}
 
 	netConnections[connDetails.ConnectionId()] = connDetails
 
@@ -293,6 +297,20 @@ func ActiveConnectionCount() int {
 	defer lock.RUnlock()
 
 	return len(netConnections)
+}
+
+// ActiveAIConnectionCount returns the number of currently-registered AI connections.
+func ActiveAIConnectionCount() int {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	count := 0
+	for _, cd := range netConnections {
+		if cd.ConnType() == ConnAI {
+			count++
+		}
+	}
+	return count
 }
 
 // make this more efficient later

--- a/internal/connections/conntype_test.go
+++ b/internal/connections/conntype_test.go
@@ -1,18 +1,18 @@
 package connections
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestConnTypeDefaultsToHuman(t *testing.T) {
 	cd := NewConnectionDetails(1, nil, nil, nil)
-	if cd.ConnType() != ConnHuman {
-		t.Errorf("default ConnType should be ConnHuman, got %d", cd.ConnType())
-	}
+	assert.Equal(t, ConnHuman, cd.ConnType())
 }
 
 func TestConnTypeSetGet(t *testing.T) {
 	cd := NewConnectionDetails(2, nil, nil, nil)
 	cd.SetConnType(ConnAI)
-	if cd.ConnType() != ConnAI {
-		t.Errorf("ConnType should be ConnAI after SetConnType, got %d", cd.ConnType())
-	}
+	assert.Equal(t, ConnAI, cd.ConnType())
 }

--- a/internal/connections/conntype_test.go
+++ b/internal/connections/conntype_test.go
@@ -1,0 +1,18 @@
+package connections
+
+import "testing"
+
+func TestConnTypeDefaultsToHuman(t *testing.T) {
+	cd := NewConnectionDetails(1, nil, nil, nil)
+	if cd.ConnType() != ConnHuman {
+		t.Errorf("default ConnType should be ConnHuman, got %d", cd.ConnType())
+	}
+}
+
+func TestConnTypeSetGet(t *testing.T) {
+	cd := NewConnectionDetails(2, nil, nil, nil)
+	cd.SetConnType(ConnAI)
+	if cd.ConnType() != ConnAI {
+		t.Errorf("ConnType should be ConnAI after SetConnType, got %d", cd.ConnType())
+	}
+}

--- a/internal/connections/ratelimit_test.go
+++ b/internal/connections/ratelimit_test.go
@@ -1,27 +1,21 @@
 package connections
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestAICommandAllowedWithinLimit(t *testing.T) {
 	cd := NewConnectionDetails(10, nil, nil, nil)
-	if !cd.AICommandAllowed(1, 2) {
-		t.Error("1st command in round 1 should be allowed")
-	}
-	if !cd.AICommandAllowed(1, 2) {
-		t.Error("2nd command in round 1 should be allowed")
-	}
-	if cd.AICommandAllowed(1, 2) {
-		t.Error("3rd command in round 1 should be denied (max 2)")
-	}
+	assert.True(t, cd.AICommandAllowed(1, 2), "1st command in round 1 should be allowed")
+	assert.True(t, cd.AICommandAllowed(1, 2), "2nd command in round 1 should be allowed")
+	assert.False(t, cd.AICommandAllowed(1, 2), "3rd command in round 1 should be denied (max 2)")
 }
 
 func TestAICommandAllowedResetsNextRound(t *testing.T) {
 	cd := NewConnectionDetails(11, nil, nil, nil)
 	cd.AICommandAllowed(1, 1) // uses the round-1 budget
-	if cd.AICommandAllowed(1, 1) {
-		t.Error("2nd command in round 1 should be denied (max 1)")
-	}
-	if !cd.AICommandAllowed(2, 1) {
-		t.Error("1st command in round 2 should be allowed after reset")
-	}
+	assert.False(t, cd.AICommandAllowed(1, 1), "2nd command in round 1 should be denied (max 1)")
+	assert.True(t, cd.AICommandAllowed(2, 1), "1st command in round 2 should be allowed after reset")
 }

--- a/internal/connections/ratelimit_test.go
+++ b/internal/connections/ratelimit_test.go
@@ -1,0 +1,27 @@
+package connections
+
+import "testing"
+
+func TestAICommandAllowedWithinLimit(t *testing.T) {
+	cd := NewConnectionDetails(10, nil, nil, nil)
+	if !cd.AICommandAllowed(1, 2) {
+		t.Error("1st command in round 1 should be allowed")
+	}
+	if !cd.AICommandAllowed(1, 2) {
+		t.Error("2nd command in round 1 should be allowed")
+	}
+	if cd.AICommandAllowed(1, 2) {
+		t.Error("3rd command in round 1 should be denied (max 2)")
+	}
+}
+
+func TestAICommandAllowedResetsNextRound(t *testing.T) {
+	cd := NewConnectionDetails(11, nil, nil, nil)
+	cd.AICommandAllowed(1, 1) // uses the round-1 budget
+	if cd.AICommandAllowed(1, 1) {
+		t.Error("2nd command in round 1 should be denied (max 1)")
+	}
+	if !cd.AICommandAllowed(2, 1) {
+		t.Error("1st command in round 2 should be allowed after reset")
+	}
+}

--- a/internal/connections/stripansi_test.go
+++ b/internal/connections/stripansi_test.go
@@ -1,0 +1,21 @@
+package connections
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStripAnsiRemovesColorCodes(t *testing.T) {
+	in := []byte("\x1b[31mred\x1b[0m text")
+	got := StripAnsi(in)
+	if !bytes.Equal(got, []byte("red text")) {
+		t.Errorf("expected %q, got %q", "red text", got)
+	}
+}
+
+func TestStripAnsiLeavesPlainText(t *testing.T) {
+	in := []byte("no codes here")
+	if got := StripAnsi(in); !bytes.Equal(got, in) {
+		t.Errorf("plain text should be unchanged, got %q", got)
+	}
+}

--- a/internal/connections/stripansi_test.go
+++ b/internal/connections/stripansi_test.go
@@ -1,21 +1,17 @@
 package connections
 
 import (
-	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStripAnsiRemovesColorCodes(t *testing.T) {
-	in := []byte("\x1b[31mred\x1b[0m text")
-	got := StripAnsi(in)
-	if !bytes.Equal(got, []byte("red text")) {
-		t.Errorf("expected %q, got %q", "red text", got)
-	}
+	got := StripAnsi([]byte("\x1b[31mred\x1b[0m text"))
+	assert.Equal(t, []byte("red text"), got)
 }
 
 func TestStripAnsiLeavesPlainText(t *testing.T) {
 	in := []byte("no codes here")
-	if got := StripAnsi(in); !bytes.Equal(got, in) {
-		t.Errorf("plain text should be unchanged, got %q", got)
-	}
+	assert.Equal(t, in, StripAnsi(in))
 }

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -42,6 +42,7 @@ type UserRecord struct {
 	ConfigOptions  map[string]any        `yaml:"configoptions,omitempty"`
 	Muted          bool                  `yaml:"muted,omitempty"`        // Cannot SEND custom communications to anyone but admin/mods
 	ScreenReader   bool                  `yaml:"screenreader,omitempty"` // Are they using a screen reader? (We should remove excess symbols)
+	IsAI           bool                  `yaml:"isai,omitempty"`         // Flagged as an AI/test account
 	EmailAddress   string                `yaml:"emailaddress,omitempty"` // Email address (if provided)
 	TipsComplete   map[string]bool       `yaml:"tipscomplete,omitempty"` // Tips the user has followed/completed so they can be quiet
 	EventLog       UserLog               `yaml:"-"`                      // Do not retain in user file (for now)

--- a/internal/users/userrecord_isai_test.go
+++ b/internal/users/userrecord_isai_test.go
@@ -1,9 +1,10 @@
 package users
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -11,29 +12,18 @@ func TestUserRecordIsAISerializes(t *testing.T) {
 	u := UserRecord{Username: "tester", IsAI: true}
 
 	out, err := yaml.Marshal(u)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if !strings.Contains(string(out), "isai: true") {
-		t.Errorf("expected 'isai: true' in YAML, got:\n%s", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "isai: true")
 
 	var back UserRecord
-	if err := yaml.Unmarshal(out, &back); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if !back.IsAI {
-		t.Errorf("IsAI should round-trip true, got false")
-	}
+	require.NoError(t, yaml.Unmarshal(out, &back))
+	assert.True(t, back.IsAI, "IsAI should round-trip true")
 }
 
 func TestUserRecordIsAIOmittedWhenFalse(t *testing.T) {
 	u := UserRecord{Username: "human"}
+
 	out, err := yaml.Marshal(u)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if strings.Contains(string(out), "isai:") {
-		t.Errorf("isai should be omitted when false, got:\n%s", out)
-	}
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "isai:", "isai should be omitted when false")
 }

--- a/internal/users/userrecord_isai_test.go
+++ b/internal/users/userrecord_isai_test.go
@@ -1,0 +1,39 @@
+package users
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestUserRecordIsAISerializes(t *testing.T) {
+	u := UserRecord{Username: "tester", IsAI: true}
+
+	out, err := yaml.Marshal(u)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "isai: true") {
+		t.Errorf("expected 'isai: true' in YAML, got:\n%s", out)
+	}
+
+	var back UserRecord
+	if err := yaml.Unmarshal(out, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !back.IsAI {
+		t.Errorf("IsAI should round-trip true, got false")
+	}
+}
+
+func TestUserRecordIsAIOmittedWhenFalse(t *testing.T) {
+	u := UserRecord{Username: "human"}
+	out, err := yaml.Marshal(u)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "isai:") {
+		t.Errorf("isai should be omitted when false, got:\n%s", out)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/GoMudEngine/GoMud/internal/audio"
 	"github.com/GoMudEngine/GoMud/internal/buffs"
-	"github.com/GoMudEngine/GoMud/internal/modmanager"
 	"github.com/GoMudEngine/GoMud/internal/characters"
 	"github.com/GoMudEngine/GoMud/internal/colorpatterns"
 	"github.com/GoMudEngine/GoMud/internal/configs"
@@ -32,6 +31,7 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/keywords"
 	"github.com/GoMudEngine/GoMud/internal/language"
 	"github.com/GoMudEngine/GoMud/internal/migration"
+	"github.com/GoMudEngine/GoMud/internal/modmanager"
 	"github.com/GoMudEngine/GoMud/internal/usercommands"
 	"github.com/GoMudEngine/GoMud/internal/version"
 	"github.com/gorilla/websocket"
@@ -326,14 +326,20 @@ func main() {
 	allServerListeners := make([]net.Listener, 0, len(c.Network.TelnetPort))
 	for _, port := range c.Network.TelnetPort {
 		if p, err := strconv.Atoi(port); err == nil && p > 0 {
-			if s := TelnetListenOnPort(``, p, &wg, int(c.Network.MaxTelnetConnections)); s != nil {
+			if s := TelnetListenOnPort(``, p, &wg, int(c.Network.MaxTelnetConnections), connections.ConnHuman); s != nil {
 				allServerListeners = append(allServerListeners, s)
 			}
 		}
 	}
 
 	if c.Network.LocalPort > 0 {
-		TelnetListenOnPort(`127.0.0.1`, int(c.Network.LocalPort), &wg, 0)
+		TelnetListenOnPort(`127.0.0.1`, int(c.Network.LocalPort), &wg, 0, connections.ConnHuman)
+	}
+
+	if c.Network.AIPort > 0 {
+		if s := TelnetListenOnPort(``, int(c.Network.AIPort), &wg, int(c.Network.MaxAIConnections), connections.ConnAI); s != nil {
+			allServerListeners = append(allServerListeners, s)
+		}
 	}
 
 	if sshPort := int(c.Network.SSHPort); sshPort > 0 {
@@ -698,6 +704,10 @@ func handleTelnetConnection(connDetails *connections.ConnectionDetails, wg *sync
 	splashTxt, _ := templates.Process("login/connect-splash", nil)
 	connections.SendTo([]byte(templates.AnsiParse(splashTxt)), connDetails.ConnectionId())
 
+	if connDetails.ConnType() == connections.ConnAI {
+		connections.SendTo([]byte("\r\nThis port is for AI clients. Human players, please use the standard telnet port.\r\n\r\n"), connDetails.ConnectionId())
+	}
+
 	// --- Trigger the Prompt Handler to initialize state and send the FIRST prompt ---
 	// Create a dummy input that signifies "start the process" but has no actual user data/control codes.
 	initialTriggerInput := &connections.ClientInput{
@@ -885,6 +895,12 @@ func handleTelnetConnection(connDetails *connections.ConnectionDetails, wg *sync
 
 			worldManager.SendEnterWorld(userObject.UserId, userObject.Character.RoomId)
 
+			if connDetails.ConnType() == connections.ConnAI && !userObject.IsAI {
+				connections.SendTo([]byte("\r\nWarning: this account is not flagged as AI but connected on the AI port.\r\n"), connDetails.ConnectionId())
+			} else if connDetails.ConnType() == connections.ConnHuman && userObject.IsAI {
+				connections.SendTo([]byte("\r\nWarning: this AI account is connected on a human port. Please use the AI port.\r\n"), connDetails.ConnectionId())
+			}
+
 			clientInput.Reset()
 			continue
 		}
@@ -940,6 +956,19 @@ func handleTelnetConnection(connDetails *connections.ConnectionDetails, wg *sync
 						connections.SendTo([]byte(templates.AnsiParse(userObject.GetCommandPrompt())), clientInput.ConnectionId)
 					}
 
+				}
+
+				if connDetails.ConnType() == connections.ConnAI {
+					if !connDetails.AICommandAllowed(int64(util.GetRoundCount()), int(c.Network.AICommandsPerRound)) {
+						connections.SendTo(
+							[]byte(fmt.Sprintf("Command dropped — AI rate limit (%d/round). Wait for the next round.\r\n", int(c.Network.AICommandsPerRound))),
+							connDetails.ConnectionId(),
+						)
+						clientInput.Reset()
+						userObject.SetUnsentText(``, ``)
+						time.Sleep(time.Duration(10) * time.Millisecond)
+						continue
+					}
 				}
 
 				wi := WorldInput{
@@ -1182,7 +1211,7 @@ func HandleWebSocketConnection(conn *websocket.Conn) {
 	}
 }
 
-func TelnetListenOnPort(hostname string, portNum int, wg *sync.WaitGroup, maxConnections int) net.Listener {
+func TelnetListenOnPort(hostname string, portNum int, wg *sync.WaitGroup, maxConnections int, connType connections.ConnType) net.Listener {
 
 	server, err := net.Listen("tcp", fmt.Sprintf("%s:%d", hostname, portNum))
 	if err != nil {
@@ -1208,19 +1237,28 @@ func TelnetListenOnPort(hostname string, portNum int, wg *sync.WaitGroup, maxCon
 			}
 
 			if maxConnections > 0 {
-				if connections.ActiveConnectionCount() >= maxConnections {
-					conn.Write([]byte(fmt.Sprintf("\n\n\n!!! Server is full (%d connections). Try again later. !!!\n\n\n", connections.ActiveConnectionCount())))
+				activeCount := connections.ActiveConnectionCount()
+				if connType == connections.ConnAI {
+					activeCount = connections.ActiveAIConnectionCount()
+				}
+				if activeCount >= maxConnections {
+					if connType == connections.ConnAI {
+						conn.Write([]byte("\n\n\n!!! AI connection pool is full. Try again later. !!!\n\n\n"))
+					} else {
+						conn.Write([]byte(fmt.Sprintf("\n\n\n!!! Server is full (%d connections). Try again later. !!!\n\n\n", activeCount)))
+					}
 					conn.Close()
 					continue
 				}
 			}
 
 			wg.Add(1)
+			connDetails := connections.Add(conn, nil, connType)
+			if connType == connections.ConnAI {
+				connDetails.SetStripAnsi(true)
+			}
 			// hand off the connection to a handler goroutine so that we can continue handling new connections
-			go handleTelnetConnection(
-				connections.Add(conn, nil),
-				wg,
-			)
+			go handleTelnetConnection(connDetails, wg)
 
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -336,8 +336,8 @@ func main() {
 		TelnetListenOnPort(`127.0.0.1`, int(c.Network.LocalPort), &wg, 0, connections.ConnHuman)
 	}
 
-	if c.Network.AIPort > 0 {
-		if s := TelnetListenOnPort(``, int(c.Network.AIPort), &wg, int(c.Network.MaxAIConnections), connections.ConnAI); s != nil {
+	if c.Network.AI.Port > 0 {
+		if s := TelnetListenOnPort(``, int(c.Network.AI.Port), &wg, int(c.Network.AI.MaxConnections), connections.ConnAI); s != nil {
 			allServerListeners = append(allServerListeners, s)
 		}
 	}
@@ -959,9 +959,9 @@ func handleTelnetConnection(connDetails *connections.ConnectionDetails, wg *sync
 				}
 
 				if connDetails.ConnType() == connections.ConnAI {
-					if !connDetails.AICommandAllowed(int64(util.GetRoundCount()), int(c.Network.AICommandsPerRound)) {
+					if !connDetails.AICommandAllowed(int64(util.GetRoundCount()), int(c.Network.AI.CommandsPerRound)) {
 						connections.SendTo(
-							[]byte(fmt.Sprintf("Command dropped — AI rate limit (%d/round). Wait for the next round.\r\n", int(c.Network.AICommandsPerRound))),
+							[]byte(fmt.Sprintf("Command dropped — AI rate limit (%d/round). Wait for the next round.\r\n", int(c.Network.AI.CommandsPerRound))),
 							connDetails.ConnectionId(),
 						)
 						clientInput.Reset()


### PR DESCRIPTION
# Description

Adds an **optional, disabled-by-default** dedicated telnet port for AI/test
clients, with its own connection cap, per-round command rate limit, and clean
(ANSI-stripped) output, plus a persisted `IsAI` flag on user records. **With
default config this PR changes nothing** — the AI port is off (`AI.Port: 0`)
until an operator enables it.

This is the engine slice of a generalized AI playtest harness for GoMud (a way
for operators to point an AI agent at their server, have it play through a set
of goals using standard tester "personalities," and emit a report). The
harness itself ships as community artifacts — a registry module and an external
adapter — but a dedicated, bounded port for AI traffic can only live in the
engine: a second listener, a connection-type tag, a per-type cap, output
shaping, and an input-loop rate gate all sit below the plugin/module API. This
PR is exactly that core slice and nothing more; all *policy* (account
provisioning, sandbox/safe-mode, flagging commands) stays in a separate, opt-in
community module. (A heads-up was given to the maintainer on Discord that this
change was coming; this description is written so reviewers who weren't part of
that conversation have full context.)

## Changes

- Added `Network.AI.Port` (`0` = disabled), `Network.AI.MaxConnections` (default
  `20`), and `Network.AI.CommandsPerRound` (default `2`) config fields, with
  `Validate()` defaults — mirrors the existing `SSHPort` convention.
- Added `_datafiles/config.yaml` entries for the three keys, shipped DISABLED
  (`AI.Port: 0`).
- Added `UserRecord.IsAI bool` (`yaml:"isai,omitempty"`) — a persisted flag
  marking an account as an AI/test account.
- Added `connections.ConnType` (`ConnHuman`/`ConnAI`) on `ConnectionDetails`,
  with atomic `ConnType()` / `SetConnType()`.
- Added `connections.StripAnsi` + a `stripAnsi` flag, wired into `Write` so AI
  connections receive plain text (telnet IAC preserved).
- Added `ConnectionDetails.AICommandAllowed(round, max)` — a per-round command
  rate limiter for AI connections.
- Changed `connections.Add(conn, ws)` to `Add(conn, ws, connType ...ConnType)`
  (variadic, backwards-compatible) and added `ActiveAIConnectionCount()`.
- Changed `TelnetListenOnPort(...)` to take a `connType` parameter; existing
  human/local call sites pass `ConnHuman` (behavior unchanged).
- Added an AI listener in `main()` that opens only when `AI.Port > 0`, with an
  independent cap, ANSI stripping, a pre-`SendInput` rate gate, an AI-port
  greeting, and post-login port-mismatch warnings.
- Added unit tests (testify) for config defaulting, `ConnType`, `StripAnsi`,
  the rate limiter, and `ActiveAIConnectionCount`.

---

## What this PR deliberately does NOT add

To keep the diff thin and the responsibility boundary clean, this PR contains
**no policy**: no account auto-provisioning, no safe-mode / sandbox
confinement, no `IsAI` flagging commands, no leaderboard changes. Those live in
the separate, opt-in `playtest` community module built on these primitives.

## Backwards compatibility

- `AI.Port` ships `0` (disabled): a stock server opens the same ports as before;
  this PR is a no-op until configured.
- `connections.Add(...)`'s new `connType` is **variadic**, so existing 2-arg
  callers (including out-of-tree ones) compile unchanged and default to
  `ConnHuman`.
- `TelnetListenOnPort`'s new parameter is internal; all in-tree call sites are
  updated to `ConnHuman`.

## New configuration

| Key | Default | Meaning |
|-----|---------|---------|
| `Network.AI.Port` | `0` | Telnet port for AI clients. `0` disables. Set e.g. `55555` to enable. |
| `Network.AI.MaxConnections` | `20` | Max concurrent AI connections (independent of human cap). |
| `Network.AI.CommandsPerRound` | `2` | Max commands an AI connection may submit per round. |

Plus `UserRecord.IsAI` (`isai` in user YAML), defaulting to `false`/omitted.

## Behavior when enabled

- **Cap reached:** new AI connection receives
  `!!! AI connection pool is full. Try again later. !!!` and is closed.
- **Rate limit hit:** the command is dropped and the client is told
  `Command dropped — AI rate limit (N/round). Wait for the next round.`
- **Greeting / mismatch warnings:** AI-port connections get a one-line port
  notice; a mismatched account (AI on a human port, or vice versa) gets a
  non-blocking post-login warning.

## Test plan

- [x] `go test ./internal/configs/ ./internal/connections/ ./internal/users/` — green.
- [x] `go build ./...` — clean.
- [x] Boot with `AI.Port: 0` — listeners unchanged, no AI port (no-op default).
- [x] Boot with `AI.Port: 55555` — server reaches "Server Ready" and binds
  `0.0.0.0:55555` alongside `33333`/`44444`; greeting, clean output, cap, and
  rate-limit verified over a raw telnet connection.

