### PR TITLE
fix(conversations): initialize LastRound so fresh conversations survive cleanup

### DIFF
--- a/internal/conversations/conversations.go
+++ b/internal/conversations/conversations.go
@@ -102,8 +102,13 @@ func AttemptConversation(initiatorMobId int, initatorInstanceId int, initiatorNa
 		MobInstanceId1: initatorInstanceId,
 		MobInstanceId2: participantInstanceId,
 		StartRound:     util.GetRoundCount(),
-		Position:       0,
-		ActionList:     dataFile[chosenIndex].Conversation,
+		// LastRound must start at the current round - the cleanup in
+		// getConversation treats rounds since LastRound as staleness, and a
+		// zero value makes a brand-new conversation look ancient and
+		// eligible for deletion before its first action fires.
+		LastRound:  util.GetRoundCount(),
+		Position:   0,
+		ActionList: dataFile[chosenIndex].Conversation,
 	}
 
 	return conversationUniqueId

--- a/internal/conversations/plugin_test.go
+++ b/internal/conversations/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/GoMudEngine/GoMud/internal/mudlog"
+	"github.com/GoMudEngine/GoMud/internal/util"
 )
 
 func TestMain(m *testing.M) {
@@ -117,5 +118,32 @@ func TestReadPluginConversationFile_KeyFormat(t *testing.T) {
 	}
 	if _, ok := readPluginConversationFile("frostfang", 43); ok {
 		t.Fatalf("did not expect a file for mob 43")
+	}
+}
+
+// TestAttemptConversation_FreshConversationNotStale guards against a fresh
+// conversation being eligible for the random cleanup in getConversation. A
+// zero LastRound made new conversations look ancient (the round counter
+// starts above one million), so any lookup that won the 2% maintenance roll
+// deleted a conversation that was just created.
+func TestAttemptConversation_FreshConversationNotStale(t *testing.T) {
+	resetPluginState()
+	defer resetPluginState()
+
+	RegisterFS(newFakeFS(map[string][]byte{
+		`conversations/testzone/9001.yaml`: []byte(sampleConversation),
+	}))
+
+	convId := AttemptConversation(9001, 1, "goblin", 2, "rat", "TestZone")
+	if convId == 0 {
+		t.Fatalf("expected a non-zero conversation id from plugin file")
+	}
+
+	c := conversations[convId]
+	if c == nil {
+		t.Fatalf("expected conversation to be stored")
+	}
+	if c.LastRound != util.GetRoundCount() {
+		t.Fatalf("expected fresh conversation LastRound to equal the current round %d, got %d", util.GetRoundCount(), c.LastRound)
 	}
 }


### PR DESCRIPTION
## The bug

`getConversation` has a 2% chance per call of running maintenance that deletes any conversation more than 10 rounds stale, measured as `rNow - LastRound`. But `AttemptConversation` never set `LastRound`, and the round counter starts at 1,314,000 - so every freshly created conversation looked ancient until its first `NextActions` call. Any lookup that won the maintenance roll deleted a conversation that was just created.

Two consequences:

- **In game:** a conversation can silently vanish between creation and its first line of dialogue (2% per lookup in that window).
- **In CI:** `TestAttemptConversation_UsesPluginFile` creates a conversation and immediately looks it up, so it fails on ~2% of runs regardless of what a PR changes. Example: the initial Go Tests failure on #639 ([this run](https://github.com/GoMudEngine/GoMud/actions/runs/30244309841/job/89907921447)), which passed untouched on rerun. Reproducible on master with `go test -run TestAttemptConversation_UsesPluginFile -count 300 ./internal/conversations/`.

## The fix

`LastRound` now starts at the current round, matching `StartRound`. Dialogue timing is unchanged: conversations are created by the mob `converse` command during a round, and actions are pulled by the `NewRound_IdleMobs` hook on the following round, so the same-round guard in `NextActions` never bit in the real flow.

Includes a deterministic regression test. Verified with 300 consecutive `-count` runs, which reliably failed on master before the fix.