### PR TITLE
ci: update release asset targets

### DIFF
--- a/.github/actions/codegen-and-test/action.yml
+++ b/.github/actions/codegen-and-test/action.yml
@@ -8,3 +8,30 @@ runs:
       shell: bash
     - run: go test -race ./...
       shell: bash
+    - run: |
+        tmp_dir="$(mktemp -d)"
+        trap 'rm -rf "$tmp_dir"' EXIT
+
+        build_target() {
+          local goos="$1"
+          local goarch="$2"
+          local goarm="$3"
+          local output="$4"
+
+          if [ -n "$goarm" ]; then
+            env GOOS="$goos" GOARCH="$goarch" GOARM="$goarm" \
+              go build -o "$tmp_dir/$output" .
+          else
+            env GOOS="$goos" GOARCH="$goarch" \
+              go build -o "$tmp_dir/$output" .
+          fi
+        }
+
+        build_target linux amd64 "" gomud-linux_x64
+        build_target linux arm64 "" gomud-linux_arm64
+        build_target linux arm 7 gomud-linux_armv7
+        build_target windows amd64 "" gomud-windows_x64.exe
+        build_target windows arm64 "" gomud-windows_arm64.exe
+        build_target darwin amd64 "" gomud-darwin_x64
+        build_target darwin arm64 "" gomud-darwin_arm64
+      shell: bash

--- a/.github/actions/codegen-and-test/action.yml
+++ b/.github/actions/codegen-and-test/action.yml
@@ -8,7 +8,8 @@ runs:
       shell: bash
     - run: go test -race ./...
       shell: bash
-    - run: |
+    - name: Cross-compile release targets
+      run: |
         tmp_dir="$(mktemp -d)"
         trap 'rm -rf "$tmp_dir"' EXIT
 
@@ -18,13 +19,15 @@ runs:
           local goarm="$3"
           local output="$4"
 
+          echo "::group::Build $output ($goos/$goarch${goarm:+ GOARM=$goarm})"
           if [ -n "$goarm" ]; then
             env GOOS="$goos" GOARCH="$goarch" GOARM="$goarm" \
-              go build -o "$tmp_dir/$output" .
+              go build -v -o "$tmp_dir/$output" .
           else
             env GOOS="$goos" GOARCH="$goarch" \
-              go build -o "$tmp_dir/$output" .
+              go build -v -o "$tmp_dir/$output" .
           fi
+          echo "::endgroup::"
         }
 
         build_target linux amd64 "" gomud-linux_x64

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -149,6 +149,12 @@ jobs:
           -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-windows_x64.exe .
 
+      - name: Build windows arm64
+        run: >-
+          env GOOS=windows GOARCH=arm64 go build -v
+          -ldflags "-X main.version=${BINARY_VERSION}"
+          -o bin/gomud-windows_arm64.exe .
+
       - name: Build darwin/arm64
         run: >-
           env GOOS=darwin GOARCH=arm64 go build -v
@@ -167,11 +173,17 @@ jobs:
           -ldflags "-X main.version=${BINARY_VERSION}"
           -o bin/gomud-linux_x64 .
 
-      - name: Build linux/arm5
+      - name: Build linux/arm64
         run: >-
-          env GOOS=linux GOARCH=arm GOARM=5 go build -v
+          env GOOS=linux GOARCH=arm64 go build -v
           -ldflags "-X main.version=${BINARY_VERSION}"
-          -o bin/gomud-linux_arm5 .
+          -o bin/gomud-linux_arm64 .
+
+      - name: Build linux/armv7
+        run: >-
+          env GOOS=linux GOARCH=arm GOARM=7 go build -v
+          -ldflags "-X main.version=${BINARY_VERSION}"
+          -o bin/gomud-linux_armv7 .
 
       - name: Upload bin
         # actions/upload-artifact v7.0.1
@@ -222,10 +234,12 @@ jobs:
           cd bin
           sha256sum \
             gomud-windows_x64.exe \
