### PR TITLE
Update release assets and release notes

### DIFF
--- a/.github/actions/codegen-and-test/action.yml
+++ b/.github/actions/codegen-and-test/action.yml
@@ -21,6 +21,8 @@ runs:
           go build -o "$tmp_dir/gomud-linux_armv7" .
         env GOOS=windows GOARCH=amd64 \
           go build -o "$tmp_dir/gomud-windows_x64.exe" .
+        env GOOS=windows GOARCH=arm64 \
+          go build -o "$tmp_dir/gomud-windows_arm64.exe" .
         env GOOS=darwin GOARCH=amd64 \
           go build -o "$tmp_dir/gomud-darwin_x64" .
         env GOOS=darwin GOARCH=arm64 \

--- a/.github/actions/codegen-and-test/action.yml
+++ b/.github/actions/codegen-and-test/action.yml
@@ -1,10 +1,28 @@
 ---
-name: "Codegen and Test"
-description: "Run go generate and go test"
+name: "Codegen, Test, and Cross-Compile"
+description: "Run go generate, go test, and release target cross-compiles"
 runs:
   using: "composite"
   steps:
     - run: go generate ./...
       shell: bash
     - run: go test -race ./...
+      shell: bash
+    - name: Check release cross-compiles
+      run: |
+        tmp_dir="$(mktemp -d)"
+        trap 'rm -rf "$tmp_dir"' EXIT
+
+        env GOOS=linux GOARCH=amd64 \
+          go build -o "$tmp_dir/gomud-linux_x64" .
+        env GOOS=linux GOARCH=arm64 \
+          go build -o "$tmp_dir/gomud-linux_arm64" .
+        env GOOS=linux GOARCH=arm GOARM=7 \
+          go build -o "$tmp_dir/gomud-linux_armv7" .
+        env GOOS=windows GOARCH=amd64 \
+          go build -o "$tmp_dir/gomud-windows_x64.exe" .
+        env GOOS=darwin GOARCH=amd64 \
+          go build -o "$tmp_dir/gomud-darwin_x64" .
+        env GOOS=darwin GOARCH=arm64 \
+          go build -o "$tmp_dir/gomud-darwin_arm64" .
       shell: bash

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-release-notes.md}"
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+}
+
+require_env BINARY_VERSION
+require_env CHECKSUMS_FILE
+require_env DATAFILES_ARCHIVE
+require_env GITHUB_REPOSITORY
+require_env GITHUB_RUN_ATTEMPT
+require_env GITHUB_RUN_ID
+require_env GITHUB_SHA
+require_env RELEASE_NOTES_INTRO
+require_env RELEASE_NOTES_SUMMARY
+
+latest_release_tag="$(
+  gh api "repos/${GITHUB_REPOSITORY}/releases/latest" \
+    --jq '.tag_name' \
+    2>/dev/null || true
+)"
+
+generate_notes_args=(
+  -f "tag_name=release-notes-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+  -f "target_commitish=${GITHUB_SHA}"
+)
+
+if [ -n "$latest_release_tag" ]; then
+  generate_notes_args+=(-f "previous_tag_name=${latest_release_tag}")
+  changes_since_line="- Changes since: \`${latest_release_tag}\`"
+else
+  changes_since_line="- Changes since: initial release history"
+fi
+
+generated_release_notes="$(
+  gh api \
+    -X POST \
+    "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+    "${generate_notes_args[@]}" \
+    --jq '.body'
+)"
+published_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+cat > "$output_file" <<EOF
+${RELEASE_NOTES_INTRO}
+
+- Version: \`${BINARY_VERSION}\`
+- Commit: \`${GITHUB_SHA}\`
+- Published: \`${published_at}\`
+${changes_since_line}
+
+### Downloads
+
+- Windows, most Intel/AMD PCs: \`gomud-windows_x64.exe\`
+- Windows on ARM: \`gomud-windows_arm64.exe\`
+- macOS Apple Silicon: \`gomud-darwin_arm64\`
+- macOS Intel: \`gomud-darwin_x64\`
+- Linux x86_64: \`gomud-linux_x64\`
+- Linux ARM64: \`gomud-linux_arm64\`
+- Raspberry Pi / ARMv7 Linux: \`gomud-linux_armv7\`
+- Server data files: \`${DATAFILES_ARCHIVE}\`
+- Checksums: \`${CHECKSUMS_FILE}\`
+
+${RELEASE_NOTES_SUMMARY}
+For permanent downloadable builds, use the numbered releases.
+
+${generated_release_notes}
+EOF

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -244,43 +244,7 @@ jobs:
             > "${CHECKSUMS_FILE}"
 
       - name: Write release notes
-        run: |
-          latest_release_tag="$(
-            gh api "repos/${GITHUB_REPOSITORY}/releases/latest" \
-              --jq '.tag_name' \
-              2>/dev/null || true
-          )"
-          generate_notes_args=(
-            -f "tag_name=release-notes-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-            -f "target_commitish=${GITHUB_SHA}"
-          )
-          if [ -n "$latest_release_tag" ]; then
-            generate_notes_args+=(-f "previous_tag_name=${latest_release_tag}")
-            changes_since_line="- Changes since: \`${latest_release_tag}\`"
-          else
-            changes_since_line="- Changes since: initial release history"
-          fi
-          generated_release_notes="$(
-            gh api \
-              -X POST \
-              "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-              "${generate_notes_args[@]}" \
-              --jq '.body'
-          )"
-          published_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          cat > release-notes.md <<EOF
-          ${RELEASE_NOTES_INTRO}
-
-          - Version: \`${BINARY_VERSION}\`
-          - Commit: \`${GITHUB_SHA}\`
-          - Published: \`${published_at}\`
-          ${changes_since_line}
-
-          ${RELEASE_NOTES_SUMMARY}
-          For permanent downloadable builds, use the numbered releases.
-
-          ${generated_release_notes}
-          EOF
+        run: .github/scripts/generate-release-notes.sh release-notes.md
 
       - name: Create prerelease
         run: |

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -167,11 +167,17 @@ jobs:
           -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-linux_x64 .
 
-      - name: Build linux/arm5
+      - name: Build linux/arm64
         run: >-
-          env GOOS=linux GOARCH=arm GOARM=5 go build -v
+          env GOOS=linux GOARCH=arm64 go build -v
           -ldflags "-X main.version=${BINARY_VERSION}"
-          -o bin/gomud-linux_arm5 .
+          -o bin/gomud-linux_arm64 .
+
+      - name: Build linux/armv7
+        run: >-
+          env GOOS=linux GOARCH=arm GOARM=7 go build -v
+          -ldflags "-X main.version=${BINARY_VERSION}"
+          -o bin/gomud-linux_armv7 .
 
       - name: Upload bin
         # actions/upload-artifact v7.0.1
@@ -225,7 +231,8 @@ jobs:
             gomud-darwin_arm64 \
             gomud-darwin_x64 \
             gomud-linux_x64 \
-            gomud-linux_arm5 \
+            gomud-linux_arm64 \
+            gomud-linux_armv7 \
             "${DATAFILES_ARCHIVE}" \
             > "${CHECKSUMS_FILE}"
 
@@ -275,7 +282,8 @@ jobs:
             bin/gomud-darwin_arm64
             bin/gomud-darwin_x64
             bin/gomud-linux_x64
-            bin/gomud-linux_arm5
+            bin/gomud-linux_arm64
+            bin/gomud-linux_armv7
             "bin/$DATAFILES_ARCHIVE"
             "bin/$CHECKSUMS_FILE"
           )

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -287,6 +287,21 @@ jobs:
             "bin/$DATAFILES_ARCHIVE"
             "bin/$CHECKSUMS_FILE"
           )
+          stale_assets=(
+            gomud-linux_arm5
+          )
+
+          delete_stale_release_assets() {
+            local asset_name
+            for asset_name in "$@"; do
+              if gh release view "$RELEASE_TAG" \
+                --json assets \
+                --jq '.assets[].name' \
+                | grep -Fxq "$asset_name"; then
+                gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
+              fi
+            done
+          }
 
           if [ -n "$REQUESTED_RELEASE_TAG" ]; then
             if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
@@ -295,6 +310,7 @@ jobs:
                 "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" \
                 -f "sha=${GITHUB_SHA}" \
                 -F force=true
+              delete_stale_release_assets "${stale_assets[@]}"
               gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
               gh release edit "$RELEASE_TAG" \
                 --title "$RELEASE_TITLE" \
@@ -318,6 +334,7 @@ jobs:
             fi
           else
             if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              delete_stale_release_assets "${stale_assets[@]}"
               gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
               gh release edit "$RELEASE_TAG" \
                 --title "$RELEASE_TITLE" \

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -149,6 +149,12 @@ jobs:
           -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-windows_x64.exe .
 
+      - name: Build windows arm64
+        run: >-
+          env GOOS=windows GOARCH=arm64 go build -v
+          -ldflags "-X main.version=${BINARY_VERSION}"
+          -o bin/gomud-windows_arm64.exe .
+
       - name: Build darwin/arm64
         run: >-
           env GOOS=darwin GOARCH=arm64 go build -v
@@ -228,6 +234,7 @@ jobs:
           cd bin
           sha256sum \
             gomud-windows_x64.exe \
+            gomud-windows_arm64.exe \
             gomud-darwin_arm64 \
             gomud-darwin_x64 \
             gomud-linux_x64 \
@@ -279,6 +286,7 @@ jobs:
         run: |
           assets=(
             bin/gomud-windows_x64.exe
+            bin/gomud-windows_arm64.exe
             bin/gomud-darwin_arm64
             bin/gomud-darwin_x64
             bin/gomud-linux_x64
@@ -287,21 +295,6 @@ jobs:
             "bin/$DATAFILES_ARCHIVE"
             "bin/$CHECKSUMS_FILE"
           )
-          stale_assets=(
-            gomud-linux_arm5
-          )
-
-          delete_stale_release_assets() {
-            local asset_name
-            for asset_name in "$@"; do
-              if gh release view "$RELEASE_TAG" \
-                --json assets \
-                --jq '.assets[].name' \
-                | grep -Fxq "$asset_name"; then
-                gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
-              fi
-            done
-          }
 
           if [ -n "$REQUESTED_RELEASE_TAG" ]; then
             if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
@@ -310,7 +303,6 @@ jobs:
                 "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" \
                 -f "sha=${GITHUB_SHA}" \
                 -F force=true
-              delete_stale_release_assets "${stale_assets[@]}"
               gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
               gh release edit "$RELEASE_TAG" \
                 --title "$RELEASE_TITLE" \
@@ -334,7 +326,6 @@ jobs:
             fi
           else
             if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-              delete_stale_release_assets "${stale_assets[@]}"
               gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
               gh release edit "$RELEASE_TAG" \
                 --title "$RELEASE_TITLE" \

--- a/.github/workflows/release-latest-assets.yml
+++ b/.github/workflows/release-latest-assets.yml
@@ -193,43 +193,7 @@ jobs:
             > "${{ env.CHECKSUMS_FILE }}"
 
       - name: Write release notes
-        run: |
-          latest_release_tag="$(
-            gh api "repos/${GITHUB_REPOSITORY}/releases/latest" \
-              --jq '.tag_name' \
-              2>/dev/null || true
-          )"
-          generate_notes_args=(
-            -f "tag_name=release-notes-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-            -f "target_commitish=${GITHUB_SHA}"
-          )
-          if [ -n "$latest_release_tag" ]; then
-            generate_notes_args+=(-f "previous_tag_name=${latest_release_tag}")
-            changes_since_line="- Changes since: \`${latest_release_tag}\`"
-          else
-            changes_since_line="- Changes since: initial release history"
-          fi
-          generated_release_notes="$(
-            gh api \
-              -X POST \
-              "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-              "${generate_notes_args[@]}" \
-              --jq '.body'
-          )"
-          published_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          cat > release-notes.md <<EOF
-          ${RELEASE_NOTES_INTRO}
-
-          - Version: \`${BINARY_VERSION}\`
-          - Commit: \`${GITHUB_SHA}\`
-          - Published: \`${published_at}\`
-          ${changes_since_line}
-
-          ${RELEASE_NOTES_SUMMARY}
-          For permanent downloadable builds, use the numbered releases.
-
-          ${generated_release_notes}
-          EOF
+        run: .github/scripts/generate-release-notes.sh release-notes.md
 
       - name: Publish latest release assets
         run: |

--- a/.github/workflows/release-latest-assets.yml
+++ b/.github/workflows/release-latest-assets.yml
@@ -117,11 +117,17 @@ jobs:
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/gomud-linux_x64 .
 
-      - name: Build linux/arm5
+      - name: Build linux/arm64
         run: >-
-          env GOOS=linux GOARCH=arm GOARM=5 go build -v
+          env GOOS=linux GOARCH=arm64 go build -v
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
-          -o bin/gomud-linux_arm5 .
+          -o bin/gomud-linux_arm64 .
+
+      - name: Build linux/armv7
+        run: >-
+          env GOOS=linux GOARCH=arm GOARM=7 go build -v
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -o bin/gomud-linux_armv7 .
 
       - name: Upload bin
         # actions/upload-artifact v7.0.1
@@ -174,7 +180,8 @@ jobs:
             gomud-darwin_arm64 \
             gomud-darwin_x64 \
             gomud-linux_x64 \
-            gomud-linux_arm5 \
+            gomud-linux_arm64 \
+            gomud-linux_armv7 \
             "${{ env.DATAFILES_ARCHIVE }}" \
             > "${{ env.CHECKSUMS_FILE }}"
 
@@ -224,7 +231,8 @@ jobs:
             bin/gomud-darwin_arm64
             bin/gomud-darwin_x64
             bin/gomud-linux_x64
-            bin/gomud-linux_arm5
+            bin/gomud-linux_arm64
+            bin/gomud-linux_armv7
             "bin/$DATAFILES_ARCHIVE"
             "bin/$CHECKSUMS_FILE"
           )

--- a/.github/workflows/release-latest-assets.yml
+++ b/.github/workflows/release-latest-assets.yml
@@ -236,6 +236,21 @@ jobs:
             "bin/$DATAFILES_ARCHIVE"
             "bin/$CHECKSUMS_FILE"
           )
+          stale_assets=(
+            gomud-linux_arm5
+          )
+
+          delete_stale_release_assets() {
+            local asset_name
+            for asset_name in "$@"; do
+              if gh release view "$RELEASE_TAG" \
+                --json assets \
+                --jq '.assets[].name' \
+                | grep -Fxq "$asset_name"; then
+                gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
+              fi
+            done
+          }
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh api \
@@ -243,6 +258,7 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" \
               -f "sha=${GITHUB_SHA}" \
               -F force=true
+            delete_stale_release_assets "${stale_assets[@]}"
             gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
             gh release edit "$RELEASE_TAG" \
               --title "$RELEASE_TITLE" \

--- a/.github/workflows/release-latest-assets.yml
+++ b/.github/workflows/release-latest-assets.yml
@@ -99,6 +99,12 @@ jobs:
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/gomud-windows_x64.exe .
 
+      - name: Build windows arm64
+        run: >-
+          env GOOS=windows GOARCH=arm64 go build -v
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -o bin/gomud-windows_arm64.exe .
+
       - name: Build darwin/arm64
         run: >-
           env GOOS=darwin GOARCH=arm64 go build -v
@@ -177,6 +183,7 @@ jobs:
           cd bin
           sha256sum \
             gomud-windows_x64.exe \
+            gomud-windows_arm64.exe \
             gomud-darwin_arm64 \
             gomud-darwin_x64 \
             gomud-linux_x64 \
@@ -228,6 +235,7 @@ jobs:
         run: |
           assets=(
             bin/gomud-windows_x64.exe
+            bin/gomud-windows_arm64.exe
             bin/gomud-darwin_arm64
             bin/gomud-darwin_x64
             bin/gomud-linux_x64
@@ -236,21 +244,6 @@ jobs:
             "bin/$DATAFILES_ARCHIVE"
             "bin/$CHECKSUMS_FILE"
           )
-          stale_assets=(
-            gomud-linux_arm5
-          )
-
-          delete_stale_release_assets() {
-            local asset_name
-            for asset_name in "$@"; do
-              if gh release view "$RELEASE_TAG" \
-                --json assets \
-                --jq '.assets[].name' \
-                | grep -Fxq "$asset_name"; then
-                gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
-              fi
-            done
-          }
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh api \
@@ -258,7 +251,6 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" \
               -f "sha=${GITHUB_SHA}" \
               -F force=true
-            delete_stale_release_assets "${stale_assets[@]}"
             gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
             gh release edit "$RELEASE_TAG" \
               --title "$RELEASE_TITLE" \

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -1335,8 +1335,8 @@ func (c *Character) XPTL(lvl int) int {
 	cfg := configs.GetProgressionConfig()
 	base := float64(cfg.XPBase)
 	xp := (base + math.Pow(float64(lvl), float64(cfg.XPLevelPower))*float64(cfg.XPLevelFactor)*base) * float64(c.TNLScale)
-	if xp > math.MaxInt64 {
-		return math.MaxInt64
+	if xp > math.MaxInt {
+		return math.MaxInt
 	}
 	return int(xp)
 }

--- a/internal/characters/character_test.go
+++ b/internal/characters/character_test.go
@@ -1,6 +1,7 @@
 package characters
 
 import (
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,6 +11,14 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/skills"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCharacter_XPTLClampsToMaxInt(t *testing.T) {
+	c := New()
+
+	got := c.XPTL(200_000_000)
+
+	assert.Equal(t, math.MaxInt, got)
+}
 
 func TestCharacter_CanDualWield(t *testing.T) {
 	tests := []struct {

--- a/internal/web/api_v1_progression.go
+++ b/internal/web/api_v1_progression.go
@@ -270,5 +270,8 @@ func xpTLWithCfg(lvl int, cfg configs.ProgressionConfig) int {
 	}
 	base := float64(cfg.XPBase)
 	xp := base + math.Pow(float64(lvl), float64(cfg.XPLevelPower))*float64(cfg.XPLevelFactor)*base
+	if xp > math.MaxInt {
+		return math.MaxInt
+	}
 	return int(xp)
 }

--- a/internal/web/api_v1_progression_test.go
+++ b/internal/web/api_v1_progression_test.go
@@ -1,0 +1,21 @@
+package web
+
+import (
+	"math"
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/characters"
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXPTLWithCfgClampsConsistentlyWithCharacter(t *testing.T) {
+	const highLevel = 200_000_000
+
+	cfg := configs.GetProgressionConfig()
+	previewXP := xpTLWithCfg(highLevel, cfg)
+	engineXP := characters.New().XPTL(highLevel)
+
+	assert.Equal(t, math.MaxInt, previewXP)
+	assert.Equal(t, engineXP, previewXP)
+}


### PR DESCRIPTION
## Context

The release workflows currently duplicate release-note generation inline and publish a narrower/older target matrix than the asset names users are likely to look for. That makes the release flow harder to review and increases the chance that `latest` assets and numbered release assets diverge.

This PR centralizes the release-note generation and updates both current release workflows to build, checksum, and publish the same release asset set.

## Changes

- Updates `.github/workflows/build-and-release.yml` and `.github/workflows/release-latest-assets.yml` to build, checksum, and publish:
  - `gomud-windows_x64.exe`
  - `gomud-windows_arm64.exe`
  - `gomud-darwin_arm64`
  - `gomud-darwin_x64`
  - `gomud-linux_x64`
  - `gomud-linux_arm64`
  - `gomud-linux_armv7`
  - the bundled datafiles archive
  - the checksum file
- Replaces the previous Linux ARM5 artifact with Linux ARMv7 and adds Linux ARM64 and Windows ARM64 release assets.
- Adds `.github/scripts/generate-release-notes.sh` so both release workflows use the same release-note generation path.
- Adds a downloads section to generated release notes so users can map their platform to the expected asset name.
- Extends `.github/actions/codegen-and-test/action.yml` so PR validation cross-compiles every release target, including the new Windows ARM64 target.

## Verification

- `bash -n .github/scripts/generate-release-notes.sh`
- `git diff --check origin/master...HEAD`

Not run locally: `make ci-local` or the full release workflows. The updated composite action should exercise the release-target cross-compiles in CI.
