### PR TITLE
ci: publish Docker images only for stable releases

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -34,6 +34,9 @@ workflow to avoid duplicate full race-test runs on merge.
    required reviewers on that environment in repository settings.
 5. After environment approval, the workflow creates a draft release, uploads
    assets, attaches release notes, then publishes the stable release.
+6. After the stable release is published, the `Stable Release` workflow calls
+   the `Docker Image` workflow to build and publish the GitHub Container
+   Registry image.
 
 Stable release workflow policy does not move tags, use `--clobber`, or replace
 existing releases. Keep repository-wide immutable releases disabled so the
@@ -59,6 +62,8 @@ After a release workflow succeeds:
 - Confirm binaries and `SHA256SUMS.txt` have artifact attestations.
 - For stable releases, confirm the release tag points at the intended commit and
   the release is no longer a draft.
+- For stable releases, confirm the GitHub Container Registry image was updated
+  with the stable release tag and `latest` tags.
 
 ### FAQ
 

--- a/.github/act/docker_package_call.json
+++ b/.github/act/docker_package_call.json
@@ -1,0 +1,5 @@
+{
+  "inputs": {
+    "release_tag": "v0.0.0"
+  }
+}

--- a/.github/scripts/ci-local-act.sh
+++ b/.github/scripts/ci-local-act.sh
@@ -32,7 +32,5 @@ run_act pull_request .github/act/pull_request.json \
 run_act push .github/act/push_master.json .github/workflows/prerelease.yml
 run_act workflow_dispatch .github/act/stable_release.json \
 	.github/workflows/stable-release.yml
-run_act push .github/act/push_master.json \
-	.github/workflows/docker-package.yml ${ACT_DRYRUN_SECRETS:-}
-run_act pull_request .github/act/pull_request.json \
+run_act workflow_call .github/act/docker_package_call.json \
 	.github/workflows/docker-package.yml ${ACT_DRYRUN_SECRETS:-}

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -10,7 +10,7 @@ name: Docker Image
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.release_tag }}
+  group: docker-package-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -2,17 +2,15 @@
 name: Docker Image
 
 "on":
-  # Manual dispatch lets maintainers rebuild the image without changing source.
-  workflow_dispatch:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Stable semver release tag, such as v0.10.0
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 permissions:
@@ -21,64 +19,12 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  RELEASE_TAG: ${{ inputs.release_tag }}
 
 jobs:
-  detect-changes:
-    name: Detect Docker Build Inputs
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    outputs:
-      docker_build: >-
-        ${{ steps.filter.outputs.docker_build }}
-    steps:
-      # Full history is needed so push and pull request events can diff against
-      # the actual base commit instead of whatever shallow checkout provides.
-      # actions/checkout v6.0.2
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - id: filter
-        name: Detect Docker build inputs
-        env:
-          BASE_REF: >-
-            ${{ github.event.pull_request.base.sha || github.event.before }}
-          HEAD_REF: ${{ github.sha }}
-        run: |
-          set -eu
-
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "docker_build=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -z "${BASE_REF}" ] || \
-            [ "${BASE_REF}" = "0000000000000000000000000000000000000000" ]; then
-            BASE_REF="$(git rev-parse HEAD^)"
-          fi
-
-          changed_files="$(git diff --name-only "${BASE_REF}" "${HEAD_REF}")"
-          printf '%s\n' "${changed_files}"
-
-          docker_re='(^|/)[^/]+\.go$'
-          docker_re="${docker_re}|^(\.dockerignore|go\.mod|go\.sum|Makefile|_datafiles/)"
-          docker_re="${docker_re}|^(modules/|cmd/|internal/|scripts/)"
-          docker_re="${docker_re}|^(provisioning/|compose\.yml)"
-          docker_re="${docker_re}|^\.github/workflows/docker-package\.yml"
-
-          if printf '%s\n' "${changed_files}" | grep -Eq "${docker_re}"; then
-            echo "docker_build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "docker_build=false" >> "$GITHUB_OUTPUT"
-          fi
-
   package:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    needs: detect-changes
