### PR TITLE
ci: optimize release packaging workflows

### DIFF
--- a/.github/actions/go-checks/action.yml
+++ b/.github/actions/go-checks/action.yml
@@ -7,6 +7,9 @@ runs:
     - name: Generate code
       run: go generate ./...
       shell: bash
+    - name: Verify generated output is clean
+      run: git diff --exit-code
+      shell: bash
     - name: Run Go tests
       run: go test -race ./...
       shell: bash

--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -104,26 +104,62 @@ ${overview}
 
 ${summary}
 
-## Downloads
+## Install GoMud
 
-${downloads}
+### Requirements
 
-## Install From Source
+- Go 1.24 or newer
+- Optional: Docker (for container-based runs)
 
-Clone the repository, check out this release tag or commit, install the Go
-toolchain from \`go.mod\`, and run \`make build\`.
+### Quick Install (Recommended)
 
-## Manual Binary Install
+- The fastest way to get GoMud running.
+- These scripts install Go and Git (if needed), clone the GoMud repo, and build the server binary automatically.
 
-Download the binary for your operating system and CPU architecture, download
-\`${datafiles_archive}\`, unpack the datafiles next to the binary, and make the
-binary executable on Unix-like systems.
+**Linux / macOS:**
 
-## Verify Provenance
+Open a Terminal and run:
 
-Download \`${checksums_file}\` and run \`sha256sum -c ${checksums_file}\` in the
-directory containing the release assets. Verify build provenance with
-\`gh attestation verify <asset> --repo ${repository}\`.
+```shell
+curl -fsSL https://raw.githubusercontent.com/GoMudEngine/GoMud/master/scripts/install.sh | sh
+```
+
+**Windows:**
+
+Open a `Powershell` window and run:
+
+```powershell
+irm https://raw.githubusercontent.com/GoMudEngine/GoMud/master/scripts/install.ps1 | iex
+```
+
+- Both scripts install GoMud to `~/GoMud` by default.
+- Set the `GOMUD_DIR` environment variable before running to choose a different location.
+
+### Alternative: Manual Binary Install
+
+- Go to the GoMud [Release Page](https://github.com/GoMudEngine/GoMud/releases/latest)
+- Scroll down to the **Assets** section and expand it
+- Download the datafiles (needed by all operating systems):
+  - **`gomud-ALL-datafiles.zip`**
+  - Extract this zip file into the same folder as the GoMud binary
+- Download the GoMud binary/executable specific for your operating system, based on the table below:
+
+**Most common:**
+
+| Filename | Operating System | CPU Architecture | Typical Devices |
+|------------|------------------|------------------|-----------------|
+| gomud-darwin_arm64 | macOS | ARM64 (Apple Silicon) | Apple M1, M2, M3, M4 Macs |
+| gomud-linux_x64 | Linux | x86_64 (Intel/AMD 64-bit) | Most modern desktop/server Linux systems |
+| gomud-windows_x64.exe | Windows | x86_64 (Intel/AMD 64-bit) | Most modern Windows PCs |
+
+**Other options:**
+
+| Filename | Operating System | CPU Architecture | Typical Devices |
+|------------|------------------|------------------|-----------------|
+| gomud-darwin_x64 | macOS | x86_64 (Intel 64-bit) | Older Intel-based Macs |
+| gomud-windows_arm64.exe | Windows | ARM64 | Surface Pro X, Snapdragon X Elite laptops, Windows on ARM
+| gomud-linux_arm64 | Linux | ARM64 (AArch64) | Linux systems using ARM-based CPUs |
+| gomud-linux_armv7 | Linux | ARMv7 (32-bit) | Raspberry Pi 2/3 running 32-bit OS |
 
 ## Changes
 

--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -120,27 +120,27 @@ ${summary}
 
 Open a Terminal and run:
 
-```shell
+\`\`\`shell
 curl -fsSL https://raw.githubusercontent.com/GoMudEngine/GoMud/master/scripts/install.sh | sh
-```
+\`\`\`
 
 **Windows:**
 
-Open a `Powershell` window and run:
+Open a \`Powershell\` window and run:
 
-```powershell
+\`\`\`powershell
 irm https://raw.githubusercontent.com/GoMudEngine/GoMud/master/scripts/install.ps1 | iex
-```
+\`\`\`
 
-- Both scripts install GoMud to `~/GoMud` by default.
-- Set the `GOMUD_DIR` environment variable before running to choose a different location.
+- Both scripts install GoMud to \`~/GoMud\` by default.
+- Set the \`GOMUD_DIR\` environment variable before running to choose a different location.
 
 ### Alternative: Manual Binary Install
 
-- Go to the GoMud [Release Page](https://github.com/GoMudEngine/GoMud/releases/latest)
+- Go to the GoMud [Release Page](https://github.com/${repository}/releases/tag/${release_tag})
 - Scroll down to the **Assets** section and expand it
 - Download the datafiles (needed by all operating systems):
-  - **`gomud-ALL-datafiles.zip`**
+  - **\`gomud-ALL-datafiles.zip\`**
   - Extract this zip file into the same folder as the GoMud binary
 - Download the GoMud binary/executable specific for your operating system, based on the table below:
 

--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -10,12 +10,6 @@ repository="${GITHUB_REPOSITORY:-}"
 commit_sha="${GITHUB_SHA:-}"
 ref_name="${GITHUB_REF_NAME:-}"
 datafiles_archive="${DATAFILES_ARCHIVE:-gomud-ALL-datafiles.zip}"
-checksums_file="${CHECKSUMS_FILE:-SHA256SUMS.txt}"
-downloads="$(
-	DATAFILES_ARCHIVE="$datafiles_archive" \
-		CHECKSUMS_FILE="$checksums_file" \
-		.github/scripts/release-assets.sh downloads-markdown
-)"
 
 require_env() {
 	local name="$1"
@@ -140,7 +134,7 @@ irm https://raw.githubusercontent.com/GoMudEngine/GoMud/master/scripts/install.p
 - Go to the GoMud [Release Page](https://github.com/${repository}/releases/tag/${release_tag})
 - Scroll down to the **Assets** section and expand it
 - Download the datafiles (needed by all operating systems):
-  - **\`gomud-ALL-datafiles.zip\`**
+  - **\`${datafiles_archive}\`**
   - Extract this zip file into the same folder as the GoMud binary
 - Download the GoMud binary/executable specific for your operating system, based on the table below:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,12 @@ jobs:
             echo "js_lint=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if printf '%s\n' "${changed_files}" | grep -Eq '(^|/)[^/]+\.go$'; then
+          go_re='(^|/)[^/]+\.go$'
+          go_re="${go_re}|^(go\.mod|go\.sum|Makefile)$"
+          go_re="${go_re}|^\.github/actions/(go-checks|setup-go)/"
+          go_re="${go_re}|^\.github/workflows/ci\.yml"
+
+          if printf '%s\n' "${changed_files}" | grep -Eq "${go_re}"; then
             echo "runtime_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "runtime_build=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ name: CI
 # - Go format/vet
 # - conditional JS lint
 # - Go race tests
-# - Release cross-compile check
 
 "on":
   push:
@@ -30,12 +29,14 @@ permissions:
 
 jobs:
   detect-changes:
-    name: Detect JavaScript Changes
+    name: Detect Relevant Changes
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       js_lint: >-
         ${{ steps.filter.outputs.js_lint }}
+      runtime_build: >-
+        ${{ steps.filter.outputs.runtime_build }}
     steps:
       # Full history is needed so push and pull request events can diff against
       # the actual base commit instead of whatever shallow checkout provides.
@@ -69,10 +70,26 @@ jobs:
             echo "js_lint=false" >> "$GITHUB_OUTPUT"
           fi
 
+          runtime_re='(^|/)[^/]+\.go$'
+          runtime_re="${runtime_re}|^(go\.mod|go\.sum|Makefile|_datafiles/)"
+          runtime_re="${runtime_re}|^(modules/|cmd/|internal/|scripts/)"
+          runtime_re="${runtime_re}|^(provisioning/|compose\.yml)"
+          runtime_re="${runtime_re}|^\.github/actions/(go-checks|setup-go)/"
+          runtime_re="${runtime_re}|^\.github/workflows/ci\.yml"
+
+          if printf '%s\n' "${changed_files}" | grep -Eq "${runtime_re}"; then
+            echo "runtime_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "runtime_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
   go-lint:
     name: Go Format And Vet
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.runtime_build == 'true'
     steps:
       # actions/checkout v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -108,9 +125,12 @@ jobs:
         run: make js-lint
 
   test:
-    name: Go Tests And Release Cross-Compile
+    name: Go Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.runtime_build == 'true'
     steps:
       # actions/checkout v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -120,11 +140,3 @@ jobs:
       - uses: ./.github/actions/setup-go
 
       - uses: ./.github/actions/go-checks
-
-      - name: Cross-compile release targets
-        if: >-
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/master'
-        env:
-          RELEASE_DIST_DIR: ${{ runner.temp }}/release-cross-compile
-        run: .github/scripts/build-release-binaries.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   detect-changes:
-    name: Detect Relevant Changes
+    name: Detect JavaScript Changes
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - id: filter
-        name: Detect JavaScript lint inputs
+        name: Detect relevant inputs
         env:
           BASE_REF: >-
             ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -88,17 +88,26 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: detect-changes
-    if: >-
-      needs.detect-changes.outputs.runtime_build == 'true'
     steps:
+      - name: Skip Go lint checks
+        if: >-
+          needs.detect-changes.outputs.runtime_build != 'true'
+        run: echo "No runtime build inputs changed; skipping Go lint checks."
+
       # actions/checkout v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        if: >-
+          needs.detect-changes.outputs.runtime_build == 'true'
         with:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-go
+        if: >-
+          needs.detect-changes.outputs.runtime_build == 'true'
 
       - name: Run Go lint checks
+        if: >-
+          needs.detect-changes.outputs.runtime_build == 'true'
         run: make validate
 
   js-lint:
@@ -106,37 +115,54 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: detect-changes
-    # The web client JavaScript is linted only when related files change.
-    if: >-
-      needs.detect-changes.outputs.js_lint == 'true'
     steps:
+      - name: Skip JavaScript lint checks
+        if: >-
+          needs.detect-changes.outputs.js_lint != 'true'
+        run: echo "No JavaScript lint inputs changed; skipping JavaScript lint checks."
+
       # actions/checkout v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        if: >-
+          needs.detect-changes.outputs.js_lint == 'true'
         with:
           persist-credentials: false
 
       - name: Set up Node.js
+        if: >-
+          needs.detect-changes.outputs.js_lint == 'true'
         # actions/setup-node v6.4.0
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '22'
 
       - name: Run JavaScript lint checks
+        if: >-
+          needs.detect-changes.outputs.js_lint == 'true'
         run: make js-lint
 
   test:
-    name: Go Tests
+    name: Go Tests And Release Cross-Compile
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: detect-changes
-    if: >-
-      needs.detect-changes.outputs.runtime_build == 'true'
     steps:
+      - name: Skip Go tests
+        if: >-
+          needs.detect-changes.outputs.runtime_build != 'true'
+        run: echo "No runtime build inputs changed; skipping Go tests."
+
       # actions/checkout v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        if: >-
+          needs.detect-changes.outputs.runtime_build == 'true'
         with:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-go
+        if: >-
+          needs.detect-changes.outputs.runtime_build == 'true'
 
       - uses: ./.github/actions/go-checks
+        if: >-
+          needs.detect-changes.outputs.runtime_build == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         run: make js-lint
 
   test:
-    name: Go Tests And Release Cross-Compile
+    name: Go Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,7 @@ jobs:
             echo "js_lint=false" >> "$GITHUB_OUTPUT"
           fi
 
-          runtime_re='(^|/)[^/]+\.go$'
-          runtime_re="${runtime_re}|^(go\.mod|go\.sum|Makefile|_datafiles/)"
-          runtime_re="${runtime_re}|^(modules/|cmd/|internal/|scripts/)"
-          runtime_re="${runtime_re}|^(provisioning/|compose\.yml)"
-          runtime_re="${runtime_re}|^\.github/actions/(go-checks|setup-go)/"
-          runtime_re="${runtime_re}|^\.github/workflows/ci\.yml"
-
-          if printf '%s\n' "${changed_files}" | grep -Eq "${runtime_re}"; then
+          if printf '%s\n' "${changed_files}" | grep -Eq '(^|/)[^/]+\.go$'; then
             echo "runtime_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "runtime_build=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,26 +88,17 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.runtime_build == 'true'
     steps:
-      - name: Skip Go lint checks
-        if: >-
-          needs.detect-changes.outputs.runtime_build != 'true'
-        run: echo "No runtime build inputs changed; skipping Go lint checks."
-
       # actions/checkout v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        if: >-
-          needs.detect-changes.outputs.runtime_build == 'true'
         with:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-go
-        if: >-
-          needs.detect-changes.outputs.runtime_build == 'true'
 
       - name: Run Go lint checks
-        if: >-
-          needs.detect-changes.outputs.runtime_build == 'true'
         run: make validate
 
   js-lint:
@@ -115,30 +106,21 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.js_lint == 'true'
     steps:
-      - name: Skip JavaScript lint checks
-        if: >-
-          needs.detect-changes.outputs.js_lint != 'true'
-        run: echo "No JavaScript lint inputs changed; skipping JavaScript lint checks."
-
       # actions/checkout v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        if: >-
-          needs.detect-changes.outputs.js_lint == 'true'
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        if: >-
-          needs.detect-changes.outputs.js_lint == 'true'
         # actions/setup-node v6.4.0
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '22'
 
       - name: Run JavaScript lint checks
-        if: >-
-          needs.detect-changes.outputs.js_lint == 'true'
         run: make js-lint
 
   test:
@@ -146,23 +128,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.runtime_build == 'true'
     steps:
-      - name: Skip Go tests
-        if: >-
-          needs.detect-changes.outputs.runtime_build != 'true'
-        run: echo "No runtime build inputs changed; skipping Go tests."
-
       # actions/checkout v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        if: >-
-          needs.detect-changes.outputs.runtime_build == 'true'
         with:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-go
-        if: >-
-          needs.detect-changes.outputs.runtime_build == 'true'
 
       - uses: ./.github/actions/go-checks
-        if: >-
-          needs.detect-changes.outputs.runtime_build == 'true'

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -101,6 +101,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to the Container registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
         # docker/login-action v4.1.0
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -15,14 +15,70 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  detect-changes:
+    name: Detect Docker Build Inputs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      docker_build: >-
+        ${{ steps.filter.outputs.docker_build }}
+    steps:
+      # Full history is needed so push and pull request events can diff against
+      # the actual base commit instead of whatever shallow checkout provides.
+      # actions/checkout v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: filter
+        name: Detect Docker build inputs
+        env:
+          BASE_REF: >-
+            ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_REF: ${{ github.sha }}
+        run: |
+          set -eu
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "docker_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "${BASE_REF}" ] || \
+            [ "${BASE_REF}" = "0000000000000000000000000000000000000000" ]; then
+            BASE_REF="$(git rev-parse HEAD^)"
+          fi
+
+          changed_files="$(git diff --name-only "${BASE_REF}" "${HEAD_REF}")"
+          printf '%s\n' "${changed_files}"
+
+          docker_re='(^|/)[^/]+\.go$'
+          docker_re="${docker_re}|^(go\.mod|go\.sum|Makefile|_datafiles/)"
+          docker_re="${docker_re}|^(modules/|cmd/|internal/|scripts/)"
+          docker_re="${docker_re}|^(provisioning/|compose\.yml)"
+          docker_re="${docker_re}|^\.github/workflows/docker-package\.yml"
+
+          if printf '%s\n' "${changed_files}" | grep -Eq "${docker_re}"; then
+            echo "docker_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
   package:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.docker_build == 'true'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -62,7 +62,7 @@ jobs:
           printf '%s\n' "${changed_files}"
 
           docker_re='(^|/)[^/]+\.go$'
-          docker_re="${docker_re}|^(go\.mod|go\.sum|Makefile|_datafiles/)"
+          docker_re="${docker_re}|^(\.dockerignore|go\.mod|go\.sum|Makefile|_datafiles/)"
           docker_re="${docker_re}|^(modules/|cmd/|internal/|scripts/)"
           docker_re="${docker_re}|^(provisioning/|compose\.yml)"
           docker_re="${docker_re}|^\.github/workflows/docker-package\.yml"

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -45,6 +45,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ "${GITHUB_REF}" != "refs/heads/master" ]; then
+            echo "Stable releases must be run from the master branch." >&2
+            exit 1
+          fi
+
           semver_re='^v(0|[1-9][0-9]*)\.'
           semver_re="${semver_re}(0|[1-9][0-9]*)\."
           semver_re="${semver_re}(0|[1-9][0-9]*)$"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,7 +102,8 @@ For Windows, use the PowerShell installer:
     case "$raw_arch" in
     x86_64)          GO_ARCH="amd64" ;;
     aarch64 | arm64) GO_ARCH="arm64" ;;
-    armv6l | armv7l) GO_ARCH="armv6l" ;;
+    # Go distributes 32-bit Linux ARM toolchains as linux-armv6l.
+    armv6l | armv7l | armv8l) GO_ARCH="armv6l" ;;
     i386 | i686)     GO_ARCH="386" ;;
     *)               fatal "Unsupported architecture: $raw_arch." ;;
     esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,7 +102,7 @@ For Windows, use the PowerShell installer:
     case "$raw_arch" in
     x86_64)          GO_ARCH="amd64" ;;
     aarch64 | arm64) GO_ARCH="arm64" ;;
-    armv6l)          GO_ARCH="armv6l" ;;
+    armv6l | armv7l) GO_ARCH="armv6l" ;;
     i386 | i686)     GO_ARCH="386" ;;
     *)               fatal "Unsupported architecture: $raw_arch." ;;
     esac
@@ -197,6 +197,7 @@ install_go() {
     maybe_sudo tar -C /usr/local -xzf "$archive_path"
 
     # Persist PATH update to ~/.profile if not already present.
+    # shellcheck disable=SC2016
     profile_line='export PATH=$PATH:/usr/local/go/bin'
     if [ -f "$HOME/.profile" ] && grep -qF '/usr/local/go/bin' "$HOME/.profile"; then
         : # already present


### PR DESCRIPTION
## Summary

- Gate CI Go format/vet and Go tests on Go-related inputs: `*.go`, `go.mod`, `go.sum`, `Makefile`, and shared Go CI workflow/action files.
- Keep JavaScript lint conditional on JavaScript lint inputs.
- Add Docker package change detection so image builds only run when build-relevant files change, including `.dockerignore`, and skip GHCR login on pull requests.
- Improve release notes generation with current-tag asset links, safer generated Markdown output, and configurable datafiles archive text.
- Ensure stable release builds are dispatched from `master`, and keep release cross-builds out of PR CI.
- Add generated-output cleanliness verification to the shared Go checks action.
- Support `armv7l`/`armv8l` hosts in the Linux/macOS installer's Go toolchain download mapping.

## Validation

- `actionlint .github/workflows/*.yml`
- `bash -n .github/scripts/*.sh scripts/install.sh`
- `zsh -n scripts/install.sh`
- `git diff --check`
- Focused `.dockerignore` Docker detection regex check
- Focused Go-related CI gate regex check
- Release-notes dry run with `RELEASE_NOTES_SKIP_GH=true`, confirming `releases/tag/<tag>` links, Markdown literals, and configurable datafiles archive text render correctly

