### PR TITLE
ci: ignore vendored JavaScript in CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,6 +3,8 @@ name: GoMud CodeQL config
 
 # Keep CodeQL focused on GoMud source. These are checked-in third-party
 # browser bundles, better covered by dependency maintenance than source scans.
+# If a first-party script moves under one of these directories, remove or
+# narrow the matching ignore before relying on CodeQL coverage for that file.
 paths-ignore:
   - _datafiles/html/admin/static/js/monaco/**
   - _datafiles/html/admin/static/js/highlight.js

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+---
+name: GoMud CodeQL config
+
+# Keep CodeQL focused on GoMud source. These are checked-in third-party
+# browser bundles, better covered by dependency maintenance than source scans.
+paths-ignore:
+  - _datafiles/html/admin/static/js/monaco/**
+  - _datafiles/html/admin/static/js/highlight.js
+  - _datafiles/html/admin/static/css/monaco-editor.css
+  - _datafiles/html/public/static/js/xterm/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,8 @@
 ---
 name: CodeQL
 
+# This is the advanced CodeQL setup. GitHub will reject its uploaded results
+# while repository CodeQL default setup is still enabled.
 "on":
   push:
     branches:
@@ -29,8 +31,10 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-24.04
+    # Keep analyzer regressions from tying up a runner indefinitely.
     timeout-minutes: 30
     strategy:
+      # Run both languages so one analyzer failure does not hide the other.
       fail-fast: false
       matrix:
         language:
@@ -49,9 +53,11 @@ jobs:
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
           languages: ${{ matrix.language }}
+          # Path filters live in CodeQL config, not workflow event filters.
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
+        # JavaScript/TypeScript is interpreted here; only Go needs autobuild.
         if: matrix.language == 'go'
         # github/codeql-action v4.36.2
         # yamllint disable-line rule:line-length
@@ -62,4 +68,5 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
+          # Keep separate code scanning result categories for each language.
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+---
+name: CodeQL
+
+"on":
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  schedule:
+    - cron: "20 14 * * 1"
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - go
+          - javascript-typescript
+
+    steps:
+      # actions/checkout v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        # github/codeql-action v4.31.6
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        if: matrix.language == 'go'
+        # github/codeql-action v4.31.6
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+
+      - name: Perform CodeQL Analysis
+        # github/codeql-action v4.31.6
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,13 +38,13 @@ jobs:
           - javascript-typescript
 
     steps:
-      # actions/checkout v6.0.2
+      # actions/checkout v6.0.3
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        # github/codeql-action v4.31.6
+        # github/codeql-action v4.36.2
         # yamllint disable-line rule:line-length
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
@@ -53,12 +53,12 @@ jobs:
 
       - name: Autobuild
         if: matrix.language == 'go'
-        # github/codeql-action v4.31.6
+        # github/codeql-action v4.36.2
         # yamllint disable-line rule:line-length
         uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
 
       - name: Perform CodeQL Analysis
-        # github/codeql-action v4.31.6
+        # github/codeql-action v4.36.2
         # yamllint disable-line rule:line-length
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:


### PR DESCRIPTION
## Summary

- Adds an explicit CodeQL advanced setup workflow for Go and JavaScript/TypeScript.
- Adds a CodeQL config file that ignores checked-in third-party browser bundles.
- Skips JavaScript autobuild and only autobuilds Go, since JS/TS CodeQL does not need a build step here.
- Adds a 30-minute job timeout so a future analyzer hang cannot consume a runner indefinitely.

## Why

- The current CodeQL run is using GitHub dynamic default setup.
- The JavaScript/TypeScript analyzer gets stuck in `Perform CodeQL Analysis`.
- The likely cause is CodeQL scanning large vendored browser assets, especially Monaco and xterm bundles under `_datafiles/html/.../static`.
- These files are third-party generated bundles, so they are low-value for source analysis and better covered by dependency maintenance.

## Ignored Paths

- `_datafiles/html/admin/static/js/monaco/**`
- `_datafiles/html/admin/static/js/highlight.js`
- `_datafiles/html/admin/static/css/monaco-editor.css`
- `_datafiles/html/public/static/js/xterm/**`

## TODO: Change GitHub Repo Settings

@Volte6 - After this PR is merged, you will need to switch CodeQL from default setup to advanced setup, so that GitHub uses `.github/workflows/codeql.yml` instead of the dynamic workflow.

Steps:

- On the GoMud repo, open **Settings**.
- Open **Code security** or **Advanced Security**.
- Find **CodeQL analysis**.
- If it is using **Default setup**, choose the menu next to it and select **Switch to advanced setup**, or disable default setup so the checked-in workflow is used.
- Confirm new CodeQL runs come from `.github/workflows/codeql.yml`, not `dynamic/github-code-scanning/codeql`.
- Cancel any old stuck `Analyze (javascript-typescript)` runs after the switch.