-    if: >-
-      needs.detect-changes.outputs.docker_build == 'true'
     permissions:
       contents: read
       packages: write
@@ -89,6 +35,18 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+
+      - name: Validate stable release tag
+        run: |
+          set -euo pipefail
+
+          semver_re='^v(0|[1-9][0-9]*)\.'
+          semver_re="${semver_re}(0|[1-9][0-9]*)\."
+          semver_re="${semver_re}(0|[1-9][0-9]*)$"
+          if ! printf '%s\n' "$RELEASE_TAG" | grep -Eq "$semver_re"; then
+            echo "release_tag must be a stable semver tag like v0.10.0" >&2
+            exit 1
+          fi
 
       - name: Detect Go version
         id: go-version
@@ -101,7 +59,6 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to the Container registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
         # docker/login-action v4.1.0
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
@@ -116,11 +73,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable=${{
-              github.ref == 'refs/heads/master'
-              }}
-            type=ref,event=pr
-            type=sha
+            type=raw,value=latest
+            type=raw,value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG }}
 
       - name: Build and push Docker image
         id: push
@@ -128,9 +84,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
-          # Pull requests build and cache the image, but only trusted events
-          # publish to GitHub Packages.
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           file: ./provisioning/Dockerfile
           build-args: |
             GO_VERSION=${{ steps.go-version.outputs.version }}
@@ -140,7 +94,6 @@ jobs:
           cache-to: type=gha,mode=max,scope=docker-package
 
       - name: Generate artifact attestation
-        if: github.event_name != 'pull_request'
         # actions/attest-build-provenance v4.1.0
         # yamllint disable-line rule:line-length
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -132,8 +132,8 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  publish:
-    name: Publish Stable Release
+  stage-release:
+    name: Stage Stable Release
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs:
@@ -144,6 +144,8 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+    outputs:
+      release_id: ${{ steps.draft.outputs.release_id }}
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
       RELEASE_TITLE: ${{ inputs.release_tag }}
@@ -251,23 +253,11 @@ jobs:
             --title "$RELEASE_TITLE" \
             --latest
 
-      - name: Publish stable release
-        env:
-          RELEASE_ID: ${{ steps.draft.outputs.release_id }}
-        run: |
-          set -euo pipefail
-
-          gh api \
-            -X PATCH \
-            "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
-            -F draft=false \
-            -F prerelease=false
-
   docker-image:
     name: Publish Stable Docker Image
     needs:
       - validate-release
-      - publish
+      - stage-release
     uses: ./.github/workflows/docker-package.yml
     permissions:
       contents: read
@@ -277,3 +267,26 @@ jobs:
     secrets: inherit
     with:
       release_tag: ${{ inputs.release_tag }}
+
+  publish:
+    name: Publish Stable Release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs:
+      - stage-release
+      - docker-image
+    permissions:
+      contents: write
+    env:
+      RELEASE_ID: ${{ needs.stage-release.outputs.release_id }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Publish stable release
+        run: |
+          set -euo pipefail
+
+          gh api \
+            -X PATCH \
+            "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+            -F draft=false \
+            -F prerelease=false

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -262,3 +262,18 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
             -F draft=false \
             -F prerelease=false
+
+  docker-image:
+    name: Publish Stable Docker Image
+    needs:
+      - validate-release
+      - publish
+    uses: ./.github/workflows/docker-package.yml
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    secrets: inherit
+    with:
+      release_tag: ${{ inputs.release_tag }}


### PR DESCRIPTION
## Summary
- convert the Docker image workflow into a reusable `workflow_call` job that requires a stable semver `release_tag`
- publish GHCR images only from the stable release path, tagging `latest`, the exact release tag, full semver, and major/minor semver aliases
- split stable releases into staging, Docker image publishing, and final release publishing so the release is only made public after the image publish completes
- update local `act` fixtures and release docs for the stable Docker image publishing path
