### PR TITLE
Fix module config overlay clobbering operator overrides

### DIFF
--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -82,7 +82,15 @@ func AddOverlayOverrides(dotMap map[string]any) error {
 	if len(newKeys) == 0 {
 		return nil
 	}
-	return configData.OverlayOverrides(newKeys)
+
+	// Overlay the full override set rather than just the new keys. Overlaying
+	// only the new keys would unmarshal a partial Modules block into the live
+	// config, replacing the inner Modules[<name>] map wholesale and discarding
+	// every operator-supplied value for that module. Flatten first: at this
+	// point `overrides` is mixed-shape (nested maps loaded from
+	// config-overrides.yaml plus the flat dotted keys added above), and
+	// OverlayOverrides re-nests it internally.
+	return configData.OverlayOverrides(Flatten(overrides))
 }
 
 // OverlayDotMap overlays values from a dot-syntax map onto the Config.

--- a/internal/configs/overrides_test.go
+++ b/internal/configs/overrides_test.go
@@ -3,6 +3,7 @@ package configs
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -94,4 +95,67 @@ func TestOverlayDotMapMultipleFields(t *testing.T) {
 	if cfg.Statistics.SomeField != "updated" {
 		t.Errorf("Expected SomeField to be 'updated', got '%s'", cfg.Statistics.SomeField)
 	}
+}
+
+// TestAddOverlayOverridesPreservesOperatorOverrides reproduces the boot
+// sequence for a world whose config-overrides.yaml contains a partial
+// Modules block: the operator has set some (but not all) of a module's keys,
+// and the module's data-overlay config ships a superset of those keys.
+// Applying the overlay must fill in the missing defaults WITHOUT clobbering
+// the operator-supplied values or other modules' blocks.
+func TestAddOverlayOverridesPreservesOperatorOverrides(t *testing.T) {
+
+	// Snapshot and restore package globals so this test is hermetic.
+	origConfigData := configData
+	origOverrides := overrides
+	origKeyLookups := keyLookups
+	origTypeLookups := typeLookups
+	t.Cleanup(func() {
+		configData = origConfigData
+		overrides = origOverrides
+		keyLookups = origKeyLookups
+		typeLookups = origTypeLookups
+	})
+
+	configData = Config{}
+	keyLookups = map[string]string{}
+	typeLookups = map[string]string{}
+
+	// The operator's config-overrides.yaml: a partial Modules block for
+	// "weather" (missing NewSetting), plus an unrelated module's block.
+	operatorYAML := []byte(`
+Modules:
+  weather:
+    Enabled: true
+    CycleSeconds: 120
+  othermod:
+    Setting: keepme
+`)
+	loadedOverrides := map[string]any{}
+	require.NoError(t, yaml.Unmarshal(operatorYAML, &loadedOverrides))
+	overrides = loadedOverrides
+
+	// ReloadConfig applies operator overrides onto the live config at boot.
+	require.NoError(t, configData.OverlayOverrides(overrides))
+
+	// The module loads and registers its data-overlay config, a superset of
+	// the operator's keys. This mirrors how internal/plugins builds the map.
+	err := AddOverlayOverrides(map[string]any{
+		`Modules.weather.Enabled`:      false,        // module default; operator set true
+		`Modules.weather.CycleSeconds`: 60,           // module default; operator set 120
+		`Modules.weather.NewSetting`:   `overlayval`, // new key, absent from operator overrides
+	})
+	require.NoError(t, err)
+
+	flat := Flatten(map[string]any(configData.Modules))
+
+	// (a) Operator-supplied values must survive in the live config.
+	require.Equal(t, true, flat[`weather.Enabled`], `operator override Modules.weather.Enabled was clobbered by the module overlay`)
+	require.Equal(t, 120, flat[`weather.CycleSeconds`], `operator override Modules.weather.CycleSeconds was clobbered by the module overlay`)
+
+	// (b) Keys absent from the operator overrides get the overlay defaults.
+	require.Equal(t, `overlayval`, flat[`weather.NewSetting`])
+
+	// (c) Other modules' blocks are untouched.
+	require.Equal(t, `keepme`, flat[`othermod.Setting`])
 }

