### PR TITLE
Fix: Fix Wrapping Logic in Panels

### DIFF
--- a/internal/templates/panel.go
+++ b/internal/templates/panel.go
@@ -941,12 +941,15 @@ func renderSingleColumnLines(p *Panel, row PanelRow, inner int, isFirst, isLast 
 	// WrapWidth < 0 disables wrapping entirely for this row.
 	// WrapWidth > 0 uses that as the explicit wrap width.
 	// WrapWidth == 0 falls back to the panel's target width.
+	// If your wrap is greater than visible width it is adjusted.
 	effectiveWrap := row.WrapWidth
+	visibleWidth := inner - lw - 1
 	if effectiveWrap == 0 && p.width > 0 {
-		availForValue := inner - lw - 1
-		if availForValue > 0 {
-			effectiveWrap = availForValue
+		if visibleWidth > 0 {
+			effectiveWrap = visibleWidth
 		}
+	} else if effectiveWrap > visibleWidth {
+		effectiveWrap = visibleWidth
 	}
 
 	var chunks []string

--- a/internal/templates/panel_test.go
+++ b/internal/templates/panel_test.go
@@ -198,6 +198,30 @@ func TestRenderPanel_AllLinesEqualVisualWidth(t *testing.T) {
 	}
 }
 
+func TestRenderPanel_AllLinesFitInsideWidth(t *testing.T) {
+	p := makePanel("x", "X", 20, borderFull, []PanelRow{
+		{FullLabel: "Short:", ShortLabel: "S:", Value: "This is a short description."},
+		{FullLabel: "HowItBe:", ShortLabel: "HIB:", Value: "This is an extremely long line of text. It is unnecessarily long. There's no reason for it to be this long, but we want to make sure wrapping is working correctly, so I will continue to make this line longer as necessary to get back good testing data."},
+	})
+	got := renderPanel(p)
+	for i, line := range got {
+		assert.LessOrEqual(t, panelVisualWidth(line), p.width, "line %d is longer than panel width", i)
+	}
+}
+
+func TestRenderPanel_AllLinesFitInsideWidthWithMismatchedWrap(t *testing.T) {
+	p := makePanel("x", "X", 20, borderFull, []PanelRow{
+		{FullLabel: "Short:", ShortLabel: "S:", Value: "This is a short description."},
+		{FullLabel: "HowItBe:", ShortLabel: "HIB:", WrapWidth: 50, Value: "This is an extremely long line of text. It is unnecessarily long. There's no reason for it to be this long, but we want to make sure wrapping is working correctly, so I will continue to make this line longer as necessary to get back good testing data."},
+		{FullLabel: "HowItBe:", ShortLabel: "HIB:", WrapWidth: 15, Value: "This is an extremely long line of text. It is unnecessarily long. There's no reason for it to be this long, but we want to make sure wrapping is working correctly, so I will continue to make this line longer as necessary to get back good testing data."},
+		{FullLabel: "HowItBe:", ShortLabel: "HIB:", WrapWidth: 20, Value: "This is an extremely long line of text. It is unnecessarily long. There's no reason for it to be this long, but we want to make sure wrapping is working correctly, so I will continue to make this line longer as necessary to get back good testing data."},
+	})
+	got := renderPanel(p)
+	for i, line := range got {
+		assert.LessOrEqual(t, panelVisualWidth(line), p.width, "line %d is longer than panel width", i)
+	}
+}
+
 func TestRenderPanel_AnsiTagsDoNotAffectWidth(t *testing.T) {
 	p := makePanel("x", "X", 19, borderFull, []PanelRow{
 		{FullLabel: `<ansi fg="yellow">Name:</ansi>`, ShortLabel: "N:", Value: `<ansi fg="green">Alice</ansi>`},


### PR DESCRIPTION
# Description

This fix adjusts the wrapping logic for panels to ensure that effectiveWidth will fit inside the visible panel width. Before this change, it is possible that effectiveWidth would be greater than the visible panel width which would produce misaligned panels. Also add two test cases `AllLinesFitInsideWidth` and `AllLinesFitInsideWidthWithMismatchedWrap`. The first one simply tests that given a large line of text and a small panel width the lines fit within the panel width. The second one tests that passing a larger WrapWidth than the panel width doesn't produce oversized lines.

This will still break if your panel width is small enough that we aren't able to split the string into tokens based on the width. I've found that 14 seems to be the minimum size needed to display a panel correctly.

## Changes

Provide a bullet point list of noteworthy changes in this Pull Request:

- Added `AllLinesFitInsidewidth` and `AllLinesFitInsideWidthWithMismatchedWrap` test cases to test that wrapping applies properly across different situations.
- Changed the effectiveWrap calculation in `renderSingleColumnLines` to verify that effectiveWrap is not larger than the useable panel width.
- Fixes #628 
