### PR TITLE
fix: clamp XP progression values to MaxInt

### DIFF
--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -1335,8 +1335,8 @@ func (c *Character) XPTL(lvl int) int {
 	cfg := configs.GetProgressionConfig()
 	base := float64(cfg.XPBase)
 	xp := (base + math.Pow(float64(lvl), float64(cfg.XPLevelPower))*float64(cfg.XPLevelFactor)*base) * float64(c.TNLScale)
-	if xp > math.MaxInt64 {
-		return math.MaxInt64
+	if xp > math.MaxInt {
+		return math.MaxInt
 	}
 	return int(xp)
 }

--- a/internal/characters/character_test.go
+++ b/internal/characters/character_test.go
@@ -1,6 +1,7 @@
 package characters
 
 import (
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,6 +11,14 @@ import (
 	"github.com/GoMudEngine/GoMud/internal/skills"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCharacter_XPTLClampsToMaxInt(t *testing.T) {
+	c := New()
+
+	got := c.XPTL(200_000_000)
+
+	assert.Equal(t, math.MaxInt, got)
+}
 
 func TestCharacter_CanDualWield(t *testing.T) {
 	tests := []struct {

--- a/internal/web/api_v1_progression.go
+++ b/internal/web/api_v1_progression.go
@@ -270,5 +270,8 @@ func xpTLWithCfg(lvl int, cfg configs.ProgressionConfig) int {
 	}
 	base := float64(cfg.XPBase)
 	xp := base + math.Pow(float64(lvl), float64(cfg.XPLevelPower))*float64(cfg.XPLevelFactor)*base
+	if xp > math.MaxInt {
+		return math.MaxInt
+	}
 	return int(xp)
 }

--- a/internal/web/api_v1_progression_test.go
+++ b/internal/web/api_v1_progression_test.go
@@ -1,0 +1,21 @@
+package web
+
+import (
+	"math"
+	"testing"
+
+	"github.com/GoMudEngine/GoMud/internal/characters"
+	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXPTLWithCfgClampsConsistentlyWithCharacter(t *testing.T) {
+	const highLevel = 200_000_000
+
+	cfg := configs.GetProgressionConfig()
+	previewXP := xpTLWithCfg(highLevel, cfg)
+	engineXP := characters.New().XPTL(highLevel)
+
+	assert.Equal(t, math.MaxInt, previewXP)
+	assert.Equal(t, engineXP, previewXP)
+}


### PR DESCRIPTION
## Summary

- GoMud stores and returns XP-to-level values as an `int`. 
- The progression formula uses configurable values and floating-point math, so extremely high levels can produce a value larger than the native `int` range before the final conversion.
- `Character.XPTL` already attempted to guard that conversion, but it compared against `math.MaxInt64`, which prevents builds on 32-bit systems.

This PR keeps XP in the existing `int` domain and clamps both calculations to `math.MaxInt` before converting.

## Changes

- Updates `Character.XPTL` to clamp overflow-sized XP calculations to `math.MaxInt`.
- Adds the same clamp to `xpTLWithCfg`, which backs the admin progression preview.
- Adds a character-level regression test for high-level XP clamping.
- Adds a web progression test proving the preview helper and engine calculation clamp consistently.

## Verification

- `go test ./internal/characters ./internal/web`