--- a/internal/plugins/pluginconfig.go
+++ b/internal/plugins/pluginconfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/GoMudEngine/GoMud/internal/configs"
+	"github.com/GoMudEngine/GoMud/internal/mudlog"
 )
 
 type PluginConfig struct {
@@ -11,7 +12,9 @@ type PluginConfig struct {
 }
 
 func (p *PluginConfig) Set(name string, val any) {
-	configs.SetVal(fmt.Sprintf(`Modules.%s.%s`, p.pluginName, name), fmt.Sprintf(`%v`, val))
+	if err := configs.SetVal(fmt.Sprintf(`Modules.%s.%s`, p.pluginName, name), fmt.Sprintf(`%v`, val)); err != nil {
+		mudlog.Error(`PluginConfig.Set`, `plugin`, p.pluginName, `key`, name, `error`, err)
+	}
 }
 
 func (p *PluginConfig) Get(name string) any {


### PR DESCRIPTION
# Upstream PR kit 2 — module config overlay clobber + silent Set failures

Branch `fix/module-config-overlay-clobber` is already pushed to
GoMudEngine/GoMud. Open the PR here:
<https://github.com/GoMudEngine/GoMud/compare/master...fix/module-config-overlay-clobber>

## PR title

```
Fix module config overlay clobbering operator overrides; log dropped plugin config writes
```

## PR body (matches the repo's PR template: Description + Changes)

```markdown
## Description

Two related issues in the module-config write/merge path that together make
operator config silently disappear.

**1. `AddOverlayOverrides` wipes the operator's module config block.**
When a plugin loads, its data-overlay config keys are applied via
`configData.OverlayOverrides(newKeys)`, where `newKeys` is only the keys the
operator's `config-overrides.yaml` doesn't already set. Because `Modules` is
a plain `map[string]any`, the yaml unmarshal of
`{Modules:{<name>:{<newKeys only>}}}` replaces the module's inner map
wholesale — every operator-set key for that module vanishes from the live
config. The file is untouched, so this silently re-breaks on every boot.

Trigger: any world whose `config-overrides.yaml` has a partial
`Modules: <name>:` block (which `configs.SetVal` — i.e. any admin-page or
`server set` write — creates naturally) booting a module version that ships
any overlay key the block lacks. In other words: every module upgrade that
adds a config key. We hit this in the wild while releasing weather v0.2.0 —
the operator's `Enabled: true` became nil and the module booted disabled
with all settings discarded.

The function's own comment says "This ensures module defaults never clobber
operator-supplied values" — the intent is right, the implementation wasn't.
The fix applies the full merged union (operator values + new defaults), the
same proven approach `SetVal` already uses at runtime (`configs.go:365`).

**2. `PluginConfig.Set` discards `configs.SetVal`'s error.** Rejected or
failed module config writes (unregistered key, file write failure) produce
zero signal anywhere — the caller can't tell and nothing is logged. This PR
logs the error with the plugin and key names. Returning the error would be
the stronger fix, but that changes a module-facing API signature and would
break out-of-tree modules at compile time — happy to do that instead (or as
a follow-up) if you prefer.

## Changes

- `internal/configs/configs.go`: `AddOverlayOverrides` applies
  `configData.OverlayOverrides(Flatten(overrides))` (full union) instead of
  `OverlayOverrides(newKeys)`. The `Flatten` is load-bearing: at that point
  the in-memory `overrides` map is mixed-shape (nested yaml maps from the
  operator file + flat dotted keys added in the loop). The
  `len(newKeys) == 0` early return is preserved.
- `internal/plugins/pluginconfig.go`: `Set` logs `SetVal` errors via
  `mudlog.Error` (signature unchanged).
- `internal/configs/overrides_test.go`: regression test
  `TestAddOverlayOverridesPreservesOperatorOverrides` — simulates an
  operator file with a partial `Modules.weather` block plus a second
  module's block, applies a superset overlay, and asserts operator values
  survive, new keys get their defaults, and the sibling module is untouched.
  The test fails on current master (`Modules.weather.Enabled` → nil) and
  passes with the fix.

Re-confirmed against master @ 99305b2. The weather module currently ships a
boot-time self-heal working around issue 1 — once a release containing this
fix is the sensible minimum engine version, that workaround can be retired.
```