+            gomud-windows_arm64.exe \
             gomud-darwin_arm64 \
             gomud-darwin_x64 \
             gomud-linux_x64 \
-            gomud-linux_arm5 \
+            gomud-linux_arm64 \
+            gomud-linux_armv7 \
             "${DATAFILES_ARCHIVE}" \
             > "${CHECKSUMS_FILE}"
 
@@ -272,10 +286,12 @@ jobs:
         run: |
           assets=(
             bin/gomud-windows_x64.exe
+            bin/gomud-windows_arm64.exe
             bin/gomud-darwin_arm64
             bin/gomud-darwin_x64
             bin/gomud-linux_x64
-            bin/gomud-linux_arm5
+            bin/gomud-linux_arm64
+            bin/gomud-linux_armv7
             "bin/$DATAFILES_ARCHIVE"
             "bin/$CHECKSUMS_FILE"
           )

--- a/.github/workflows/release-latest-assets.yml
+++ b/.github/workflows/release-latest-assets.yml
@@ -99,6 +99,12 @@ jobs:
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/gomud-windows_x64.exe .
 
+      - name: Build windows arm64
+        run: >-
+          env GOOS=windows GOARCH=arm64 go build -v
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -o bin/gomud-windows_arm64.exe .
+
       - name: Build darwin/arm64
         run: >-
           env GOOS=darwin GOARCH=arm64 go build -v
@@ -117,11 +123,17 @@ jobs:
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
           -o bin/gomud-linux_x64 .
 
-      - name: Build linux/arm5
+      - name: Build linux/arm64
         run: >-
-          env GOOS=linux GOARCH=arm GOARM=5 go build -v
+          env GOOS=linux GOARCH=arm64 go build -v
           -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
-          -o bin/gomud-linux_arm5 .
+          -o bin/gomud-linux_arm64 .
+
+      - name: Build linux/armv7
+        run: >-
+          env GOOS=linux GOARCH=arm GOARM=7 go build -v
+          -ldflags "-X main.version=${{ env.BINARY_VERSION }}"
+          -o bin/gomud-linux_armv7 .
 
       - name: Upload bin
         # actions/upload-artifact v7.0.1
@@ -171,10 +183,12 @@ jobs:
           cd bin
           sha256sum \
             gomud-windows_x64.exe \
+            gomud-windows_arm64.exe \
             gomud-darwin_arm64 \
             gomud-darwin_x64 \
             gomud-linux_x64 \
-            gomud-linux_arm5 \
+            gomud-linux_arm64 \
+            gomud-linux_armv7 \
             "${{ env.DATAFILES_ARCHIVE }}" \
             > "${{ env.CHECKSUMS_FILE }}"
 
@@ -221,10 +235,12 @@ jobs:
         run: |
           assets=(
             bin/gomud-windows_x64.exe
+            bin/gomud-windows_arm64.exe
             bin/gomud-darwin_arm64
             bin/gomud-darwin_x64
             bin/gomud-linux_x64
-            bin/gomud-linux_arm5
+            bin/gomud-linux_arm64
+            bin/gomud-linux_armv7
             "bin/$DATAFILES_ARCHIVE"
             "bin/$CHECKSUMS_FILE"
           )


### PR DESCRIPTION
## Changes

- Add Windows ARM64 and Linux ARM64 binaries to the GitHub Actions build/release workflows.
- Replace the Linux ARM5 builds with Linux ARMv7 (a more realistic end-user use-case).
- Keep the `latest` and numbered release workflows aligned on the same build, checksum, and upload asset names.
- Extend the shared `codegen-and-test` action to cross-compile release targets during PR validation.
- Emit grouped, verbose build logs for each release target so CI failures identify the target that failed.

## Validation

- `git diff --check`
- `actionlint .github/workflows/build-and-release.yml .github/workflows/release-latest-assets.yml`
- Parsed `.github/actions/codegen-and-test/action.yml` as YAML with Ruby.